### PR TITLE
✨ Feat : Lighthouse Trust & Safety 기반 보안 헤더 1차 하드닝

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,137 @@
 import withPWA from "next-pwa";
 
+const isProduction = process.env.NODE_ENV === "production";
+
+function normalizeOrigin(value) {
+  if (!value) return null;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function toWebSocketOrigin(origin) {
+  if (!origin) return null;
+
+  try {
+    const url = new URL(origin);
+    if (url.protocol === "https:") {
+      url.protocol = "wss:";
+    } else if (url.protocol === "http:") {
+      url.protocol = "ws:";
+    } else {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function buildDirective(name, sources) {
+  return `${name} ${sources.join(" ")}`;
+}
+
+const appOrigin = normalizeOrigin(process.env.NEXT_PUBLIC_APP_URL);
+const supabaseOrigin = normalizeOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
+const supabaseWsOrigin = toWebSocketOrigin(supabaseOrigin);
+const cloudflareStreamOrigin = normalizeOrigin(
+  process.env.NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN
+);
+const kakaoMapsOrigin = "https://dapi.kakao.com";
+
+const isSecureAppOrigin = (() => {
+  if (!appOrigin) return false;
+
+  try {
+    return new URL(appOrigin).protocol === "https:";
+  } catch {
+    return false;
+  }
+})();
+
+const imageOrigins = unique([
+  "https://avatars.githubusercontent.com",
+  "https://imagedelivery.net",
+  "https://w7.pngwing.com",
+  "https://i.ytimg.com",
+  "https://customer-fllme7un34f7981k.cloudflarestream.com",
+  "https://videodelivery.net",
+  cloudflareStreamOrigin,
+]);
+
+const scriptOrigins = unique([kakaoMapsOrigin]);
+const connectOrigins = unique([
+  supabaseOrigin,
+  supabaseWsOrigin,
+  kakaoMapsOrigin,
+]);
+const frameOrigins = unique([
+  "https://www.youtube-nocookie.com",
+  cloudflareStreamOrigin,
+]);
+const mediaOrigins = unique([cloudflareStreamOrigin]);
+
+const cspReportOnly = [
+  buildDirective("default-src", ["'self'"]),
+  buildDirective("base-uri", ["'self'"]),
+  buildDirective("form-action", ["'self'"]),
+  buildDirective("object-src", ["'none'"]),
+  buildDirective("frame-ancestors", ["'self'"]),
+  buildDirective("img-src", ["'self'", "data:", "blob:", ...imageOrigins]),
+  buildDirective("font-src", ["'self'", "data:"]),
+  // next-themes 초기 인라인 스크립트 가능성을 고려한 1차 관찰용 임시 허용값
+  buildDirective("style-src", ["'self'", "'unsafe-inline'"]),
+  // Report-Only 관찰 단계에서는 인라인 스크립트를 임시 허용하고 2차에서 축소를 검토
+  buildDirective("script-src", ["'self'", "'unsafe-inline'", ...scriptOrigins]),
+  buildDirective("connect-src", ["'self'", ...connectOrigins]),
+  buildDirective("frame-src", ["'self'", ...frameOrigins]),
+  buildDirective("worker-src", ["'self'", "blob:"]),
+  buildDirective("manifest-src", ["'self'"]),
+  buildDirective("media-src", ["'self'", "blob:", ...mediaOrigins]),
+].join("; ");
+
+const securityHeaders = [
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "SAMEORIGIN",
+  },
+  {
+    key: "Cross-Origin-Opener-Policy",
+    value: "same-origin-allow-popups",
+  },
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: cspReportOnly,
+  },
+  {
+    key: "Permissions-Policy",
+    value:
+      "geolocation=(), camera=(), microphone=(), payment=(), usb=(), browsing-topics=()",
+  },
+];
+
+if (isProduction && isSecureAppOrigin) {
+  securityHeaders.push({
+    key: "Strict-Transport-Security",
+    value: "max-age=86400",
+  });
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
@@ -16,6 +148,14 @@ const nextConfig = {
       { hostname: "customer-fllme7un34f7981k.cloudflarestream.com" },
       { hostname: "videodelivery.net" },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## 작업 요약

Lighthouse Trust & Safety 경고 대응을 위해 1차 보안 헤더 하드닝을 적용했습니다.

이번 단계는 운영 회귀 위험을 낮추기 위해 enforced CSP, nonce 기반 strict CSP, Trusted Types는 제외하고, 공통 보안 헤더와 CSP Report-Only를 중심으로 구성했습니다.

## 변경 사항

### 🛡️ Security Headers

- `next.config.mjs`에 전역 보안 헤더 추가
- `X-Content-Type-Options: nosniff` 적용
- `Referrer-Policy: strict-origin-when-cross-origin` 적용
- `X-Frame-Options: SAMEORIGIN` 적용
- `Cross-Origin-Opener-Policy: same-origin-allow-popups` 적용
- production HTTPS 환경에서만 `Strict-Transport-Security: max-age=86400` 적용
- `Permissions-Policy`는 부가 하드닝 항목으로 제한 적용

### 📋 CSP Report-Only

- `Content-Security-Policy-Report-Only` 최소안 적용
- Supabase Realtime, Kakao Maps, Cloudflare Stream, YouTube embed, PWA/service worker 기준 허용 출처 정리
- 내부 same-origin iframe preview가 깨지지 않도록 `frame-src 'self'`, `frame-ancestors 'self'` 유지
- `script-src 'unsafe-inline'`은 1차 관찰용 임시 허용값으로 유지

## 제외한 항목

- enforced CSP
- nonce 기반 strict CSP
- Trusted Types
- COEP / CORP
- remotePatterns 표기 통일

## 검증

- `npm run lint` 통과
- `next.config.mjs` 설정 로드 확인
- production + HTTPS app origin 조건에서 HSTS 생성 확인
- Supabase Realtime WSS 확인
  - `wss://kfynzkfjhaujqehaeubc.supabase.co/realtime/v1/websocket...`
  - `101 Switching Protocols` 확인
- `NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN`이 origin 형태임을 확인

## 머지 후 확인

- 배포 환경 응답 헤더 확인
- Lighthouse Trust & Safety 재측정
- CSP Report-Only 위반 로그 확인
- 주요 기능 회귀 확인
  - GitHub / Kakao 로그인
  - Supabase Realtime
  - Kakao Maps
  - Cloudflare Stream
  - YouTube embed
  - PWA / Web Push
  - 이미지/영상 업로드
