### PR TITLE
🤝 Merge : 찜한 목록 기능 추가 및 제품 상세 라우팅 정합성 개선

### DIFF
--- a/app/(tabs)/products/@modal/[...catchAll]/page.tsx
+++ b/app/(tabs)/products/@modal/[...catchAll]/page.tsx
@@ -1,4 +1,13 @@
-// app/(tabs)/products/@modal/[...catchAll]/page.tsx
+/**
+ * File Name : app/(tabs)/products/@modal/[...catchAll]/page.tsx
+ * Description : modal 슬롯 미매칭 경로 정리용 catch-all
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.03.05  임도헌   Created   모달 슬롯 잔상/404 방지를 위한 catch-all null 라우트 추가
+ */
+
 export default function CatchAll() {
   return null;
 }

--- a/app/(tabs)/profile/(product)/my-likes/layout.tsx
+++ b/app/(tabs)/profile/(product)/my-likes/layout.tsx
@@ -1,0 +1,30 @@
+/**
+ * File Name : app/(tabs)/profile/(product)/my-likes/layout.tsx
+ * Description : '나의 찜한 내역' 섹션 공통 레이아웃
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.03.06  임도헌   Created   섹션 전용 레이아웃 추가 (상단 앱바 + BackButton)
+ */
+
+import type { ReactNode } from "react";
+import BackButton from "@/components/global/BackButton";
+
+export default function MyLikesLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background transition-colors">
+      <header className="sticky top-0 z-40 h-14 w-full bg-background/80 backdrop-blur-md border-b border-border">
+        <div className="mx-auto max-w-mobile h-full flex items-center px-4 gap-3">
+          <BackButton
+            fallbackHref="/profile"
+            variant="appbar"
+            className="px-0"
+          />
+          <h1 className="text-base font-semibold text-primary">찜한 내역</h1>
+        </div>
+      </header>
+      <main className="mx-auto max-w-mobile pb-24">{children}</main>
+    </div>
+  );
+}

--- a/app/(tabs)/profile/(product)/my-likes/loading.tsx
+++ b/app/(tabs)/profile/(product)/my-likes/loading.tsx
@@ -1,0 +1,51 @@
+/**
+ * File Name : app/(tabs)/profile/(product)/my-likes/loading.tsx
+ * Description : 나의 찜한 내역 페이지 로딩 스켈레톤
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.03.06  임도헌   Created   찜한 내역 전용 ProductCard 리스트 스켈레톤 적용
+ */
+
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background transition-colors">
+      <div className="px-page-x py-6 flex flex-col gap-4">
+        {/* List Skeleton */}
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col rounded-2xl border border-border bg-surface overflow-hidden shadow-sm"
+          >
+            <div className="flex p-4 gap-4">
+              {/* Thumbnail */}
+              <Skeleton className="size-24 sm:size-28 rounded-xl shrink-0" />
+
+              {/* Info */}
+              <div className="flex-1 flex flex-col justify-between py-1">
+                <div className="space-y-2">
+                  <div className="flex justify-between">
+                    <Skeleton className="h-5 w-3/4 rounded" />
+                    <Skeleton className="h-5 w-14 rounded" />
+                  </div>
+                  <Skeleton className="h-4 w-20 rounded" />
+                </div>
+
+                <div className="flex justify-between items-center pt-2 border-t border-border/50 mt-2">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-3 w-10 rounded" />
+                    <Skeleton className="size-5 rounded-full" />
+                  </div>
+                  <Skeleton className="h-3 w-16 rounded" />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(tabs)/profile/(product)/my-likes/page.tsx
+++ b/app/(tabs)/profile/(product)/my-likes/page.tsx
@@ -1,0 +1,47 @@
+/**
+ * File Name : app/(tabs)/profile/(product)/my-likes/page.tsx
+ * Description : 프로필 나의 찜한 내역 페이지
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.03.06  임도헌   Created   TanStack Query HydrationBoundary 기반 서버 프리패치 및 페이지 구현
+ */
+
+import { redirect } from "next/navigation";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { getQueryClient } from "@/lib/getQueryClient";
+import { queryKeys } from "@/lib/queryKeys";
+import getSession from "@/lib/session";
+import { getUserProductsList } from "@/features/product/service/userList";
+import MyLikesList from "@/features/product/components/MyLikesList";
+
+/**
+ * 내 찜한 내역 페이지
+ *
+ * [기능]
+ * - 세션 검증을 통한 로그인 여부 확인 및 비인가 사용자 리다이렉트 처리
+ * - QueryClient를 활용한 '찜함(LIKED)' 범위 상품 목록 서버 프리패치(Prefetch) 적용
+ * - HydrationBoundary를 통한 직렬화된 캐시 상태 클라이언트 전달
+ */
+export default async function MyLikesPage() {
+  const session = await getSession();
+  if (!session?.id) {
+    redirect("/login?callbackUrl=/profile/my-likes");
+  }
+  const userId = session.id;
+  const queryClient = getQueryClient();
+
+  // 서버에서 1페이지 프리패치 (Hydration)
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: queryKeys.products.userScope("LIKED", userId),
+    queryFn: () => getUserProductsList({ type: "LIKED", userId }, null),
+    initialPageParam: null as number | null,
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <MyLikesList userId={userId} />
+    </HydrationBoundary>
+  );
+}

