### PR TITLE
🤝 Merge : 상세 삭제·수정 후 복귀 화면 꼬임 수정

### DIFF
--- a/app/(app)/(tabs)/products/page.tsx
+++ b/app/(app)/(tabs)/products/page.tsx
@@ -53,7 +53,9 @@
  * 2026.04.13  임도헌   Modified  모바일 요청에서는 데스크톱 헤더 렌더링을 건너뛰고 목록 prefetch를 헤더 데이터와 병렬화해 초기 응답 지연을 완화
  * 2026.04.13  임도헌   Modified  최근 성능 실험 이력 중 상충되던 pull-to-refresh 주석을 정리하고 모바일 사용 상태로 기준을 통일
  * 2026.04.13  임도헌   Modified  모바일 UA 판별 로직을 제품 유틸로 분리해 페이지 책임을 축소
+ * 2026.04.24  임도헌   Modified  ProductListRefreshRelay와 ProductModalReopenRelay를 함께 주입해 목록 refresh와 모달 fallback 책임을 분리
  * 2026.04.20  임도헌   Modified  앱 셸(sm) 기준과 헤더 분기 기준을 일치시켜 640~767px 구간 헤더 레이아웃 mismatch 정리
+ * 2026.04.24  임도헌   Modified  제품 목록 refresh relay와 모달 reopen relay를 분리해 navigation 복귀 책임을 명확화
  */
 
 import { Suspense } from "react";
@@ -71,6 +73,7 @@ import ProductMobileHeader from "@/features/product/components/ProductMobileHead
 import ProductList from "@/features/product/components/ProductList";
 import ProductListSkeleton from "@/features/product/components/ProductListSkeleton";
 import KeywordAlertButton from "@/features/notification/components/KeywordAlertButton";
