### PR TITLE
🤝 Merge : CSP Report-Only 허용 출처 2차 정제

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -61,6 +61,7 @@ const imageOrigins = unique([
   "https://imagedelivery.net",
   "https://w7.pngwing.com",
   "https://i.ytimg.com",
+  "https://mts.daumcdn.net",
   "https://customer-fllme7un34f7981k.cloudflarestream.com",
   "https://videodelivery.net",
   cloudflareStreamOrigin,
@@ -71,6 +72,10 @@ const connectOrigins = unique([
   supabaseOrigin,
   supabaseWsOrigin,
   kakaoMapsOrigin,
+  "https://imagedelivery.net",
+  "https://upload.imagedelivery.net",
+  "https://upload.cloudflarestream.com",
+  "https://i.ytimg.com",
 ]);
 const frameOrigins = unique([
   "https://www.youtube-nocookie.com",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 import withPWA from "next-pwa";
 
-const isProduction = process.env.NODE_ENV === "production";
-
+// 환경변수 URL에서 CSP에 넣을 origin만 안전하게 추출한다.
 function normalizeOrigin(value) {
   if (!value) return null;
 
@@ -12,6 +11,7 @@ function normalizeOrigin(value) {
   }
 }
 
+// Supabase HTTPS origin을 Realtime WebSocket origin으로 변환한다.
 function toWebSocketOrigin(origin) {
   if (!origin) return null;
 
@@ -30,15 +30,16 @@ function toWebSocketOrigin(origin) {
   }
 }
 
+// falsey 값과 중복 출처를 제거해 CSP source list를 안정화한다.
 function unique(values) {
   return [...new Set(values.filter(Boolean))];
 }
 
+// directive 이름과 source 목록을 CSP 문자열 조각으로 만든다.
 function buildDirective(name, sources) {
   return `${name} ${sources.join(" ")}`;
 }
 
-const appOrigin = normalizeOrigin(process.env.NEXT_PUBLIC_APP_URL);
 const supabaseOrigin = normalizeOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
 const supabaseWsOrigin = toWebSocketOrigin(supabaseOrigin);
 const cloudflareStreamOrigin = normalizeOrigin(
@@ -46,32 +47,24 @@ const cloudflareStreamOrigin = normalizeOrigin(
 );
 const kakaoMapsOrigin = "https://dapi.kakao.com";
 
-const isSecureAppOrigin = (() => {
-  if (!appOrigin) return false;
-
-  try {
-    return new URL(appOrigin).protocol === "https:";
-  } catch {
-    return false;
-  }
-})();
-
 const imageOrigins = unique([
   "https://avatars.githubusercontent.com",
   "https://imagedelivery.net",
   "https://w7.pngwing.com",
   "https://i.ytimg.com",
   "https://mts.daumcdn.net",
+  "https://t1.daumcdn.net",
   "https://customer-fllme7un34f7981k.cloudflarestream.com",
   "https://videodelivery.net",
   cloudflareStreamOrigin,
 ]);
 
-const scriptOrigins = unique([kakaoMapsOrigin]);
+const scriptOrigins = unique([kakaoMapsOrigin, "https://t1.daumcdn.net"]);
 const connectOrigins = unique([
   supabaseOrigin,
   supabaseWsOrigin,
   kakaoMapsOrigin,
+  "https://t1.daumcdn.net",
   "https://imagedelivery.net",
   "https://upload.imagedelivery.net",
   "https://upload.cloudflarestream.com",
@@ -130,12 +123,8 @@ const securityHeaders = [
   },
 ];
 
-if (isProduction && isSecureAppOrigin) {
-  securityHeaders.push({
-    key: "Strict-Transport-Security",
-    value: "max-age=86400",
-  });
-}
+// Vercel custom domain은 기본으로 Strict-Transport-Security: max-age=63072000을 내려준다.
+// 운영 HSTS는 앱 헤더가 아니라 플랫폼 계층에서 관리한다.
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
## 작업 요약

Lighthouse Trust & Safety 기반 보안 헤더 2차 작업으로, 기존 `Content-Security-Policy-Report-Only` 정책의 허용 출처를 운영 QA 결과에 맞춰 정제했습니다.

이번 작업은 enforced CSP 전환이 아니라 Report-Only 정책 정제이며, 앱 필수 기능에 필요한 출처만 최소 범위로 추가했습니다.

## 변경 사항

### CSP Report-Only 출처 보정

- Cloudflare Images public asset 및 direct upload 경로를 위해 `connect-src`에 아래 출처 추가
  - `https://imagedelivery.net`
  - `https://upload.imagedelivery.net`
- Cloudflare Stream direct upload 경로를 위해 `connect-src`에 아래 출처 추가
  - `https://upload.cloudflarestream.com`
- Workbox 경유 YouTube 썸네일 요청을 위해 `connect-src`에 아래 출처 추가
  - `https://i.ytimg.com`
- Kakao Maps 지도 타일 및 SDK 하위 리소스를 위해 아래 출처 추가
  - `img-src https://mts.daumcdn.net`
  - `script-src https://t1.daumcdn.net`
  - `connect-src https://t1.daumcdn.net`
  - `img-src https://t1.daumcdn.net`

### HSTS 정리

- Vercel custom domain에서 기본 `Strict-Transport-Security: max-age=63072000`이 내려오는 것을 확인했습니다.
- 이에 따라 앱 레벨의 수동 HSTS 설정은 제거하고, 운영 HSTS는 Vercel 플랫폼 계층에서 관리하도록 정리했습니다.

### 보안 범위 유지

아래 항목은 이번 2차 범위에서 계속 보류했습니다.

- enforced `Content-Security-Policy` 전환
- nonce 기반 strict CSP
- `script-src 'unsafe-eval'`
- Trusted Types
- COEP/CORP
- `vercel.live` whitelist 추가
- YouTube player 통계/추적 요청 출처 추가
- 불필요한 wildcard 출처 추가

## QA 결과

Preview/custom domain 환경에서 주요 기능을 확인했습니다.

- 응답 헤더
  - `Content-Security-Policy-Report-Only` 존재 확인
  - enforced `Content-Security-Policy` 없음 확인
  - `script-src 'unsafe-eval'` 미허용 확인
  - `vercel.live` 미허용 확인
  - Vercel custom domain HSTS `max-age=63072000` 확인
- Kakao 지도
  - 지도 표시 및 위치 선택 정상
  - `t1.daumcdn.net`, `mts.daumcdn.net` 관련 앱 필수 CSP 로그 해소 확인
  - Kakao `unsafe-eval`은 의도된 관찰 대상으로 유지
- 이미지 업로드
  - 게시글 이미지, 상품 이미지, 프로필 아바타 업로드/표시 정상
  - Cloudflare Images 관련 `connect-src` 로그 재관찰 없음
- 영상 업로드
  - Cloudflare Stream direct upload 정상
  - `upload.cloudflarestream.com` 관련 `connect-src` 로그 재관찰 없음
- YouTube embed
  - 썸네일 표시 및 iframe 재생 정상
  - `i.ytimg.com` 관련 `connect-src` 로그 재관찰 없음
  - YouTube 통계/추적 요청은 whitelist 제외 유지
- Cloudflare Stream
  - 방송 상세 iframe, 녹화 상세 iframe, 라이브 카드 미니 프리뷰 정상
  - Vercel Live/Tracking Prevention/Player 내부 로그는 CSP 회귀가 아닌 제외 대상으로 분류

## 후속 작업

- 방송 시작 후 새로고침 전까지 방송 상세 iframe이 렌더링되지 않는 상태 동기화 버그는 별도 Fix 브랜치에서 처리 예정
- Kakao Maps `unsafe-eval`은 enforced CSP 전환 전 별도 preview 환경에서 검증 필요
- Vercel 외 환경으로 배포할 경우 HSTS 정책 별도 검토 필요