--- a/features/product/components/MyLikesList.tsx
+++ b/features/product/components/MyLikesList.tsx
@@ -1,0 +1,100 @@
+/**
+ * File Name : features/product/components/MyLikesList.tsx
+ * Description : 나의 찜한 상품 리스트 렌더링 컴포넌트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.03.06  임도헌   Created   찜한 상품 목록 UI 및 무한 스크롤 연동 구현
+ * 2026.03.06  임도헌   Modified  리스트 레이아웃/하단 로딩 배지 정렬
+ */
+"use client";
+
+import { useRef } from "react";
+import Link from "next/link";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import { usePageVisibility } from "@/hooks/usePageVisibility";
+import { useProductPagination } from "@/features/product/hooks/useProductPagination";
+import ProductCard from "@/features/product/components/productCard";
+import { HeartIcon } from "@heroicons/react/24/outline";
+import type { ProductType } from "@/features/product/types";
+
+/**
+ * 나의 찜한 제품 목록 렌더링 컴포넌트
+ *
+ * [상태 주입 및 스크롤 페이징 로직]
+ * - `useProductPagination` 훅을 활용하여 'LIKED' 범위(scope) 데이터 추출 및 전역 상태 관리
+ * - 사용자 가시성(`usePageVisibility`) 기반 `useInfiniteScroll` 스크롤 감지 및 페이징 요청 제어
+ * - 상위 4개 아이템 LCP 최적화를 위한 `isPriority` 속성 동적 주입 적용
+ *
+ * @param {Object} props
+ * @param {number} props.userId - 조회할 대상 유저 ID
+ */
+export default function MyLikesList({ userId }: { userId: number }) {
+  const liked = useProductPagination<ProductType>({
+    mode: "profile",
+    scope: { type: "LIKED", userId },
+  });
+
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const isVisible = usePageVisibility();
+
+  useInfiniteScroll({
+    triggerRef,
+    hasMore: liked.hasMore,
+    isLoading: liked.isFetchingNextPage,
+    onLoadMore: liked.loadMore,
+    enabled: isVisible,
+    rootMargin: "600px",
+    threshold: 0.1,
+  });
+
+  if (liked.products.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 px-4 text-center animate-fade-in">
+        <div className="p-4 rounded-full bg-surface-dim mb-4">
+          <HeartIcon className="size-10 text-muted/50" />
+        </div>
+        <h3 className="text-lg font-bold text-primary mb-1">
+          찜한 상품이 없습니다
+        </h3>
+        <p className="text-sm text-muted mb-6">
+          관심 있는 게임을 찾아 찜해보세요!
+        </p>
+        <Link
+          href="/products"
+          className="btn-primary text-sm h-10 px-6 inline-flex items-center shadow-sm"
+        >
+          항구로 이동하기
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col px-page-x py-6 gap-4">
+      <div className="grid grid-cols-1 gap-4">
+        {liked.products.map((product, index) => (
+          <ProductCard
+            key={product.id}
+            product={product}
+            viewMode="list"
+            isPriority={index < 4}
+          />
+        ))}
+      </div>
+
+      <div className="py-6 min-h-[40px]">
+        {liked.hasMore && (
+          <div ref={triggerRef} className="h-1 w-full" aria-hidden="true" />
+        )}
+        {liked.isFetchingNextPage && (
+          <div className="mt-3 mb-[calc(84px+env(safe-area-inset-bottom))] sm:mb-0 mx-auto w-fit flex items-center gap-2 text-sm text-muted bg-surface-dim px-4 py-2 rounded-full shadow-sm animate-fade-in whitespace-nowrap">
+            <span className="size-4 border-2 border-brand/30 border-t-brand rounded-full animate-spin" />
+            <span className="whitespace-nowrap">더 불러오는 중...</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/features/product/components/ProductLikeButton.tsx
+++ b/features/product/components/ProductLikeButton.tsx
@@ -15,15 +15,23 @@
  * 2026.01.27  임도헌   Modified  주석 설명 보강
  * 2026.03.01  임도헌   Modified  React useOptimistic 제거 및 TanStack Query useMutation 도입
  * 2026.03.05  임도헌   Modified  주석 최신화
+ * 2026.03.06  임도헌   Modified  좋아요 취소 시 '찜한 내역(LIKED)' 전역 캐시 즉시 제거 로직(Optimistic UI) 추가
+ * 2026.03.06  임도헌   Modified  LIKED 캐시 갱신 predicate 범위 정교화(구조 일치 키만 타겟팅)
+ * 2026.03.06  임도헌   Modified  products 목록 캐시(_count.product_likes) 낙관적 업데이트 및 롤백 추가
+ * 2026.03.06  임도헌   Modified  좋아요 추가 시 LIKED 목록 첫 페이지 prepend 낙관적 반영 추가
  */
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { dislikeProduct, likeProduct } from "@/features/product/actions/like";
 import { queryKeys } from "@/lib/queryKeys";
+import { toast } from "sonner";
 import { HeartIcon as OutlineHeartIcon } from "@heroicons/react/24/outline";
 import { HeartIcon } from "@heroicons/react/24/solid";
-import { toast } from "sonner";
+import {
+  isLikedScopeKey,
+  pickProductFromLists,
+} from "@/features/product/utils/productQueryCache";
 import { cn } from "@/lib/utils";
 
 interface ProductLikeButtonProps {
@@ -36,10 +44,11 @@ interface ProductLikeButtonProps {
  * 제품 좋아요 버튼 컴포넌트
  *
  * [상태 주입 및 캐시 제어 로직]
- * - 부모로부터 주입된 초기값(`initialIsLiked`, `initialLikeCount`)을 `useQuery`의 `initialData`로 설정하여 하이드레이션 구성
- * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 상태 반전 제공
- * - API 에러 발생 시 `onError`에서 캡처된 이전 상태 스냅샷(`previous`)으로 롤백 처리
- * - `onSettled` 시점 쿼리 무효화를 통한 서버 데이터와의 최종 정합성 보장
+ * - 부모로부터 주입된 초기값(`initialIsLiked`, `initialLikeCount`)을 `useQuery`의 `initialData`로 설정하여 서버 상태 동기화(Hydration) 구성
+ * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 상태 반전 및 피드백 제공
+ * - 좋아요 취소 시 찜한 목록(`LIKED` scope) 쿼리 캐시에 접근하여 해당 아이템을 목록에서 즉각 제거 처리
+ * - API 요청 에러 발생 시 `onError`에서 캡처된 이전 상태 스냅샷(`previous`)으로 안전한 롤백(Rollback) 처리
+ * - `onSettled` 시점 관련 쿼리 무효화(invalidateQueries)를 통한 서버 데이터와의 최종 정합성 보장
  */
 export default function ProductLikeButton({
   isLiked: initialIsLiked,
@@ -64,27 +73,127 @@ export default function ProductLikeButton({
     },
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
 
-      // 캐시 덮어쓰기 (Optimistic Update)
-      queryClient.setQueryData(queryKey, {
-        isLiked: !data.isLiked,
-        likeCount: data.isLiked
-          ? Math.max(0, data.likeCount - 1)
-          : data.likeCount + 1,
+      const previousLikeStatus = queryClient.getQueryData(queryKey);
+      const listQueries = queryClient.getQueriesData({
+        queryKey: queryKeys.products.lists(),
+      });
+      const likedQueries = queryClient.getQueriesData({
+        predicate: (query) => isLikedScopeKey(query.queryKey),
       });
 
-      return { previous };
+      const nextLikeCount = data.isLiked
+        ? Math.max(0, data.likeCount - 1)
+        : data.likeCount + 1;
+
+      // 1) 상세 버튼 상태 즉시 반영
+      queryClient.setQueryData(queryKey, {
+        isLiked: !data.isLiked,
+        likeCount: nextLikeCount,
+      });
+
+      // 2) /products 목록 캐시 즉시 반영 (_count.product_likes)
+      queryClient.setQueriesData(
+        { queryKey: queryKeys.products.lists() },
+        (oldData: any) => {
+          if (!oldData?.pages) return oldData;
+          return {
+            ...oldData,
+            pages: oldData.pages.map((page: any) => ({
+              ...page,
+              products: page.products.map((p: any) =>
+                p.id === productId
+                  ? {
+                      ...p,
+                      _count: {
+                        ...p._count,
+                        product_likes: nextLikeCount,
+                      },
+                    }
+                  : p
+              ),
+            })),
+          };
+        }
+      );
+
+      // 3) 좋아요 취소 시 LIKED 목록에서 즉시 제거
+      if (data.isLiked) {
+        queryClient.setQueriesData(
+          { predicate: (query) => isLikedScopeKey(query.queryKey) },
+          (oldData: any) => {
+            if (!oldData?.pages) return oldData;
+            return {
+              ...oldData,
+              pages: oldData.pages.map((page: any) => ({
+                ...page,
+                products: page.products.filter((p: any) => p.id !== productId),
+              })),
+            };
+          }
+        );
+      }
+
+      // 좋아요 추가: LIKED 첫 페이지에 즉시 prepend
+      if (!data.isLiked) {
+        const snapshot = pickProductFromLists(
+          listQueries,
+          productId
+        );
+        if (snapshot) {
+          queryClient.setQueriesData(
+            { predicate: (query) => isLikedScopeKey(query.queryKey) },
+            (oldData: any) => {
+              if (!oldData?.pages?.length) return oldData;
+
+              const alreadyExists = oldData.pages.some((page: any) =>
+                page.products.some((p: any) => p.id === productId)
+              );
+              if (alreadyExists) return oldData;
+
+              const firstPage = oldData.pages[0];
+              return {
+                ...oldData,
+                pages: [
+                  {
+                    ...firstPage,
+                    products: [snapshot, ...firstPage.products],
+                  },
+                  ...oldData.pages.slice(1),
+                ],
+              };
+            }
+          );
+        }
+      }
+
+      return { previousLikeStatus, listQueries, likedQueries };
     },
     onError: (err, variables, context) => {
       console.error("Like mutation failed:", err);
       toast.error("좋아요 처리에 실패했습니다.");
-      // 에러 발생 시 이전 상태 스냅샷으로 롤백
-      queryClient.setQueryData(queryKey, context?.previous);
+
+      // 롤백: like status
+      queryClient.setQueryData(queryKey, context?.previousLikeStatus);
+
+      // 롤백: products lists
+      context?.listQueries?.forEach(([k, v]: [readonly unknown[], unknown]) => {
+        queryClient.setQueryData(k, v);
+      });
+
+      // 롤백: liked lists
+      context?.likedQueries?.forEach(
+        ([k, v]: [readonly unknown[], unknown]) => {
+          queryClient.setQueryData(k, v);
+        }
+      );
     },
     onSettled: () => {
-      // 서버 데이터와 일치시키기 위해 백그라운드 리패치
       queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: queryKeys.products.lists() });
+      queryClient.invalidateQueries({
+        predicate: (query) => isLikedScopeKey(query.queryKey),
+      });
     },
   });
 

--- a/features/product/service/like.ts
+++ b/features/product/service/like.ts
@@ -8,15 +8,27 @@
  * 2026.01.30  임도헌   Created   service/trade.ts에서 분리
  * 2026.02.05  임도헌   Modified  좋아요 시 차단 관계 확인 로직 추가
  * 2026.03.04  임도헌   Modified  getCachedProductLikeStatus 대신 getProductLikeStatus 순수 함수로 변경
- * 2026.03.05  임도헌   Modified  주석 최신화
+ * 2026.03.06  임도헌   Modified  좋아요 추가 시 판매자 대상 알림(인앱 + 설정 기반 푸시) 발송 로직 추가
+ * 2026.03.06  임도헌   Modified  동일 유저의 좋아요 토글 스팸 방지를 위한 알림 쿨다운(10분) 검증 로직 추가
+ * 2026.03.06  임도헌   Modified  주석 최신화
+ * 
  */
 import "server-only";
 
 import db from "@/lib/db";
+import { supabase } from "@/lib/supabase";
 import type { ServiceResult } from "@/lib/types";
 import type { ProductLikeResult } from "@/features/product/types";
 import { checkBlockRelation } from "@/features/user/service/block";
 import { isUniqueConstraintError } from "@/lib/errors";
+import { sendPushNotification } from "@/features/notification/service/sender";
+import {
+  canSendPushForType,
+  isNotificationTypeEnabled,
+} from "@/features/notification/utils/policy";
+
+// 알림 스팸 방지용 쿨다운
+const LIKE_NOTIFICATION_COOLDOWN_MS = 10 * 60 * 1000; // 10분
 
 /**
  * 제품 좋아요 상태 및 카운트 조회 로직
@@ -35,13 +47,137 @@ export async function getProductLikeStatus(
 ): Promise<ProductLikeResult> {
   const likeCount = await db.productLike.count({ where: { productId } });
   let isLiked = false;
+
   if (userId) {
     const exist = await db.productLike.findUnique({
       where: { id: { productId, userId } },
     });
     isLiked = !!exist;
   }
+
   return { likeCount, isLiked };
+}
+
+/**
+ * 판매자에게 좋아요 알림을 보낼지 여부를 판단
+ *
+ * [동작]
+ * - 동일 판매자(sellerId) + 동일 상품(productId) + 동일 찜한 유저(likerName) 조합으로
+ *   최근 N분 내(기본 10분) 같은 TRADE 알림이 있었는지 확인
+ * - 최근 알림이 있으면 false(알림 생략), 없으면 true(알림 발송) 반환
+ *
+ * @param params.sellerId - 알림 수신자(판매자) ID
+ * @param params.productId - 상품 ID
+ * @param params.likerName - 좋아요를 누른 유저 닉네임
+ * @returns {Promise<boolean>} 알림 발송 가능 여부
+ */
+async function shouldSendLikeNotification(params: {
+  sellerId: number;
+  productId: number;
+  likerName: string;
+}): Promise<boolean> {
+  const { sellerId, productId, likerName } = params;
+  const since = new Date(Date.now() - LIKE_NOTIFICATION_COOLDOWN_MS);
+
+  const recent = await db.notification.findFirst({
+    where: {
+      userId: sellerId,
+      type: "TRADE",
+      title: "새 관심 신호가 도착했어요",
+      link: `/products/view/${productId}`,
+      created_at: { gte: since },
+      body: { startsWith: `${likerName}님이 '` },
+    },
+    select: { id: true },
+  });
+
+  return !recent;
+}
+
+/**
+ * 판매자에게 "찜 추가" 알림 발송
+ * - 인앱 알림(DB + broadcast)
+ * - 푸시 알림은 설정 허용 시에만 전송
+ */
+async function notifySellerOnLike(params: {
+  sellerId: number;
+  likerId: number;
+  likerName: string;
+  productId: number;
+  productTitle: string;
+  image?: string;
+}) {
+  const { sellerId, likerId, likerName, productId, productTitle, image } =
+    params;
+
+  // 본인 상품 찜은 알림 제외
+  if (sellerId === likerId) return;
+
+  // 쿨다운 내 동일 유저 재토글 알림 차단
+  const canNotify = await shouldSendLikeNotification({
+    sellerId,
+    productId,
+    likerName,
+  });
+  if (!canNotify) return;
+
+  const pref = await db.notificationPreferences.findUnique({
+    where: { userId: sellerId },
+  });
+
+  // 앱 내 알림 비활성 시 종료
+  if (pref && !isNotificationTypeEnabled(pref, "TRADE")) return;
+
+  const link = `/products/view/${productId}`;
+  const title = "새 관심 신호가 도착했어요";
+  const body = `${likerName}님이 '${productTitle}' 상품을 찜했습니다.`;
+
+  const notification = await db.notification.create({
+    data: {
+      userId: sellerId,
+      title,
+      body,
+      type: "TRADE",
+      link,
+      image,
+      isPushSent: false,
+    },
+  });
+
+  await supabase.channel(`user-${sellerId}-notifications`).send({
+    type: "broadcast",
+    event: "notification",
+    payload: {
+      id: notification.id,
+      userId: sellerId,
+      title: notification.title,
+      body: notification.body,
+      link: notification.link,
+      type: notification.type,
+      image: notification.image,
+      created_at: notification.created_at,
+    },
+  });
+
+  if (canSendPushForType(pref, "TRADE")) {
+    const pushRes = await sendPushNotification({
+      targetUserId: sellerId,
+      title,
+      message: body,
+      url: link,
+      type: "TRADE",
+      image,
+      tag: `product-liked-${productId}`,
+      renotify: false,
+    });
+
+    if (pushRes.success && (pushRes.data?.sent ?? 0) > 0) {
+      await db.notification.update({
+        where: { id: notification.id },
+        data: { isPushSent: true, sentAt: new Date() },
+      });
+    }
+  }
 }
 
 /**
@@ -63,14 +199,30 @@ export async function toggleProductLike(
   isLike: boolean
 ): Promise<ServiceResult> {
   try {
-    // 차단 확인
-    const product = await db.product.findUnique({
-      where: { id: productId },
-      select: { userId: true },
-    });
+    const [product, liker] = await Promise.all([
+      db.product.findUnique({
+        where: { id: productId },
+        select: {
+          userId: true,
+          title: true,
+          images: {
+            where: { order: 0 },
+            take: 1,
+            select: { url: true },
+          },
+        },
+      }),
+      db.user.findUnique({
+        where: { id: userId },
+        select: { username: true },
+      }),
+    ]);
 
     if (!product) return { success: false, error: "제품을 찾을 수 없습니다." };
+    if (!liker)
+      return { success: false, error: "사용자 정보를 찾을 수 없습니다." };
 
+    // 차단 체크
     const isBlocked = await checkBlockRelation(userId, product.userId);
     if (isBlocked) {
       return {
@@ -86,6 +238,18 @@ export async function toggleProductLike(
           product: { connect: { id: productId } },
         },
       });
+
+      // 좋아요 "추가" 성공 시에만 판매자 알림
+      await notifySellerOnLike({
+        sellerId: product.userId,
+        likerId: userId,
+        likerName: liker.username,
+        productId,
+        productTitle: product.title,
+        image: product.images[0]?.url
+          ? `${product.images[0].url}/public`
+          : undefined,
+      });
     } else {
       await db.productLike.delete({
         where: { id: { userId, productId } },
@@ -94,7 +258,7 @@ export async function toggleProductLike(
 
     return { success: true };
   } catch (e: any) {
-    // 멱등성 처리
+    // 좋아요 중복 요청(레이스)일 경우 멱등 처리
     if (isLike && isUniqueConstraintError(e, ["userId", "productId"])) {
       return { success: true };
     }

--- a/features/product/service/userList.ts
+++ b/features/product/service/userList.ts
@@ -18,6 +18,8 @@
  * 2026.01.25  임도헌   Modified  주석 보강 (Scope 정의, 캐싱 전략 상세 설명)
  * 2026.03.04  임도헌   Modified  unstable_cache 래퍼 및 파편화된 페이징 로직 제거, 단일 함수(getUserProductsList)로 통합
  * 2026.03.05  임도헌   Modified  주석 최신화
+ * 2026.03.06  임도헌   Modified  'LIKED' 스코프 추가 및 조건 매핑 (내가 찜한 상품 조회)
+ * 2026.03.06  임도헌   Modified  getUserProductsList 제네릭 기본 타입에 ProductType 추가(LIKED 스코프 타입 정합성 강화)
  */
 
 import "server-only";
@@ -29,6 +31,7 @@ import type {
   TabCounts,
   MySalesListItem,
   MyPurchasedListItem,
+  ProductType,
 } from "@/features/product/types";
 
 const TAKE = PRODUCTS_PAGE_TAKE;
@@ -39,12 +42,14 @@ const TAKE = PRODUCTS_PAGE_TAKE;
  * - RESERVED: 예약 중
  * - SOLD: 판매 완료
  * - PURCHASED: 구매 내역
+ * - LIKED: 좋아요 내역
  */
 export type UserProductsScope =
   | { type: "SELLING"; userId: number }
   | { type: "RESERVED"; userId: number }
   | { type: "SOLD"; userId: number }
-  | { type: "PURCHASED"; userId: number };
+  | { type: "PURCHASED"; userId: number }
+  | { type: "LIKED"; userId: number };
 
 /** Prisma Where Input 생성 헬퍼 */
 function whereFor(scope: UserProductsScope) {
@@ -70,6 +75,10 @@ function whereFor(scope: UserProductsScope) {
       return {
         purchase_userId: scope.userId,
       };
+    case "LIKED":
+      return {
+        product_likes: { some: { userId: scope.userId } },
+      };
   }
 }
 
@@ -77,18 +86,83 @@ function whereFor(scope: UserProductsScope) {
  * 사용자별 맞춤 제품 목록 조회 및 페이징 로직
  *
  * [데이터 페칭 및 가공 전략]
- * - 프로필 내 판매 내역 / 구매 내역 탭을 위한 커서 기반 무한 스크롤 데이터 추출
- * - 주입된 `scope` 타입(SELLING, RESERVED, SOLD, PURCHASED)에 따른 동적 Where 조건 분기 적용
- * - 삭제 엣지 케이스 방어를 위한 커서 유효성 사전 검사(SELECT id) 수행
+ * - 프로필 내 판매/구매/찜 내역 탭을 위한 커서 기반 무한 스크롤 데이터 추출
+ * - 주입된 `scope` 타입(SELLING, RESERVED, SOLD, PURCHASED, LIKED)에 따른 동적 Where 조건 분기 적용
  * - 단일 통합 쿼리 셀렉터(`PROFILE_SALES_UNIFIED_SELECT`) 적용을 통한 필드 정합성 유지
+ * - 기본 제네릭 타입을 `MySalesListItem | MyPurchasedListItem | ProductType`로 확장하여
+ *   LIKED 스코프의 타입 안정성 및 호출부 추론 정확도 개선
+ * - 삭제 엣지 케이스 방어를 위한 커서 유효성 사전 검사(SELECT id) 수행
  *
+ * @template T - 반환할 제품 아이템 타입 (기본값: MySalesListItem | MyPurchasedListItem | ProductType)
  * @param {UserProductsScope} scope - 조회할 목록 타입 및 대상 유저 ID
  * @param {number | null} [cursor] - 페이징 커서 (제품 ID)
  * @returns {Promise<Paginated<T>>} 페이징된 목록 및 커서 반환
  */
 export async function getUserProductsList<
-  T = MySalesListItem | MyPurchasedListItem,
+  T = MySalesListItem | MyPurchasedListItem | ProductType,
 >(scope: UserProductsScope, cursor?: number | null): Promise<Paginated<T>> {
+  // LIKED는 ProductLike.created_at 기준(최근 찜한 순)으로 별도 처리
+  if (scope.type === "LIKED") {
+    let cursorLike: { created_at: Date; productId: number } | null = null;
+
+    if (cursor) {
+      cursorLike = await db.productLike.findUnique({
+        where: {
+          id: {
+            userId: scope.userId,
+            productId: cursor,
+          },
+        },
+        select: {
+          created_at: true,
+          productId: true,
+        },
+      });
+      // 커서 대상이 사라졌다면 이전 페이지의 끝임을 의미하므로 빈 결과 반환
+      if (!cursorLike) return { products: [], nextCursor: null };
+    }
+
+    const likedRows = await db.productLike.findMany({
+      where: {
+        userId: scope.userId,
+        ...(cursorLike
+          ? {
+              OR: [
+                { created_at: { lt: cursorLike.created_at } },
+                {
+                  AND: [
+                    { created_at: cursorLike.created_at },
+                    { productId: { lt: cursorLike.productId } },
+                  ],
+                },
+              ],
+            }
+          : {}),
+      },
+      select: {
+        productId: true,
+        created_at: true,
+        product: {
+          select: PROFILE_SALES_UNIFIED_SELECT,
+        },
+      },
+      orderBy: [{ created_at: "desc" }, { productId: "desc" }],
+      take: TAKE + 1,
+    });
+
+    const hasNext = likedRows.length > TAKE;
+    const pageRows = hasNext ? likedRows.slice(0, TAKE) : likedRows;
+    const products = pageRows.map((r) => r.product) as unknown as T[];
+    const nextCursor = hasNext
+      ? (pageRows[pageRows.length - 1]?.productId ?? null)
+      : null;
+
+    return { products, nextCursor };
+  }
+
+  /**======================================================================
+   *               기존 SELLING/RESERVED/SOLD/PURCHASED 로직
+   * ====================================================================== */
   let cursorOpt: Record<string, any> = {};
 
   // 커서 유효성 검사 (삭제된 제품일 수 있으므로 확인)

--- a/features/product/utils/productQueryCache.ts
+++ b/features/product/utils/productQueryCache.ts
@@ -1,0 +1,51 @@
+/**
+ * File Name : features/product/utils/productQueryCache.ts
+ * Description : Product TanStack Query 캐시 유틸
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.03.06  임도헌   Created   LIKED 스코프 판별 및 목록 캐시 스냅샷 추출 유틸 분리
+ */
+
+/**
+ * products/userScope/LIKED/{userId} 구조의 Query Key인지 판별
+ *
+ * - getQueriesData/setQueriesData/invalidateQueries에서 predicate를 재사용해
+ *   LIKED 스코프 캐시만 정확히 타겟팅
+ * - 문자열 하드코딩을 컴포넌트마다 반복하지 않아 오타/누락 위험 Down
+ */
+export function isLikedScopeKey(key: readonly unknown[]) {
+  return (
+    Array.isArray(key) &&
+    key.length >= 4 &&
+    key[0] === "products" &&
+    key[1] === "userScope" &&
+    key[2] === "LIKED" &&
+    typeof key[3] === "number"
+  );
+}
+
+/**
+ * products.list 계열 캐시들에서 특정 product 스냅샷 1건을 추출
+ *
+ * - 좋아요 추가 직후 LIKED 목록에 즉시 prepend(낙관적 반영)하려면
+ *   최소한의 제품 데이터 스냅샷이 필요
+ * - 서버 재요청 전에도 UX를 즉시 맞추기 위해, 이미 로딩된 list 캐시에서 재사용
+ * - 데이터 형태가 페이지별로 나뉘어 있으므로 pages -> products 순회로 탐색
+ */
+export function pickProductFromLists(
+  listQueries: [readonly unknown[], unknown][],
+  productId: number
+) {
+  for (const [, data] of listQueries) {
+    const pages = (data as any)?.pages;
+    if (!Array.isArray(pages)) continue;
+
+    for (const page of pages) {
+      const found = page?.products?.find?.((p: any) => p.id === productId);
+      if (found) return found;
+    }
+  }
+  return null;
+}

--- a/features/stream/components/RTMPInfoModal.tsx
+++ b/features/stream/components/RTMPInfoModal.tsx
@@ -209,7 +209,7 @@ export default function RTMPInfoModal({
   };
 
   // 닫기 공통 로직: 사용자가 "스트리밍 페이지로 이동" 하지 않았다면
-  // 생성된 broadcast를 삭제하여 중복 생성을 방지합니다.
+  // 생성된 broadcast를 삭제하여 중복 생성을 방지
   const handleClose = () => {
     // 만약 네비게이트 했으면 즉시 닫기
     if (navigatedToBroadcastRef.current || !broadcastId) {

--- a/features/user/actions/product.ts
+++ b/features/user/actions/product.ts
@@ -9,28 +9,57 @@
  * 2026.01.24  임도헌   Moved     app/(tabs)/profile/(product)/actions.ts에서 이동
  * 2026.03.04  임도헌   Modified  getUserProductsList 통합 호출 구조 적용
  * 2026.03.05  임도헌   Modified  주석 최신화
+ * 2026.03.06  임도헌   Modified  PURCHASED/LIKED/RESERVED 스코프 접근 권한 검증 추가
  */
 "use server";
 
+import getSession from "@/lib/session";
 import {
   getUserProductsList,
   type UserProductsScope,
 } from "@/features/product/service/userList";
-import type { Paginated } from "@/features/product/types";
+import type {
+  Paginated,
+  MySalesListItem,
+  MyPurchasedListItem,
+  ProductType,
+} from "@/features/product/types";
+import { USER_ERRORS } from "@/features/user/constants";
 
 /**
  * 유저 제품 목록 조회 Server Action
  *
  * [데이터 페칭 및 권한 제어]
- * - 요청 유저 정보 기반 Service 계층의 제품 목록 조회 호출
- * - 페이징 처리된 데이터(Paginated) 객체 반환
+ * - 요청받은 스코프(UserProductsScope) 기반으로 Service 계층의 제품 목록 조회 함수를 호출
+ * - 커서 기반 페이지네이션(cursor) 파라미터를 전달하여 다음 페이지 데이터 추출
+ * - 개인 스코프(PURCHASED/LIKED/RESERVED)는 세션 사용자와 scope.userId 일치 여부를 검증
+ * - 반환 타입 기본값을 `MySalesListItem | MyPurchasedListItem | ProductType`으로 통일해
+ *   SELLING/RESERVED/SOLD/PURCHASED/LIKED 전 스코프 타입 추론 정합성 확보
  *
- * @param {UserProductsScope} scope - 판매/예약/구매 등 제품 범위 설정
- * @param {number | null} [cursor] - 페이지네이션 커서
+ * @template T - 반환할 제품 아이템 타입
+ *   (기본값: MySalesListItem | MyPurchasedListItem | ProductType)
+ * @param {UserProductsScope} scope - 판매/예약/구매/찜 등 제품 목록 범위 및 대상 유저 정보
+ * @param {number | null} [cursor=null] - 커서 기반 페이지네이션 기준 ID
+ * @returns {Promise<Paginated<T>>} 제품 목록과 다음 커서 정보
  */
-export async function getUserProductsAction<T = any>(
+export async function getUserProductsAction<
+  T = MySalesListItem | MyPurchasedListItem | ProductType,
+>(
   scope: UserProductsScope,
   cursor: number | null = null
 ): Promise<Paginated<T>> {
+  const session = await getSession();
+  const viewerId = session?.id ?? null;
+
+  // 개인 데이터 성격이 강한 스코프는 본인만 조회 가능
+  const isPrivateScope =
+    scope.type === "PURCHASED" ||
+    scope.type === "LIKED" ||
+    scope.type === "RESERVED";
+
+  if (isPrivateScope && viewerId !== scope.userId) {
+    throw new Error(USER_ERRORS.UNAUTHORIZED);
+  }
+
   return await getUserProductsList<T>(scope, cursor);
 }

--- a/features/user/components/profile/MyProfile.tsx
+++ b/features/user/components/profile/MyProfile.tsx
@@ -35,6 +35,7 @@
  * 2026.02.26  임도헌   Modified   모든 버튼에 hover시 dark:hover:text-brand-light 추가
  * 2026.03.01  임도헌   Modified   이벤트 리스너(window.addEventListener) 제거 및 Zustand(ModalStore) 도입
  * 2026.03.05  임도헌   Modified   주석 최신화
+ * 2026.03.06  임도헌   Modified   거래 정보 섹션에 '찜한 내역' 바로가기 링크 추가
  */
 "use client";
 
@@ -61,6 +62,7 @@ import type {
   ProfileAverageRating,
   UserProfile,
 } from "@/features/user/types";
+import { HeartIcon } from "@heroicons/react/24/solid";
 
 const ProfileReviewsModal = dynamic(() => import("./ProfileReviewsModal"), {
   ssr: false,
@@ -188,6 +190,7 @@ export default function MyProfile({
       <section>
         <h2 className="text-sm font-bold text-primary mb-3">거래 정보</h2>
         <div className="grid grid-cols-2 gap-3">
+          {/*  판매 내역 */}
           <Link
             href="/profile/my-sales"
             className="group p-4 bg-surface rounded-xl border border-border shadow-sm hover:border-brand/30 hover:shadow-md transition-all"
@@ -200,7 +203,7 @@ export default function MyProfile({
               판매 중인 물품 관리
             </p>
           </Link>
-
+          {/*  구매 내역 */}
           <Link
             href="/profile/my-purchases"
             className="group p-4 bg-surface rounded-xl border border-border shadow-sm hover:border-brand/30 hover:shadow-md transition-all"
@@ -212,6 +215,22 @@ export default function MyProfile({
             <p className="text-xs text-muted group-hover:text-primary transition-colors">
               구매한 물품 확인
             </p>
+          </Link>
+          {/*  찜한 내역 */}
+          <Link
+            href="/profile/my-likes"
+            className="col-span-2 flex items-center justify-between group p-4 bg-surface rounded-xl border border-border shadow-sm hover:border-brand/30 hover:shadow-md transition-all"
+          >
+            <div>
+              <div className="flex items-center gap-2 mb-1 text-rose-500">
+                <HeartIcon className="size-5" />
+                <span className="text-sm font-semibold">찜한 내역</span>
+              </div>
+              <p className="text-xs text-muted group-hover:text-primary transition-colors">
+                내가 찜한 관심 상품
+              </p>
+            </div>
+            <ChevronRightIcon className="size-5 text-muted group-hover:text-brand transition-colors" />
           </Link>
         </div>
       </section>

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -47,7 +47,7 @@ export const queryKeys = {
     detail: (id: number) => [...queryKeys.products.details(), id] as const,
     likeStatus: (productId: number) =>
       [...queryKeys.products.detail(productId), "likeStatus"] as const,
-    // 유저 프로필 탭의 판매/구매 목록용
+    // 유저 프로필 탭의 판매/구매/찜 목록용
     userScope: (scope: string, userId: number) =>
       [...queryKeys.products.all, "userScope", scope, userId] as const,
   },

--- a/prisma/migrations/20260305163331_add_like_feed_and_notification_indexes/migration.sql
+++ b/prisma/migrations/20260305163331_add_like_feed_and_notification_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "Notification_userId_type_link_created_at_idx" ON "Notification"("userId", "type", "link", "created_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "ProductLike_productId_idx" ON "ProductLike"("productId");
+
+-- CreateIndex
+CREATE INDEX "ProductLike_userId_created_at_productId_idx" ON "ProductLike"("userId", "created_at" DESC, "productId" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@
  * 2026.02.20  임도헌   Modified  동네 보기 범위 추가
  * 2026.02.21  임도헌   Modified  KeywordAlert에도 동네 범위 추가
  * 2026.02.24  임도헌   Modified  유저 모델에 카카오 ID 추가
+ * 2026.03.06  임도헌   Modified  ProductLike/Notification 인덱스 추가 (좋아요 목록/알림 중복 검사 성능 최적화)
  */
 generator client {
   provider = "prisma-client"
@@ -341,6 +342,8 @@ model ProductLike {
   productId Int
 
   @@id(name: "id", [userId, productId]) // 복합 키
+  @@index([productId]) // 상품별 좋아요 카운트/조회 최적화
+  @@index([userId, created_at(sort: Desc), productId(sort: Desc)]) // 내 찜 목록 최신순 + 커서 페이징 최적화
 }
 
 /// 거래 후기 (Review)
@@ -576,6 +579,7 @@ model Notification {
 
   @@index([userId, created_at]) // 내 알림함
   @@index([userId, isRead]) // 안 읽은 알림 필터
+  @@index([userId, type, link, created_at(sort: Desc)]) // 거래 알림 최근 중복 검사 쿼리 최적화
 }
 
 /// Web Push 구독 정보 (PWA)


### PR DESCRIPTION
[✨ Feat: 찜한 목록 기능 추가]
- 찜한 상품 전용 목록 페이지 및 관련 레이아웃/로딩 스켈레톤 구현
- 좋아요 토글 시 찜 목록 캐시를 즉시 반영하는 Optimistic UI 적용
- 판매자 대상 알림 연동 및 찜 목록 스코프 조회 로직 추가

[🚑 Fix: 제품 상세 모달 및 수정 플로우 라우팅 정리]
- Intercepting Route 환경에서 제품 수정 후 발생하던 404 문제 해결
- 모달 상세 / 일반 상세 / 수정 페이지 간 복귀 흐름을 컨텍스트 기준으로 정리
- 상세 모달 재오픈 릴레이 및 returnTo/flow 파라미터 전략 정비

[📝 Comment]
- 관련 도메인 파일 JSDoc 정리
- History 주석 최신화