+import ProductListRefreshRelay from "@/features/product/components/ProductListRefreshRelay";
 import ProductModalReopenRelay from "@/features/product/components/ProductModalReopenRelay";
 import { fetchProductCategories } from "@/features/product/service/category";
 import {
@@ -208,6 +211,7 @@ export default async function ProductsPage({
 
   return (
     <div className="flex flex-col min-h-screen bg-background pb-24 transition-colors">
+      <ProductListRefreshRelay />
       <ProductModalReopenRelay />
       <div className="sm:hidden">
         <ProductMobileHeader

--- a/app/(app)/(tabs)/profile/(product)/my-sales/page.tsx
+++ b/app/(app)/(tabs)/profile/(product)/my-sales/page.tsx
@@ -19,6 +19,7 @@
  * 2026.03.03  임도헌   Modified  TanStack Query HydrationBoundary 적용 및 initialSelling Props 제거
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/profile/(product)/my-sales/page.tsx 에서 app/(app)/(tabs)/profile/(product)/my-sales/page.tsx 로 변경 (라우트 그룹 개편)
+ * 2026.04.24  임도헌   Modified  상세 삭제/숨김 후 back 복귀 stale 보정을 위한 my-sales refresh relay 주입
  */
 
 import { redirect } from "next/navigation";
@@ -27,6 +28,7 @@ import { getQueryClient } from "@/lib/getQueryClient";
 import { queryKeys } from "@/lib/queryKeys";
 import getSession from "@/lib/session";
 import MySalesProductList from "@/features/product/components/MySalesProductList";
+import MySalesRefreshRelay from "@/features/product/components/MySalesRefreshRelay";
 import {
   getUserTabCounts,
   getUserProductsList,
@@ -61,6 +63,7 @@ export default async function MySalesPage() {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
+      <MySalesRefreshRelay />
       <MySalesProductList userId={userId} initialCounts={initialCounts} />
     </HydrationBoundary>
   );

--- a/app/(app)/(tabs)/profile/page.tsx
+++ b/app/(app)/(tabs)/profile/page.tsx
@@ -34,6 +34,7 @@
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/profile/page.tsx 에서 app/(app)/(tabs)/profile/page.tsx 로 변경 (라우트 그룹 개편)
  * 2026.04.16  임도헌   Modified   profile Lighthouse 대응으로 서버 선로딩/클라이언트 하단 지연 로드 구조 설명 주석 보강
  * 2026.04.17  임도헌   Modified   헤더 보조 주석을 현재 역할 기준으로 다듬어 unreadCount 선로딩 의도를 명확화
+ * 2026.04.24  임도헌   Modified   녹화 상세 삭제 후 내 프로필로 back 복귀할 때 방송국 섹션을 1회 refresh하도록 relay 추가
  */
 
 import { redirect } from "next/navigation";
@@ -53,6 +54,7 @@ import { getUserAverageRating } from "@/features/user/service/metric";
 import { getAllBadges, getUserBadges } from "@/features/user/service/badge";
 import { getRecentBroadcasts } from "@/features/stream/service/list";
 import { getUnreadNotificationCount } from "@/features/notification/actions/count";
+import RecordingListRefreshRelay from "@/features/stream/components/RecordingListRefreshRelay";
 
 export const dynamic = "force-dynamic";
 
@@ -82,27 +84,30 @@ export default async function ProfilePage() {
   const queryClient = getQueryClient();
 
   // 2. 대량 데이터 병렬 로딩 (성능 최적화)
-  const [averageRating, badgesPair, streams, unreadCount, previewReviews] = await Promise.all([
-    getUserAverageRating(user.id),
-    (async () => {
-      const [badges, badgesEarned] = await Promise.all([
-        getAllBadges(),
-        getUserBadges(user.id),
-      ]);
-      return { badges, userBadges: badgesEarned };
-    })(),
-    getRecentBroadcasts(user.id, 6, true),
-    getUnreadNotificationCount(),
-    getUserReviews(user.id, null, 2, user.id).then((res) => res.reviews),
-    queryClient.prefetchInfiniteQuery({
-      queryKey: queryKeys.reviews.user(user.id),
-      queryFn: () => getUserReviewsAction(user.id, null),
-      initialPageParam: null as any,
-    }),
-  ]);
+  const [averageRating, badgesPair, streams, unreadCount, previewReviews] =
+    await Promise.all([
+      getUserAverageRating(user.id),
+      (async () => {
+        const [badges, badgesEarned] = await Promise.all([
+          getAllBadges(),
+          getUserBadges(user.id),
+        ]);
+        return { badges, userBadges: badgesEarned };
+      })(),
+      getRecentBroadcasts(user.id, 6, true),
+      getUnreadNotificationCount(),
+      getUserReviews(user.id, null, 2, user.id).then((res) => res.reviews),
+      queryClient.prefetchInfiniteQuery({
+        queryKey: queryKeys.reviews.user(user.id),
+        queryFn: () => getUserReviewsAction(user.id, null),
+        initialPageParam: null as any,
+      }),
+    ]);
 
   return (
     <div className="min-h-screen bg-background transition-colors pb-24">
+      {/* 녹화 상세 삭제 후 /profile로 back 복귀하면 내 방송국 목록만 1회 서버 payload 재요청으로 보정 */}
+      <RecordingListRefreshRelay />
       <header className="sticky top-0 z-30 h-16 border-b border-border-subtle bg-background shadow-sm">
         <div className="flex h-full items-center justify-end gap-2 px-page-x">
           {/* 헤더에서 바로 필요한 unread count의 서버 동시 준비 및 첫 렌더 즉시 노출 */}
@@ -138,6 +143,3 @@ export default async function ProfilePage() {
     </div>
   );
 }
-
-
-

--- a/app/(app)/posts/[id]/edit/page.tsx
+++ b/app/(app)/posts/[id]/edit/page.tsx
@@ -18,7 +18,7 @@
  * 2026.03.13  임도헌   Modified  returnTo 복귀 경로를 수정 화면의 저장/삭제 흐름에 반영
  * 2026.03.14  임도헌   Modified  상세에서 진입한 수정 흐름을 flow=detail-edit로 받아 저장 후 back 복귀 기준을 명시
  * 2026.03.18  임도헌   Modified  detail-edit 삭제 복귀를 정규화된 returnTo 기준으로 판단하고, back 복귀 + 목록 refresh 플래그로 stale list와 raw 쿼리 예외를 함께 정리
- * 2026.04.01  임도헌   Modified  게시글 detail-edit 삭제는 history back 대신 명시 경로 복귀로 정리해 상세/목록 히스토리 문맥을 분리
+ * 2026.04.01  임도헌   Modified  당시 게시글 detail-edit 삭제 복귀를 명시 경로 기준으로 정리해 상세/목록 히스토리 문맥을 분리
  * 2026.03.23  임도헌   Modified  게시글 수정 페이지 id 가드를 상세 본문과 같은 유효 숫자/양수 기준으로 통일
  * 2026.04.06  임도헌   Modified  게시글 삭제를 상세 owner 메뉴로 이동해 수정 페이지는 편집 전용으로 단순화
  * 2026.04.12  임도헌   Moved     파일 경로를 app/posts/[id]/edit/page.tsx 에서 app/(app)/posts/[id]/edit/page.tsx 로 변경 (라우트 그룹 개편)

--- a/app/(app)/streams/[id]/recording/page.tsx
+++ b/app/(app)/streams/[id]/recording/page.tsx
@@ -170,6 +170,7 @@ export default async function RecordingVodPage({
         liveInputUid={base.broadcast.stream_id}
         categoryLabel={category?.kor_name ?? null}
         categoryIcon={category?.icon ?? null}
+        preferHistoryBack={!!searchParams?.returnTo}
       />
 
       <main className="flex-1 flex flex-col items-center gap-3 pb-20 px-page-x py-6 w-full max-w-mobile mx-auto">

--- a/features/post/components/PostForm.tsx
+++ b/features/post/components/PostForm.tsx
@@ -31,11 +31,13 @@
  * 2026.04.05  임도헌   Modified  게시글 detail-edit 저장/취소는 back 복귀 + 1회 refresh/상단 스크롤로 정리해 중복 히스토리와 스크롤 전파 문제를 함께 보정
  * 2026.04.14  임도헌   Modified  지도 선택 모달을 지연 로드하고 mode 기반 내부 서버 액션 선택으로 작성 페이지 초기 번들 부담을 완화
  * 2026.04.21  임도헌   Modified  메타/위치/하단 액션 섹션을 분리하고 주요 함수 설명 주석을 보강
+ * 2026.04.24  임도헌   Modified  detail-edit 저장 back 복귀는 명시적 내부 returnTo 문맥과 히스토리가 모두 있을 때만 허용하도록 보강
+ * 2026.04.24  임도헌   Modified  navigation refresh helper 기준으로 detail-edit 복귀 플래그 기록 중복을 정리
  */
 "use client";
 
 import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -70,8 +72,9 @@ import { usePostVideoUpload } from "@/features/post/hooks/usePostVideoUpload";
 import { applyFieldErrors } from "@/lib/applyFieldErrors";
 import { focusFirstFieldError } from "@/lib/focusFirstFieldError";
 import {
-  createNavigationRefreshFlagKey,
-  setNavigationRefreshFlag,
+  canUseBrowserBack,
+  markNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 import PostMetaSection from "@/features/post/components/PostMetaSection";
 import PostLocationSection from "@/features/post/components/PostLocationSection";
@@ -114,7 +117,7 @@ const LazyLocationPicker = dynamic(
  * - 블록 렌더링 UI는 `PostEditorBlocksField`, 순수 초기화 헬퍼는 `utils/editor`로 분리
  * - 카테고리, 태그, 지도 기반 위치(Location) 데이터 매핑 기능 제공
  * - FormErrorSummary, applyFieldErrors, focusFirstFieldError 기반의 검증 UX 적용
- * - 폼 제출 시 mode에 맞는 내부 서버 액션을 선택하고 결과에 따른 복귀/리다이렉트 처리
+ * - 폼 제출 시 mode에 맞는 내부 서버 액션을 선택하고 결과에 따른 back/replace 복귀를 처리
  *
  * @param {PostFormProps} props - 초기값, 모드, 복귀 경로, 상세 수정 플로우 설정
  */
@@ -128,10 +131,17 @@ export default function PostForm({
   editFlow,
 }: PostFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   // 쿼리 클라이언트 인스턴스 가져오기
   const queryClient = useQueryClient();
   const imageInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const blockRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const rawReturnTo = searchParams.get("returnTo");
+  // 게시글 detail-edit 저장은 명시적 내부 returnTo 문맥이 있는 경우에만 back 허용
+  const canResumeDetailEditHistory =
+    editFlow === "detail-edit" &&
+    !!rawReturnTo &&
+    canUseBrowserBack();
 
   const initialFormValues = useMemo(
     () =>
@@ -180,10 +190,10 @@ export default function PostForm({
   // create/edit 공개 props에는 직렬화 가능한 값만 두고, 서버 액션은 mode로 내부 선택
   const action = mode === "create" ? createPostAction : updatePostAction;
 
-  // 상세 진입 편집 복귀
-  // detail-edit는 기존 상세 히스토리를 재사용하고, 직접 진입처럼 back 대상이 없을 때만 안전 경로로 replace
+  // detail-edit 저장은 명시적 returnTo 문맥이 확인될 때만 back 사용
+  // 직접 진입/북마크처럼 내부 복귀 문맥이 없으면 안전한 backUrl replace로 정리
   const returnToDetailEditOrigin = () => {
-    if (typeof window !== "undefined" && window.history.length > 1) {
+    if (canResumeDetailEditHistory) {
       router.back();
       return;
     }
@@ -662,8 +672,9 @@ export default function PostForm({
         if (isEdit && editFlow === "detail-edit") {
           // 상세 진입 편집 복귀
           // back 복귀 직후 상세가 1회 최신화/상단 스크롤을 수행하도록 세션 플래그 기록
-          setNavigationRefreshFlag(
-            createNavigationRefreshFlagKey("post-detail-refresh", result.postId)
+          markNavigationRefresh(
+            NAVIGATION_REFRESH_SCOPES.POST_DETAIL,
+            result.postId
           );
           returnToDetailEditOrigin();
           return;

--- a/features/post/components/PostListRefreshRelay.tsx
+++ b/features/post/components/PostListRefreshRelay.tsx
@@ -6,33 +6,38 @@
  * History
  * Date        Author   Status    Description
  * 2026.04.07  임도헌   Created   게시글 상세 삭제 후 history back 복귀 시 목록 stale 상태를 1회 refresh로 보정
+ * 2026.04.24  임도헌   Modified  같은 탭 sessionStorage 기반 router.refresh 트리거라는 역할이 드러나도록 주석 보강
+ * 2026.04.24  임도헌   Modified  navigation refresh helper로 목록 refresh flag 소비 로직을 단순화
  */
 "use client";
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import {
-  consumeNavigationRefreshFlag,
-  createNavigationRefreshFlagKey,
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_ROOT_ID,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 /**
  * 게시글 목록 복귀 후 1회 refresh 릴레이
  *
  * [기능]
- * - 상세 삭제 후 `router.back()`으로 돌아온 `/posts` 목록이 stale 상태로 남지 않도록
- *   세션 플래그를 1회 소비해 `router.refresh()`를 수행
+ * - 상세 삭제 후 `router.back()`으로 돌아온 게시글 목록이 stale 상태로 남지 않도록
+ *   같은 탭 세션 플래그를 1회 소비해 `router.refresh()`를 수행
  */
 export default function PostListRefreshRelay() {
   const router = useRouter();
 
   useEffect(() => {
-    const refreshKey = createNavigationRefreshFlagKey(
-      "posts-list-refresh",
-      "root"
-    );
-
-    if (!consumeNavigationRefreshFlag(refreshKey)) return;
+    if (
+      !consumeNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.POSTS_LIST,
+        NAVIGATION_REFRESH_ROOT_ID
+      )
+    ) {
+      return;
+    }
     router.refresh();
   }, [router]);
 

--- a/features/post/components/postsDetail/PostDetailClientEffects.tsx
+++ b/features/post/components/postsDetail/PostDetailClientEffects.tsx
@@ -6,14 +6,15 @@
  * History
  * Date        Author   Status    Description
  * 2026.04.14  임도헌   Created   detail-edit 저장 후 back 복귀 시 1회 refresh와 상단 스크롤을 안정적으로 소비하는 클라이언트 island 분리
+ * 2026.04.24  임도헌   Modified  navigation refresh helper로 상세 refresh flag 소비 로직을 단순화
  */
 "use client";
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import {
-  consumeNavigationRefreshFlag,
-  createNavigationRefreshFlagKey,
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 interface PostDetailClientEffectsProps {
@@ -23,21 +24,21 @@ interface PostDetailClientEffectsProps {
 /**
  * 게시글 상세에서 브라우저 복귀 문맥에 의존하는 부작용만 처리
  * back 복귀로 기존 상세 인스턴스가 복원되는 경우에도 세션 플래그를 소비해
- * 상단 스크롤과 1회 refresh를 안정적으로 수행하도록 별도 island로 분리했다.
+ * 상단 스크롤과 1회 refresh를 안정적으로 수행하기 위한 별도 island 분리
  */
 export default function PostDetailClientEffects({
   postId,
 }: PostDetailClientEffectsProps) {
   const router = useRouter();
 
+  // detail-edit back 복귀, BFCache 복원, 탭 재활성화 시 세션 flag 재확인
   useEffect(() => {
-    const refreshKey = createNavigationRefreshFlagKey(
-      "post-detail-refresh",
-      postId
-    );
-
     const consumeRefreshIfNeeded = () => {
-      if (!consumeNavigationRefreshFlag(refreshKey)) return;
+      if (
+        !consumeNavigationRefresh(NAVIGATION_REFRESH_SCOPES.POST_DETAIL, postId)
+      ) {
+        return;
+      }
       window.scrollTo({ top: 0, left: 0, behavior: "auto" });
       router.refresh();
     };
@@ -49,6 +50,7 @@ export default function PostDetailClientEffects({
       consumeRefreshIfNeeded();
     };
 
+    // 브라우저가 기존 상세 인스턴스를 재사용하는 경로까지 동일하게 보정
     window.addEventListener("pageshow", consumeRefreshIfNeeded);
     window.addEventListener("focus", consumeRefreshIfNeeded);
     document.addEventListener("visibilitychange", handleVisibilityChange);

--- a/features/post/components/postsDetail/PostDetailTopbar.tsx
+++ b/features/post/components/postsDetail/PostDetailTopbar.tsx
@@ -61,6 +61,7 @@ interface PostDetailTopbarProps {
   backHref?: string;
   canEdit?: boolean;
   editHref?: string;
+  preferHistoryBack?: boolean;
 }
 
 /**
@@ -77,6 +78,7 @@ export default function PostDetailTopbar({
   backHref,
   canEdit,
   editHref,
+  preferHistoryBack = false,
 }: PostDetailTopbarProps) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -162,7 +164,7 @@ export default function PostDetailTopbar({
               postId={postId}
               editHref={editHref!}
               nextAfterDelete={nextAfterDelete}
-              preferHistoryBack={Boolean(backHref)}
+              preferHistoryBack={preferHistoryBack}
             />
           ) : (
             <div className="relative" ref={menuRef}>

--- a/features/post/components/postsDetail/PostOwnerMenu.tsx
+++ b/features/post/components/postsDetail/PostOwnerMenu.tsx
@@ -7,6 +7,7 @@
  * Date        Author   Status    Description
  * 2026.04.06  임도헌   Created   게시글 상세의 수정/삭제 액션을 상단 관리 메뉴로 통합
  * 2026.04.08  임도헌   Modified  삭제 후 목록 진입 문맥이면 back + posts 목록 refresh로 복귀하도록 보강
+ * 2026.04.24  임도헌   Modified  navigation refresh helper 기준으로 삭제 후 back 복귀 플래그 기록 중복을 정리
  */
 "use client";
 
@@ -24,8 +25,10 @@ import ConfirmDialog from "@/components/global/ConfirmDialog";
 import { deletePostAction } from "@/features/post/actions/delete";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import {
-  createNavigationRefreshFlagKey,
-  setNavigationRefreshFlag,
+  canUseBrowserBack,
+  markNavigationRefresh,
+  NAVIGATION_REFRESH_ROOT_ID,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 interface PostOwnerMenuProps {
@@ -41,8 +44,9 @@ interface PostOwnerMenuProps {
  * [기능]
  * - 상단 메뉴 버튼 하나로 수정/삭제 액션 제공
  * - 모바일은 BottomSheet, 데스크톱은 드롭다운 메뉴 사용
- * - 목록에서 진입한 상세는 삭제 후 history back으로 목록 문맥 유지
- * - 직접 진입처럼 안전한 back 대상이 없을 때만 게시글 목록 또는 안전한 returnTo 경로로 replace 복귀
+ * - 목록/이전 화면 문맥에서 진입한 상세 삭제는 history back으로 기존 엔트리를 재사용
+ * - 게시글 목록 문맥은 세션 refresh 플래그를 1회 소비해 stale list를 보정
+ * - 직접 진입처럼 안전한 back 대상이 없을 때만 `nextAfterDelete` 기준으로 replace 복귀
  */
 export default function PostOwnerMenu({
   postId,
@@ -57,6 +61,7 @@ export default function PostOwnerMenu({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
+  // 데스크톱 드롭다운만 외부 클릭으로 닫고, 모바일 BottomSheet는 자체 닫기 UX 사용
   useEffect(() => {
     if (isMobile) return;
 
@@ -84,14 +89,14 @@ export default function PostOwnerMenu({
         setConfirmOpen(false);
         setIsOpen(false);
 
-        if (
-          preferHistoryBack &&
-          typeof window !== "undefined" &&
-          window.history.length > 1
-        ) {
-          setNavigationRefreshFlag(
-            createNavigationRefreshFlagKey("posts-list-refresh", "root")
-          );
+        if (preferHistoryBack && canUseBrowserBack()) {
+          // 게시글 목록 문맥은 back 전에 flag를 남겨 복귀 후 stale list 보정
+          if (nextAfterDelete.startsWith("/posts")) {
+            markNavigationRefresh(
+              NAVIGATION_REFRESH_SCOPES.POSTS_LIST,
+              NAVIGATION_REFRESH_ROOT_ID
+            );
+          }
           router.back();
           return;
         }

--- a/features/post/components/postsDetail/index.tsx
+++ b/features/post/components/postsDetail/index.tsx
@@ -30,6 +30,7 @@
  * 2026.04.10  임도헌   Modified  post 타이포 정책에 맞춰 모바일 카테고리 칩 weight를 500 기준으로 정리
  * 2026.04.14  임도헌   Modified  상세 지도/복귀 부작용을 전용 컴포넌트로 분리해 초기 본문 비용과 scroll 복귀 안정성을 함께 개선
  * 2026.04.14  임도헌   Modified  main 랜드마크와 섹션 헤딩 레벨을 정리해 접근성과 문서 구조를 보강
+ * 2026.04.24  임도헌   Modified  detail-edit 링크에도 항상 내부 returnTo를 실어 저장 back 안전 조건과 정합성을 맞춤
  * ===============================================================================================
  * PostDetail (게시글 상세) 페이지를 구성하는 UI 요소 모음
  *
@@ -93,10 +94,11 @@ export default function PostDetail({
   const canEdit = post.user.id === user.id;
   const categoryLabel =
     post.category && POST_CATEGORY[post.category as PostCategoryType];
-  const editHref =
-    hasExplicitReturnTo && returnTo
-      ? `/posts/${post.id}/edit?returnTo=${encodeURIComponent(returnTo)}&flow=detail-edit`
-      : `/posts/${post.id}/edit?flow=detail-edit`;
+  // detail-edit는 항상 내부 상세 경로를 returnTo로 포함해 저장 시 안전한 back 기준 정렬
+  const detailReturnTo = returnTo ?? `/posts/${post.id}`;
+  const editHref = `/posts/${post.id}/edit?returnTo=${encodeURIComponent(
+    detailReturnTo
+  )}&flow=detail-edit`;
 
   return (
     <div className="relative min-h-screen bg-background transition-colors pb-20">
@@ -113,6 +115,7 @@ export default function PostDetail({
         backHref={returnTo}
         canEdit={canEdit}
         editHref={editHref}
+        preferHistoryBack={hasExplicitReturnTo}
       />
 
       <main className="mx-auto flex w-full max-w-mobile flex-col gap-8 px-page-x py-6">

--- a/features/product/components/MyLikesList.tsx
+++ b/features/product/components/MyLikesList.tsx
@@ -12,15 +12,18 @@
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 찜 목록 빈 상태 CTA 타이포를 정리
  * 2026.04.17  임도헌   Modified  찜 목록의 무한 스크롤/빠른 해제/상단 카드 우선 로드 책임 설명 보강
  * 2026.04.17  임도헌   Modified  Lighthouse 대응: 첫 카드만 priority 적용하고 빈 상태 heading/order 정리
+ * 2026.04.24  임도헌   Modified  찜 목록 제품 상세 진입 시 현재 목록 경로를 returnTo로 전달
  */
 "use client";
 
 import { useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { usePageVisibility } from "@/hooks/usePageVisibility";
 import { useProductPagination } from "@/features/product/hooks/useProductPagination";
 import ProductCard from "@/features/product/components/productCard";
+import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import type { LikedProductListItem } from "@/features/product/types";
 
@@ -37,6 +40,12 @@ import type { LikedProductListItem } from "@/features/product/types";
  * @param {number} props.userId - 조회할 대상 유저 ID
  */
 export default function MyLikesList({ userId }: { userId: number }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentQuery = searchParams.toString();
+  const returnTo = sanitizeCallbackUrl(
+    currentQuery ? `${pathname}?${currentQuery}` : pathname
+  );
   const liked = useProductPagination<LikedProductListItem>({
     mode: "profile",
     scope: { type: "LIKED", userId },
@@ -90,6 +99,7 @@ export default function MyLikesList({ userId }: { userId: number }) {
             // 첫 카드만 대표 LCP 후보로 우선 로드해 초기 이미지 경쟁 완화
             isPriority={index === 0}
             showQuickUnlike
+            returnTo={returnTo}
           />
         ))}
       </div>

--- a/features/product/components/MySalesRefreshRelay.tsx
+++ b/features/product/components/MySalesRefreshRelay.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * File Name : features/product/components/MySalesRefreshRelay.tsx
+ * Description : 내 판매 목록 back 복귀 후 mixed tree를 정리하는 refresh 릴레이
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.04.24  임도헌   Created   상세 삭제/숨김 후 내 판매 목록 back 복귀 시 현재 엔트리를 1회 reload하는 relay 추가
+ * 2026.04.24  임도헌   Modified  navigation refresh helper로 my-sales refresh flag 소비 로직을 단순화
+ */
+
+import { useEffect } from "react";
+import {
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_ROOT_ID,
+  NAVIGATION_REFRESH_SCOPES,
+} from "@/lib/navigationRefreshFlag";
+
+/**
+ * 내 판매 목록 복귀 후 1회 refresh 릴레이
+ *
+ * [기능]
+ * - 상세 삭제/숨김 상태 변경 후 `router.back()`으로 돌아온 `/profile/my-sales`가 stale 상태로 남지 않도록
+ *   같은 탭 세션 플래그를 1회 소비해 현재 엔트리를 `window.location.reload()`로 다시 로드
+ * - App Router가 back 복귀 시 이전 상세 트리를 함께 복원하는 예외 케이스를 강제로 정리
+ */
+export default function MySalesRefreshRelay() {
+  // `/profile/my-sales` 복귀 직후 세션 flag 소비 및 상세 트리 잔상 제거
+  useEffect(() => {
+    if (
+      !consumeNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.MY_SALES,
+        NAVIGATION_REFRESH_ROOT_ID
+      )
+    ) {
+      return;
+    }
+    window.location.reload();
+  }, []);
+
+  return null;
+}

--- a/features/product/components/ProductForm.tsx
+++ b/features/product/components/ProductForm.tsx
@@ -40,6 +40,9 @@
  * 2026.04.14  임도헌   Modified  지연 로드/복귀 흐름/업로드 단계 주석을 현재 구조 기준으로 간결하게 정리
  * 2026.04.14  임도헌   Modified  use client 직렬화 경고를 피하기 위해 서버 액션 prop을 제거하고 mode 기반 내부 선택으로 전환
  * 2026.04.21  임도헌   Modified  이미지/카테고리/거래 장소/하단 액션 섹션을 분리하고 함수 설명을 보강
+ * 2026.04.24  임도헌   Modified  edit 저장 back 복귀는 명시적 내부 returnTo 문맥과 히스토리가 모두 있을 때만 허용하도록 보강
+ * 2026.04.24  임도헌   Modified  detail-edit 취소도 안전한 내부 returnTo 문맥이면 back 복귀를 우선 사용하도록 정리
+ * 2026.04.24  임도헌   Modified  navigation refresh helper 기준으로 detail/modal edit 복귀 플래그 기록 중복을 정리
  */
 
 /**
@@ -94,8 +97,9 @@ import type { LocationData } from "@/features/map/types";
 import { applyFieldErrors } from "@/lib/applyFieldErrors";
 import { focusFirstFieldError } from "@/lib/focusFirstFieldError";
 import {
-  createNavigationRefreshFlagKey,
-  setNavigationRefreshFlag,
+  canUseBrowserBack,
+  markNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 import {
   stripProductImagePublicVariant,
@@ -139,7 +143,7 @@ const CF_HASH = process.env.NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_HASH;
  * - RHF + Zod 기반 검증과 필드 상태를 관리
  * - 이미지 업로드/정렬/애니메이션 메타를 통합 관리
  * - 대분류/소분류, 거래 장소, 태그 등 부가 입력 흐름을 함께 조정
- * - 저장 성공 후 create/edit 진입 맥락에 맞춰 복귀 경로를 분기
+ * - 저장 성공 후 create/edit 진입 맥락에 맞춰 back 또는 replace 복귀 경로를 분기
  * - 지도 선택 모달은 첫 화면 번들을 줄이기 위해 필요 시점에만 지연 로드
  */
 export default function ProductForm({
@@ -154,6 +158,9 @@ export default function ProductForm({
   // 저장 후 상세/목록 복귀에 재사용할 returnTo를 안전한 내부 경로로 정제
   const rawReturnTo = sp.get("returnTo");
   const returnTo = rawReturnTo ? sanitizeCallbackUrl(rawReturnTo) : null;
+  // back 복귀는 앱이 심어 둔 내부 returnTo 문맥과 실제 히스토리가 함께 있을 때만 허용
+  const canResumeEditHistory =
+    !!rawReturnTo && canUseBrowserBack();
   const isModalEditFlow = sp.get("flow") === "modal-edit";
   const [resetSignal, setResetSignal] = useState(0);
   const [isUploading, setIsUploading] = useState(false);
@@ -161,9 +168,10 @@ export default function ProductForm({
   // create/edit 공개 props에는 직렬화 가능한 값만 두고, 서버 액션은 mode로 내부 선택
   const action = mode === "create" ? createProductAction : updateProductAction;
 
-  // modal-edit는 기존 히스토리를 우선 재사용하고, back 대상이 없을 때만 목록 릴레이로 복귀
+  // modal-edit는 앱이 만든 returnTo 문맥이 확인될 때만 back 재사용
+  // 직접 진입/북마크처럼 안전한 복귀 대상이 없으면 openProductId fallback으로 모달 재오픈
   const returnToModalEditOrigin = (productId: number) => {
-    if (typeof window !== "undefined" && window.history.length > 1) {
+    if (canResumeEditHistory) {
       router.back();
       return;
     }
@@ -178,11 +186,13 @@ export default function ProductForm({
     router.replace(`/products/view/${productId}`);
   };
 
-  // detail-edit는 기존 상세 히스토리를 우선 재사용하고, 직접 진입일 때만 상세 replace로 복귀
+  // detail-edit 저장은 명시적 returnTo 문맥이 있는 경우에만 back 사용
+  // 그 외 직접 진입/외부 히스토리 가능성은 전체 문서 이동으로 상세를 다시 로드해 stale tree 회피
   const returnToDetailEditOrigin = (productId: number, detailHref: string) => {
-    if (typeof window !== "undefined" && window.history.length > 1) {
-      setNavigationRefreshFlag(
-        createNavigationRefreshFlagKey("product-detail-refresh", productId)
+    if (canResumeEditHistory) {
+      markNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.PRODUCT_DETAIL,
+        productId
       );
       router.back();
       return;
@@ -503,8 +513,9 @@ export default function ProductForm({
           );
           if (isModalEditFlow) {
             // 모달 상세는 1회 refresh 플래그를 남기고 이전 히스토리로 복귀
-            setNavigationRefreshFlag(
-              createNavigationRefreshFlagKey("product-modal-refresh", productId)
+            markNavigationRefresh(
+              NAVIGATION_REFRESH_SCOPES.PRODUCT_MODAL,
+              productId
             );
             returnToModalEditOrigin(productId);
           } else {
@@ -555,7 +566,7 @@ export default function ProductForm({
   }, [previews.length, clearErrors]);
 
   /**
-   * 폼을 초기 상태로 되돌린다.
+   * 폼 초기 상태 복원
    * - RHF 값뿐 아니라 업로드 미리보기/애니메이션 메타/대분류 선택 상태까지 함께 복원
    */
   const resetForm = () => {
@@ -579,7 +590,7 @@ export default function ProductForm({
 
   /**
    * 대분류 선택 변경
-   * - 기타(OTHER)는 대분류 자체를 최종 categoryId로 사용하고, 일반 카테고리는 소분류를 다시 선택하게 만든다.
+   * - 기타(OTHER)는 대분류 자체를 최종 categoryId로 사용하고, 일반 카테고리는 소분류 재선택 유도
    */
   const handleMainCategoryChange = (value: string) => {
     const id = value ? Number(value) : null;
@@ -792,8 +803,8 @@ export default function ProductForm({
             return;
           }
 
-          if (mode === "edit") {
-            router.replace(cancelHref);
+          if (mode === "edit" && defaultValues.id) {
+            returnToDetailEditOrigin(defaultValues.id, cancelHref);
             return;
           }
 

--- a/features/product/components/ProductListRefreshRelay.tsx
+++ b/features/product/components/ProductListRefreshRelay.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * File Name : features/product/components/ProductListRefreshRelay.tsx
+ * Description : 제품 목록 back 복귀 후 mixed tree를 정리하는 refresh 릴레이
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.04.24  임도헌   Created   ProductModalReopenRelay에서 제품 목록 refresh 책임을 분리해 전용 relay로 신설
+ */
+
+import { useEffect } from "react";
+import {
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_ROOT_ID,
+  NAVIGATION_REFRESH_SCOPES,
+} from "@/lib/navigationRefreshFlag";
+
+/**
+ * 제품 목록 복귀 후 1회 reload 릴레이
+ *
+ * [기능]
+ * - 상세/모달 삭제 후 `router.back()`으로 돌아온 `/products`가 stale 상태로 남지 않도록
+ *   같은 탭 세션 플래그를 1회 소비해 현재 엔트리를 `window.location.reload()`로 다시 로드
+ * - App Router가 back 복귀 시 이전 상세 트리를 함께 복원하는 mixed tree 예외 케이스를 강제로 정리
+ */
+export default function ProductListRefreshRelay() {
+  // `/products` 진입 직후 세션 flag 소비 및 App Router mixed tree 강제 정리
+  useEffect(() => {
+    if (
+      !consumeNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.PRODUCTS_LIST,
+        NAVIGATION_REFRESH_ROOT_ID
+      )
+    ) {
+      return;
+    }
+
+    window.location.reload();
+  }, []);
+
+  return null;
+}

--- a/features/product/components/ProductModalReopenRelay.tsx
+++ b/features/product/components/ProductModalReopenRelay.tsx
@@ -1,16 +1,17 @@
 /**
  * File Name : features/product/components/ProductModalReopenRelay.tsx
- * Description : 제품 목록 freshness 보강 및 모달 상세 fallback 재오픈을 담당하는 목록 릴레이
+ * Description : 제품 모달 상세 fallback 재오픈을 담당하는 릴레이
  * Author : 임도헌
  *
  * History
  * Date        Author   Status    Description
  * 2026.03.05  임도헌   Created   편집 완료 후 목록(/products) 경유 시 인터셉트 모달 재오픈 릴레이 추가
- * 2026.03.17  임도헌   Modified  삭제 후 back 복귀한 목록은 세션 refresh 플래그를 1회 소비해 stale list를 방지
+ * 2026.03.17  임도헌   Modified  삭제 후 back 복귀한 목록의 stale 상태 보정을 릴레이에서 처리하도록 확장
  * 2026.03.18  임도헌   Modified  returnTo 재오픈 경로에 sanitizeCallbackUrl을 적용해 목록 복귀 경로 안전성 보강
  * 2026.04.02  임도헌   Modified  openProductId 중간 URL을 먼저 returnTo로 정리한 뒤 모달 상세를 다시 push하는 fallback 릴레이로 보정
  * 2026.04.06  임도헌   Modified  history back 우선 정책 기준에 맞춰 fallback 릴레이 역할을 명시
  * 2026.04.13  임도헌   Modified  재오픈 경로 계산 보조 함수를 분리하고 단계형 인라인 주석을 정리
+ * 2026.04.24  임도헌   Modified  제품 목록 refresh 책임을 ProductListRefreshRelay로 분리하고 모달 fallback 재오픈 책임만 유지
  */
 
 "use client";
@@ -23,10 +24,6 @@ import {
   type ReadonlyURLSearchParams,
 } from "next/navigation";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
-import {
-  consumeNavigationRefreshFlag,
-  createNavigationRefreshFlagKey,
-} from "@/lib/navigationRefreshFlag";
 
 function getSanitizedCurrentHref(
   pathname: string,
@@ -47,12 +44,11 @@ function buildProductModalHref(id: number, returnTo: string) {
 }
 
 /**
- * 제품 목록 복귀 후 모달 상세 재오픈 릴레이
+ * 제품 모달 상세 fallback 재오픈 릴레이
  *
  * [기능]
  * - `openProductId`가 붙은 중간 URL을 먼저 `returnTo` 목록 경로로 정리
  * - history back 대상이 없을 때만 인터셉트 상세를 다시 여는 fallback 복귀 경로 제공
- * - 삭제/수정 후 back 복귀한 목록은 세션 refresh 플래그를 1회 소비해 stale list를 방지
  */
 export default function ProductModalReopenRelay() {
   const router = useRouter();
@@ -71,16 +67,7 @@ export default function ProductModalReopenRelay() {
     [pathname, sp]
   );
 
-  useEffect(() => {
-    const refreshKey = createNavigationRefreshFlagKey(
-      "products-list-refresh",
-      "root"
-    );
-
-    if (!consumeNavigationRefreshFlag(refreshKey)) return;
-    router.refresh();
-  }, [router]);
-
+  // `openProductId` 중간 URL을 먼저 안전한 목록 URL로 정리
   useEffect(() => {
     if (!openProductId) return;
 
@@ -100,6 +87,7 @@ export default function ProductModalReopenRelay() {
     router.replace(returnTo);
   }, [openProductId, returnToParam, router]);
 
+  // 목록 URL 정리 완료 후 다음 tick에서 인터셉트 모달 상세 재오픈
   useEffect(() => {
     if (!pendingModalReopen) return;
     if (currentHref !== pendingModalReopen.returnTo) return;

--- a/features/product/components/productDetail/ProductDetailClientEffects.tsx
+++ b/features/product/components/productDetail/ProductDetailClientEffects.tsx
@@ -7,6 +7,7 @@
  * Date        Author   Status    Description
  * 2026.04.14  임도헌   Created   최근 본 상품 저장과 편집 후 refresh 플래그 소비를 별도 클라이언트 island로 분리
  * 2026.04.14  임도헌   Modified  클라이언트 island의 책임과 부작용 범위가 드러나도록 함수 상단 JSDoc 설명을 보강
+ * 2026.04.24  임도헌   Modified  navigation refresh helper로 제품 상세 refresh flag 소비 로직을 단순화
  */
 
 "use client";
@@ -19,8 +20,8 @@ import {
   saveRecentViewedProduct,
 } from "@/features/product/utils/recentViewed";
 import {
-  consumeNavigationRefreshFlag,
-  createNavigationRefreshFlagKey,
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 interface ProductDetailClientEffectsProps {
@@ -39,6 +40,7 @@ export default function ProductDetailClientEffects({
 }: ProductDetailClientEffectsProps) {
   const router = useRouter();
 
+  // 브라우저 저장소 기반 최근 본 상품 동기화
   useEffect(() => {
     if (product.hidden_at) {
       removeRecentViewedProduct(product.id);
@@ -67,15 +69,19 @@ export default function ProductDetailClientEffects({
     });
   }, [product]);
 
+  // 일반 상세 detail-edit back 복귀 시에만 서버 payload 1회 재요청
   useEffect(() => {
     if (isModalContext) return;
 
-    const refreshKey = createNavigationRefreshFlagKey(
-      "product-detail-refresh",
-      product.id
-    );
     // detail-edit 저장 후 back 복귀한 기존 상세의 1회 최신화
-    if (!consumeNavigationRefreshFlag(refreshKey)) return;
+    if (
+      !consumeNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.PRODUCT_DETAIL,
+        product.id
+      )
+    ) {
+      return;
+    }
     router.refresh();
   }, [isModalContext, product.id, router]);
 

--- a/features/product/components/productDetail/ProductOwnerMenu.tsx
+++ b/features/product/components/productDetail/ProductOwnerMenu.tsx
@@ -8,6 +8,9 @@
  * 2026.04.06  임도헌   Created   상세/모달 상세의 수정/삭제 액션을 상단 메뉴로 통합
  * 2026.04.08  임도헌   Modified  삭제 후 최근 본 상품에서 제거하고 목록 진입 문맥이면 back + 목록 refresh로 복귀하도록 보강
  * 2026.04.09  임도헌   Modified  판매완료 상품 숨기기/숨김 해제 액션과 복귀 분기 추가
+ * 2026.04.24  임도헌   Modified  내 판매 목록 삭제 복귀는 replace+refresh를 우선 적용하고 일반 back 분기와 주석을 현재 정책 기준으로 정리
+ * 2026.04.24  임도헌   Modified  내 판매 목록도 전용 refresh relay를 통해 back + 1회 refresh 복귀를 사용하도록 조정
+ * 2026.04.24  임도헌   Modified  returnTo 문맥 분류와 navigation refresh helper로 삭제/숨김 복귀 분기 중복을 정리
  */
 "use client";
 
@@ -28,8 +31,10 @@ import ConfirmDialog from "@/components/global/ConfirmDialog";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { removeRecentViewedProduct } from "@/features/product/utils/recentViewed";
 import {
-  createNavigationRefreshFlagKey,
-  setNavigationRefreshFlag,
+  canUseBrowserBack,
+  markNavigationRefresh,
+  NAVIGATION_REFRESH_ROOT_ID,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 interface ProductOwnerMenuProps {
@@ -39,6 +44,15 @@ interface ProductOwnerMenuProps {
   isHidden?: boolean;
 }
 
+type ProductReturnContext = "products" | "my-sales" | "chats" | "other";
+
+function getProductReturnContext(rawReturnTo: string | null): ProductReturnContext {
+  if (rawReturnTo?.startsWith("/products")) return "products";
+  if (rawReturnTo?.startsWith("/profile/my-sales")) return "my-sales";
+  if (rawReturnTo?.startsWith("/chats/")) return "chats";
+  return "other";
+}
+
 /**
  * 상품 상세 owner 전용 관리 메뉴
  *
@@ -46,7 +60,8 @@ interface ProductOwnerMenuProps {
  * - 상단 메뉴 버튼 하나로 수정/숨기기/삭제 관리 액션 제공
  * - 판매완료 상품만 숨기기/숨김 해제를 허용
  * - 모바일은 BottomSheet, 데스크톱은 드롭다운 메뉴 사용
- * - 목록에서 진입한 상세/모달은 삭제 후 history back으로 목록 문맥 유지
+ * - `/products` 문맥은 삭제 후 back 복귀를 우선하고, 목록 mixed tree 정리는 ProductListRefreshRelay에 위임
+ * - `/profile/my-sales` 문맥도 back 복귀를 우선하고, 내 판매 mixed tree 정리는 MySalesRefreshRelay에 위임
  * - 숨기기/숨김 해제는 공개 목록(/products) 또는 내 판매(/profile/my-sales) 문맥으로 자연스럽게 복귀
  */
 export default function ProductOwnerMenu({
@@ -67,13 +82,30 @@ export default function ProductOwnerMenu({
   const returnTo = rawReturnTo
     ? sanitizeCallbackUrl(rawReturnTo)
     : "/products";
+  const returnContext = getProductReturnContext(rawReturnTo);
   const nextAfterDelete =
-    returnTo && !returnTo.startsWith("/chats/") ? returnTo : "/products";
+    returnContext !== "chats" ? returnTo : "/products";
+  const hasBackHistory = canUseBrowserBack();
+  // 모달 상세는 목록 위에 열린 상태가 정상 문맥이므로 제품 목록 returnTo에서만 back 복귀 허용
+  const canGoBackToProductsListModal =
+    isModalContext &&
+    returnContext === "products" &&
+    hasBackHistory;
+  const canGoBackToMySales =
+    returnContext === "my-sales" && hasBackHistory;
+  // rawReturnTo가 있어야 내부 문맥에서 온 복귀로 판단하고 history 재사용 허용
+  // full-page 상세 삭제는 모바일 퍼스트 기준으로 back UX 우선
+  const canGoBackAfterDelete =
+    !!rawReturnTo &&
+    returnContext !== "chats" &&
+    returnContext !== "my-sales" &&
+    hasBackHistory;
   const editFlow = isModalContext ? "modal-edit" : "detail-edit";
   const editHref = `/products/view/${productId}/edit?returnTo=${encodeURIComponent(
     returnTo
   )}&flow=${editFlow}`;
 
+  // 데스크톱 드롭다운만 외부 클릭으로 닫고, 모바일 BottomSheet는 자체 닫기 UX 사용
   useEffect(() => {
     if (isMobile) return;
 
@@ -90,6 +122,22 @@ export default function ProductOwnerMenu({
   const handleEdit = () => {
     setIsOpen(false);
     router.push(editHref);
+  };
+
+  const goBackWithRefresh = (
+    scope:
+      | typeof NAVIGATION_REFRESH_SCOPES.PRODUCTS_LIST
+      | typeof NAVIGATION_REFRESH_SCOPES.MY_SALES
+  ) => {
+    // 복귀 대상 화면의 relay가 flag를 소비해 stale/mixed tree 상태 정리
+    markNavigationRefresh(scope, NAVIGATION_REFRESH_ROOT_ID);
+    router.back();
+  };
+
+  const replaceReturnToAndRefresh = () => {
+    // 안전한 back 대상이 없을 때는 명시 경로로 이동 후 현재 트리 재요청
+    router.replace(returnTo);
+    router.refresh();
   };
 
   const handleToggleHidden = () => {
@@ -116,24 +164,25 @@ export default function ProductOwnerMenu({
         removeRecentViewedProduct(productId);
       }
 
-      if (rawReturnTo?.startsWith("/products")) {
-        setNavigationRefreshFlag(
-          createNavigationRefreshFlagKey("products-list-refresh", "root")
-        );
-
-        if (typeof window !== "undefined" && window.history.length > 1) {
-          router.back();
+      if (returnContext === "products") {
+        // 공개 목록/모달 문맥은 back 복귀 후 제품 목록 relay에서 mixed tree 정리
+        if (canGoBackToProductsListModal) {
+          goBackWithRefresh(NAVIGATION_REFRESH_SCOPES.PRODUCTS_LIST);
           return;
         }
 
-        router.replace(returnTo);
-        router.refresh();
+        replaceReturnToAndRefresh();
         return;
       }
 
-      if (rawReturnTo?.startsWith("/profile/my-sales")) {
-        router.replace(returnTo);
-        router.refresh();
+      if (returnContext === "my-sales") {
+        // 내 판매 문맥은 전용 relay가 my-sales 화면의 stale/mixed tree 정리
+        if (canGoBackToMySales) {
+          goBackWithRefresh(NAVIGATION_REFRESH_SCOPES.MY_SALES);
+          return;
+        }
+
+        replaceReturnToAndRefresh();
         return;
       }
 
@@ -155,24 +204,35 @@ export default function ProductOwnerMenu({
       setIsOpen(false);
       removeRecentViewedProduct(productId);
 
-      if (rawReturnTo?.startsWith("/products")) {
-        setNavigationRefreshFlag(
-          createNavigationRefreshFlagKey("products-list-refresh", "root")
-        );
-
-        if (typeof window !== "undefined" && window.history.length > 1) {
-          router.back();
+      if (returnContext === "products") {
+        // 제품 목록에서 진입한 상세 삭제는 모바일 back UX를 우선 유지
+        if (canGoBackToProductsListModal) {
+          goBackWithRefresh(NAVIGATION_REFRESH_SCOPES.PRODUCTS_LIST);
           return;
         }
 
-        router.replace(returnTo);
-        router.refresh();
+        if (canGoBackAfterDelete) {
+          goBackWithRefresh(NAVIGATION_REFRESH_SCOPES.PRODUCTS_LIST);
+          return;
+        }
+
+        replaceReturnToAndRefresh();
         return;
       }
 
-      if (rawReturnTo?.startsWith("/profile/my-sales")) {
-        router.replace(returnTo);
-        router.refresh();
+      if (returnContext === "my-sales") {
+        // 내 판매에서 진입한 상세 삭제도 back 복귀 후 relay reload로 잔상 제거
+        if (canGoBackToMySales) {
+          goBackWithRefresh(NAVIGATION_REFRESH_SCOPES.MY_SALES);
+          return;
+        }
+
+        replaceReturnToAndRefresh();
+        return;
+      }
+
+      if (canGoBackAfterDelete) {
+        router.back();
         return;
       }
 

--- a/features/product/components/productDetail/modal/ProductDetailModalContainer.tsx
+++ b/features/product/components/productDetail/modal/ProductDetailModalContainer.tsx
@@ -21,9 +21,10 @@
  * 2026.03.18  임도헌   Modified  모달 상세의 returnTo를 sanitizeCallbackUrl 기준으로 정리해 닫기/수정 복귀 경로 안전성 보강
  * 2026.03.22  임도헌   Modified  데스크톱 모달 높이와 보더 톤을 최근 상세 모달 기준으로 정리
  * 2026.04.02  임도헌   Modified  모달 상세에서 수정 진입은 push를 유지하고 저장 후 목록 릴레이 재오픈 흐름과 정합성을 맞춤
- * 2026.04.06  임도헌   Modified  modal-edit 저장 후 back 우선, 목록 릴레이 fallback 기준으로 주석 최신화
+ * 2026.04.06  임도헌   Modified  modal-edit 저장 후 back 우선, 모달 재오픈 fallback 기준으로 주석 최신화
  * 2026.04.06  임도헌   Modified  모달 owner 액션도 상단 관리 메뉴로 통일
  * 2026.04.09  임도헌   Modified  모달 owner 메뉴에도 판매완료 숨김 상태를 전달해 상세/모달 관리 정책을 통일
+ * 2026.04.24  임도헌   Modified  navigation refresh helper로 모달 refresh flag 소비와 back 가능 여부 판별을 정리
  */
 "use client";
 
@@ -38,8 +39,9 @@ import { lockBodyScroll, unlockBodyScroll } from "@/lib/bodyScrollLock";
 import type { ProductDetailType } from "@/features/product/types";
 import { cn } from "@/lib/utils";
 import {
-  consumeNavigationRefreshFlag,
-  createNavigationRefreshFlagKey,
+  canUseBrowserBack,
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 interface ProductDetailProps {
@@ -54,7 +56,7 @@ interface ProductDetailProps {
  * - 배경 스크롤 잠금, 포커스 트랩, ESC 닫기 등 모달 필수 기능을 제공
  * - 닫기 시 `returnTo` 쿼리 파라미터를 사용하여 이전 목록 상태를 유지하며 복귀
  * - 모달 편집은 `flow=modal-edit`로 진입하고 저장 후 기존 모달 히스토리로 back 복귀를 우선 사용
- * - history back 대상이 없을 때만 목록 릴레이 fallback으로 같은 모달 상세를 다시 연다
+ * - history back 대상이 없을 때만 ProductModalReopenRelay fallback으로 같은 모달 상세를 다시 연다
  */
 export default function ProductDetailModalContainer(props: ProductDetailProps) {
   const router = useRouter();
@@ -78,20 +80,23 @@ export default function ProductDetailModalContainer(props: ProductDetailProps) {
   }, []);
 
   useEffect(() => {
-    const refreshKey = createNavigationRefreshFlagKey(
-      "product-modal-refresh",
-      props.product.id
-    );
-    // 모달 편집 저장 후 history back 대상이 없어 목록 릴레이를 거쳐 다시 열린 상세만
+    // modal-edit 저장 후 기존 모달 상세로 back 복귀했거나 fallback으로 재오픈된 상세만
     // 세션 플래그를 1회 소비해 최신 데이터로 다시 동기화.
-    if (!consumeNavigationRefreshFlag(refreshKey)) return;
+    if (
+      !consumeNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.PRODUCT_MODAL,
+        props.product.id
+      )
+    ) {
+      return;
+    }
     router.refresh();
   }, [props.product.id, router]);
 
   // 모달 닫기와 편집 진입에 재사용하는 복귀 경로 정제
   const returnTo = sanitizeCallbackUrl(sp.get("returnTo") ?? "/products");
   const handleOverlayClick = () => {
-    if (window.history.length > 1) {
+    if (canUseBrowserBack()) {
       router.back();
       return;
     }

--- a/features/stream/components/RecordingListRefreshRelay.tsx
+++ b/features/stream/components/RecordingListRefreshRelay.tsx
@@ -1,11 +1,14 @@
 /**
  * File Name : features/stream/components/RecordingListRefreshRelay.tsx
- * Description : 녹화 목록/채널 back 복귀 후 stale list를 1회만 새로고침하는 릴레이
+ * Description : 녹화 목록/채널/프로필 back 복귀 후 stale list를 1회만 새로고침하는 릴레이
  * Author : 임도헌
  *
  * History
  * Date        Author   Status    Description
  * 2026.04.07  임도헌   Created   녹화 상세 삭제 후 returnTo 대상 목록으로 back 복귀할 때 stale 상태를 1회 refresh로 보정
+ * 2026.04.24  임도헌   Modified  현재 정규화 경로와 같은 탭 sessionStorage 기반 router.refresh 트리거라는 설명으로 주석 보강
+ * 2026.04.24  임도헌   Modified  내 프로필 방송국 복귀도 같은 녹화 목록 refresh relay로 처리
+ * 2026.04.24  임도헌   Modified  navigation refresh helper로 녹화 목록 refresh flag 소비 로직을 단순화
  */
 "use client";
 
@@ -13,22 +16,23 @@ import { useEffect, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import {
-  consumeNavigationRefreshFlag,
-  createNavigationRefreshFlagKey,
+  consumeNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 /**
- * 녹화 목록/채널 복귀 후 1회 refresh 릴레이
+ * 녹화 목록/채널/프로필 복귀 후 1회 refresh 릴레이
  *
  * [기능]
  * - 삭제 후 `router.back()`으로 돌아온 returnTo 대상 화면이 stale 상태로 남지 않도록
- *   현재 경로를 키로 세션 플래그를 1회 소비해 `router.refresh()`를 수행
+ *   현재 정규화 경로를 키로 같은 탭 세션 플래그를 1회 소비해 `router.refresh()`를 수행
  */
 export default function RecordingListRefreshRelay() {
   const router = useRouter();
   const pathname = usePathname();
   const sp = useSearchParams();
 
+  // 삭제 직전에 기록한 returnTo와 동일한 형태로 맞춰 sessionStorage flag key 매칭
   const currentHref = useMemo(
     () =>
       sanitizeCallbackUrl(
@@ -37,13 +41,17 @@ export default function RecordingListRefreshRelay() {
     [pathname, sp]
   );
 
+  // 녹화 삭제 후 돌아온 목록/프로필/채널 화면에서만 서버 payload 1회 재요청
   useEffect(() => {
-    const refreshKey = createNavigationRefreshFlagKey(
-      "recording-list-refresh",
-      currentHref
-    );
-
-    if (!consumeNavigationRefreshFlag(refreshKey)) return;
+    // 같은 탭에서 방금 생성된 단발성 flag만 소비해 새 탭/직접 진입 영향 차단
+    if (
+      !consumeNavigationRefresh(
+        NAVIGATION_REFRESH_SCOPES.RECORDING_LIST,
+        currentHref
+      )
+    ) {
+      return;
+    }
     router.refresh();
   }, [currentHref, router]);
 

--- a/features/stream/components/recording/RecordingTopbar.tsx
+++ b/features/stream/components/recording/RecordingTopbar.tsx
@@ -18,6 +18,9 @@
  * 2026.03.25  임도헌   Modified  owner 전용 녹화 삭제 액션을 상단 메뉴로 이동해 상세 본문 시청 흐름을 단순화
  * 2026.04.03  임도헌   Modified  다시보기 상단 옵션의 차단/신고 위계와 삭제 문구를 다른 도메인과 같은 액션 문법으로 정리
  * 2026.04.08  임도헌   Modified  녹화 삭제 후 목록/채널 진입 문맥이면 back + 1회 refresh로 복귀하도록 정리
+ * 2026.04.24  임도헌   Modified  녹화 삭제의 back/replace 복귀 조건이 현재 정책 기준으로 드러나도록 주석 보강
+ * 2026.04.24  임도헌   Modified  내 프로필 방송국에서 진입한 녹화 삭제도 back + refresh 복귀 대상으로 포함
+ * 2026.04.24  임도헌   Modified  navigation refresh helper 기준으로 녹화 삭제 후 back 복귀 플래그 기록 중복을 정리
  */
 
 "use client";
@@ -41,8 +44,9 @@ import UserAvatar from "@/components/global/UserAvatar";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { cn, handleShare } from "@/lib/utils";
 import {
-  createNavigationRefreshFlagKey,
-  setNavigationRefreshFlag,
+  canUseBrowserBack,
+  markNavigationRefresh,
+  NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
 
 const ReportModal = dynamic(
@@ -50,16 +54,37 @@ const ReportModal = dynamic(
   { ssr: false }
 );
 
+/**
+ * 녹화 삭제 후 `router.back()`으로 복귀해도 안전한 내부 목록 문맥인지 판별
+ *
+ * - `/streams...`: 메인 라이브/다시보기 목록
+ * - `/profile`: 내 프로필의 "내 방송국" 섹션
+ * - `/profile/{username}/channel`: 유저 채널 다시보기 섹션
+ *
+ * 그 외 경로는 삭제 후 복귀 위치를 예측하기 어려우므로 replace fallback 사용
+ */
+function isSafeRecordingReturnTarget(href: string) {
+  return (
+    href.startsWith("/streams") ||
+    /^\/profile(?:\?|$)/.test(href) ||
+    /^\/profile\/[^/]+\/channel(?:\?|$)/.test(href)
+  );
+}
+
 interface RecordingTopbarProps {
   broadcastId: number;
   ownerId: number;
   username: string;
   avatar: string | null;
   isOwner?: boolean;
-  backHref?: string; // 기본: /streams
+  /** 뒤로가기/삭제 완료 후 돌아갈 내부 경로. 기본값은 다시보기 목록이다. */
+  backHref?: string;
   liveInputUid?: string | null;
-  categoryLabel?: string | null; /** 방송 카테고리 표시용 (선택) */
+  /** 방송 카테고리 표시용 라벨 */
+  categoryLabel?: string | null;
   categoryIcon?: string | null;
+  /** 명시적 returnTo 문맥에서 삭제 후 router.back() 복귀를 허용할지 여부 */
+  preferHistoryBack?: boolean;
 }
 
 /**
@@ -67,6 +92,7 @@ interface RecordingTopbarProps {
  * - 좌측에 뒤로가기 버튼과 작성자 프로필을 배치
  * - 우측에 카테고리 칩, 공유 버튼, 소유자/시청자별 옵션 메뉴를 노출
  * - 소유자는 녹화 삭제, 시청자는 스트리머 차단/다시보기 신고 액션을 실행
+ * - 녹화 삭제는 목록/채널/내 프로필 문맥이 명시된 경우에만 back을 재사용하고, 그 외에는 replace 복귀를 사용
  * - 스크롤 중에도 상단에 고정되어 상세 액션 접근을 유지
  */
 export default function RecordingTopbar({
@@ -79,6 +105,7 @@ export default function RecordingTopbar({
   liveInputUid,
   categoryLabel,
   categoryIcon,
+  preferHistoryBack = false,
 }: RecordingTopbarProps) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -149,15 +176,21 @@ export default function RecordingTopbar({
       setDeleteConfirmOpen(false);
       setMenuOpen(false);
 
-      if (typeof window !== "undefined" && window.history.length > 1) {
-        setNavigationRefreshFlag(
-          createNavigationRefreshFlagKey("recording-list-refresh", backHref)
-        );
+      const canReturnWithHistory =
+        preferHistoryBack &&
+        canUseBrowserBack() &&
+        isSafeRecordingReturnTarget(backHref);
+
+      if (canReturnWithHistory) {
+        // 삭제 후에는 기존 목록/채널/프로필 히스토리 엔트리로 돌아가고,
+        // 복귀 화면에서만 1회 router.refresh()를 실행해 stale 목록 보정
+        markNavigationRefresh(NAVIGATION_REFRESH_SCOPES.RECORDING_LIST, backHref);
         router.back();
         return;
       }
 
       router.replace(backHref || `/profile/${username}/channel`);
+      router.refresh();
     } catch (error) {
       console.error(error);
       toast.error(

--- a/features/stream/selects.ts
+++ b/features/stream/selects.ts
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.04.02  임도헌   Created   constants.ts에서 방송 요약 조회용 Prisma select 분리
+ * 2026.04.24  임도헌   Modified  프로필 방송국 썸네일을 최신 ready VOD 기준으로 맞추기 위해 vodAssets thumbnail_url 포함
  */
 
 import { Prisma } from "@/generated/prisma/client";
@@ -30,9 +31,10 @@ export const BROADCAST_SUMMARY_SELECT = {
   },
   category: { select: { id: true, kor_name: true, icon: true } },
   tags: { select: { name: true } },
+  // 프로필 방송국도 다시보기 목록과 같은 대표 썸네일을 쓰도록 최신 ready VOD 1개만 함께 조회
   vodAssets: {
     where: { ready_at: { not: null } },
-    select: { id: true },
+    select: { id: true, thumbnail_url: true },
     orderBy: { id: "desc" },
     take: 1,
   },

--- a/features/stream/service/list.ts
+++ b/features/stream/service/list.ts
@@ -18,6 +18,7 @@
  * 2026.03.25  임도헌   Modified  메인 스트리밍 리스트에서 실제 팔로우 상태를 함께 조회해 FOLLOWERS 잠금 플래그를 정확히 계산
  * 2026.03.29  임도헌   Modified  메인 다시보기 목록에 최신/인기 정렬과 팔로잉만 보조 필터를 분리 적용
  * 2026.04.02  임도헌   Modified  방송 요약 Prisma select import를 selects.ts 기준으로 정리
+ * 2026.04.24  임도헌   Modified  프로필 방송국의 종료 방송 썸네일도 최신 ready VOD thumbnail_url을 우선 사용하도록 보정
  */
 
 import "server-only";
@@ -383,8 +384,11 @@ export async function getRecentBroadcasts(
     select: BROADCAST_SUMMARY_SELECT,
   });
 
-  return broadcasts.map((b) => ({
-    ...serializeStream(
+  return broadcasts.map((b) => {
+    // getRecentBroadcasts는 Broadcast 중심 DTO지만, 종료 방송 카드는 최신 ready VOD로 이동
+    // 따라서 대표 이미지도 Broadcast 업로드 썸네일보다 VOD 처리 완료 썸네일 우선
+    const latestVod = b.vodAssets[0] ?? null;
+    const stream = serializeStream(
       {
         ...b,
         stream_id: b.liveInput.provider_uid,
@@ -393,9 +397,17 @@ export async function getRecentBroadcasts(
         tags: b.tags,
       },
       { isFollowing: false, isMine: includePrivate }
-    ),
-    latestVodId: b.vodAssets[0]?.id ?? null,
-  }));
+    );
+
+    return {
+      ...stream,
+      thumbnail: latestVod?.thumbnail_url ?? stream.thumbnail,
+      thumbnailAnimated: latestVod?.thumbnail_url
+        ? false
+        : stream.thumbnailAnimated,
+      latestVodId: latestVod?.id ?? null,
+    };
+  });
 }
 
 /* -------------------------------------------------------------------------- */

--- a/features/user/components/profile/UserProfile.tsx
+++ b/features/user/components/profile/UserProfile.tsx
@@ -46,6 +46,7 @@
  * 2026.04.08  임도헌   Modified   방송국 rail 좌우 정렬선을 다른 프로필 섹션과 같은 시작선으로 맞춤
  * 2026.04.17  임도헌   Modified   방송국 링크/후기·뱃지/판매 목록 섹션 주석을 현재 구조 기준으로 최신화
  * 2026.04.19  임도헌   Modified   타인 프로필 판매 목록 탭 active 톤을 판매내역과 같은 기준으로 정리
+ * 2026.04.24  임도헌   Modified   타인 프로필 제품 카드에 현재 프로필 returnTo를 전달해 상세 복귀 문맥 유지
  */
 
 "use client";
@@ -421,6 +422,7 @@ export default function UserProfile({
                   type={activeTab}
                   userId={user.id}
                   viewMode={viewMode}
+                  returnTo={next}
                 />
               </Suspense>
             </div>
@@ -455,10 +457,12 @@ function SalesTabContent({
   type,
   userId,
   viewMode,
+  returnTo,
 }: {
   type: ProductStatus;
   userId: number;
   viewMode: ViewMode;
+  returnTo: string;
 }) {
   const triggerRef = useRef<HTMLDivElement>(null);
   const isVisible = usePageVisibility();
@@ -505,6 +509,7 @@ function SalesTabContent({
             product={product}
             viewMode={viewMode}
             isPriority={i < 4}
+            returnTo={returnTo}
           />
         ))}
       </div>

--- a/lib/navigationRefreshFlag.ts
+++ b/lib/navigationRefreshFlag.ts
@@ -7,17 +7,34 @@
  * Date        Author   Status    Description
  * 2026.03.14  임도헌   Created   router.back() 복귀 직후 1회 refresh가 필요한 상세 화면에 공통으로 사용할 세션 플래그 유틸 추가
  * 2026.03.14  임도헌   Modified  URL 파라미터 오염 없이 back UX를 유지하기 위해 세션 기반 단발성 refresh 신호 규칙과 TTL 설명 보강
+ * 2026.04.24  임도헌   Modified  sessionStorage 기반 같은 탭 전용 신호와 router.refresh 트리거 역할이 드러나도록 주석 정리
+ * 2026.04.24  임도헌   Modified  navigation refresh scope 상수와 mark/consume 편의 함수를 추가해 도메인별 중복 제거
  */
 
 const NAVIGATION_REFRESH_TTL_MS = 10_000;
 
+export const NAVIGATION_REFRESH_ROOT_ID = "root";
+
+export const NAVIGATION_REFRESH_SCOPES = {
+  POST_DETAIL: "post-detail-refresh",
+  POSTS_LIST: "posts-list-refresh",
+  PRODUCT_DETAIL: "product-detail-refresh",
+  PRODUCT_MODAL: "product-modal-refresh",
+  PRODUCTS_LIST: "products-list-refresh",
+  MY_SALES: "my-sales-refresh",
+  RECORDING_LIST: "recording-list-refresh",
+} as const;
+
+export type NavigationRefreshScope =
+  (typeof NAVIGATION_REFRESH_SCOPES)[keyof typeof NAVIGATION_REFRESH_SCOPES];
+
 /**
- * 세션 기반 1회 refresh 신호 키 생성
+ * 세션 기반 1회 `router.refresh()` 신호 키 생성
  *
  * [구성 이유]
  * - 상세 -> 수정 -> 저장 후 `router.back()`으로 복귀하면 이전 상세 화면이 App Router 캐시에서 복원될 수 있음
  * - 이때 URL에 `refreshed=1` 같은 파라미터를 붙이면 히스토리가 늘어나고 주소도 지저분해짐
- * - 그래서 현재 브라우저 세션 안에서만 살아있는 단발성 신호를 `sessionStorage`에 기록해 사용
+ * - 그래서 같은 탭의 현재 브라우저 세션 안에서만 살아있는 단발성 신호를 `sessionStorage`에 기록해 사용
  *
  * @param {string} scope - 화면 유형 구분값 (예: post-detail-refresh)
  * @param {number | string} id - 대상 리소스 식별자
@@ -30,11 +47,21 @@ export function createNavigationRefreshFlagKey(
 }
 
 /**
- * 1회 refresh 신호 기록
+ * 브라우저 히스토리 back을 실제로 호출할 수 있는 환경인지 확인
+ *
+ * 단순 분기 중복을 줄이기 위한 low-level helper
+ * “어떤 경로가 안전한 back 대상인지”는 각 도메인에서 별도 판단
+ */
+export function canUseBrowserBack() {
+  return typeof window !== "undefined" && window.history.length > 1;
+}
+
+/**
+ * 1회 `router.refresh()` 신호 기록
  *
  * [동작 방식]
  * - boolean 대신 타임스탬프를 저장해 오래 남은 플래그를 무시할 수 있게 함
- * - 동일 세션에서만 소비되는 임시 신호이므로 새 탭이나 외부 진입에는 영향을 주지 않음
+ * - 같은 탭의 동일 세션에서만 소비되는 임시 신호이므로 새 탭이나 외부 진입에는 영향을 주지 않음
  *
  * @param {string} key - `createNavigationRefreshFlagKey`로 생성한 키
  */
@@ -43,8 +70,16 @@ export function setNavigationRefreshFlag(key: string) {
   sessionStorage.setItem(key, Date.now().toString());
 }
 
+/** scope/id 조합으로 1회 refresh 신호를 기록 */
+export function markNavigationRefresh(
+  scope: NavigationRefreshScope,
+  id: number | string
+) {
+  setNavigationRefreshFlag(createNavigationRefreshFlagKey(scope, id));
+}
+
 /**
- * 유효한 1회 refresh 신호 소비
+ * 유효한 1회 `router.refresh()` 신호 소비
  *
  * [소비 규칙]
  * - TTL 안에 생성된 플래그만 유효한 신호로 판단
@@ -53,7 +88,7 @@ export function setNavigationRefreshFlag(key: string) {
  *
  * @param {string} key - `createNavigationRefreshFlagKey`로 생성한 키
  * @param {number} ttlMs - 유효 시간(ms), 기본 10초
- * @returns {boolean} 즉시 1회 refresh가 필요한지 여부
+ * @returns {boolean} 즉시 `router.refresh()`가 필요한지 여부
  */
 export function consumeNavigationRefreshFlag(
   key: string,
@@ -70,4 +105,16 @@ export function consumeNavigationRefreshFlag(
   if (!Number.isFinite(createdAt)) return false;
 
   return Date.now() - createdAt <= ttlMs;
+}
+
+/** scope/id 조합으로 1회 refresh 신호를 소비 */
+export function consumeNavigationRefresh(
+  scope: NavigationRefreshScope,
+  id: number | string,
+  ttlMs: number = NAVIGATION_REFRESH_TTL_MS
+) {
+  return consumeNavigationRefreshFlag(
+    createNavigationRefreshFlagKey(scope, id),
+    ttlMs
+  );
 }


### PR DESCRIPTION
[↩️ Return Flow]
- 제품, 게시글, 녹화 상세의 삭제 후 복귀 흐름 정리
- 제품 상세 수정 저장/취소 및 게시글 상세 수정 저장의 back 복귀 조건 통일
- returnTo 기반 내부 복귀 문맥 유지
- 타인 프로필과 찜 목록 제품 카드의 상세 복귀 위치 누락 보완
- 삭제된 상세 forward 재진입은 서버 notFound 방어 기준 유지

[🧭 Refresh Relay]
- /products 및 /profile/my-sales 복귀 시 상세 화면 잔상 예외 처리
- ProductListRefreshRelay, MySalesRefreshRelay, ProductModalReopenRelay 책임 분리
- navigationRefreshFlag 공통 helper와 scope 상수 추가
