### PR TITLE
🤝 Merge : Lighthouse 3차 QA 후속 접근성·UX 정리

### DIFF
--- a/components/global/BottomSheet.tsx
+++ b/components/global/BottomSheet.tsx
@@ -8,6 +8,7 @@
  * 2026.03.06  임도헌   Created   모바일 액션 메뉴 및 필터용 공용 바텀시트 추가
  * 2026.03.12  임도헌   Modified  공용 bodyScrollLock 유틸 적용으로 검색 모달 등과 중첩되어도 스크롤 잠금/복구 안정화
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.04.26  임도헌   Modified  드래그 닫기를 pointer 이벤트로 통합해 PC 좁은 viewport의 마우스 드래그도 지원
  */
 
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
@@ -52,6 +53,7 @@ export default function BottomSheet({
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const dragStartYRef = useRef(0);
+  const dragCurrentYRef = useRef(0);
   const titleId = useId();
   const fallbackDescriptionId = useId();
   const descriptionId = description ? fallbackDescriptionId : undefined;
@@ -73,6 +75,8 @@ export default function BottomSheet({
       previousFocusRef.current?.focus?.();
       setTranslateY(0);
       setIsDragging(false);
+      dragStartYRef.current = 0;
+      dragCurrentYRef.current = 0;
     };
   }, [open]);
 
@@ -113,26 +117,34 @@ export default function BottomSheet({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [open, onClose]);
 
-  const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
-    dragStartYRef.current = event.touches[0]?.clientY ?? 0;
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+
+    dragStartYRef.current = event.clientY;
+    dragCurrentYRef.current = 0;
     setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
   };
 
-  const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     if (!isDragging) return;
-    const currentY = event.touches[0]?.clientY ?? dragStartYRef.current;
-    const deltaY = Math.max(0, currentY - dragStartYRef.current);
+    const deltaY = Math.max(0, event.clientY - dragStartYRef.current);
+    dragCurrentYRef.current = deltaY;
     setTranslateY(deltaY);
   };
 
-  const handleTouchEnd = () => {
+  const handlePointerEnd = (event: React.PointerEvent<HTMLDivElement>) => {
     setIsDragging(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
 
-    if (translateY > 96) {
+    if (dragCurrentYRef.current > 96) {
       onClose();
       return;
     }
 
+    dragCurrentYRef.current = 0;
     setTranslateY(0);
   };
 
@@ -160,10 +172,11 @@ export default function BottomSheet({
         style={{ transform: `translateY(${translateY}px)` }}
       >
         <div
-          className="flex cursor-grab flex-col items-center px-4 pt-3 active:cursor-grabbing"
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
+          className="flex touch-none select-none cursor-grab flex-col items-center px-4 pt-3 active:cursor-grabbing"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerEnd}
+          onPointerCancel={handlePointerEnd}
         >
           <div
             className="mb-3 h-1.5 w-12 rounded-full bg-border"

--- a/features/chat/components/ScheduleModal.tsx
+++ b/features/chat/components/ScheduleModal.tsx
@@ -10,9 +10,11 @@
  * 2026.03.06  임도헌   Modified  닫기 버튼 터치 타겟과 버튼 hover 대비를 표준 규칙에 맞게 조정
  * 2026.03.22  임도헌   Modified  최근 모달 톤 기준으로 외곽선과 헤더/푸터 보더 강도 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.04.26  임도헌   Modified  약속 설정 모달에 dialog 의미와 날짜/시간 입력 라벨 연결, ESC 닫기 흐름을 보강
+ * 2026.04.26  임도헌   Modified  약속 입력 오류 문구를 사용자가 수정할 항목 기준으로 구체화
  */
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import {
   MapPinIcon,
@@ -46,18 +48,34 @@ export default function ScheduleModal({
   const [location, setLocation] = useState<LocationData | null>(null);
   const [showMap, setShowMap] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen || showMap) return;
+
+    const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isPending) onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, isPending, onClose, showMap]);
 
   if (!isOpen) return null;
 
   const handleSubmit = () => {
     if (!dateStr || !timeStr || !location) {
-      toast.error("날짜, 시간, 장소를 모두 입력해주세요.");
+      toast.error("약속 날짜, 시간, 장소를 모두 입력해주세요.");
       return;
     }
 
     const dateTime = new Date(`${dateStr}T${timeStr}`);
     if (isNaN(dateTime.getTime()) || dateTime < new Date()) {
-      toast.error("올바른 미래 시간을 선택해주세요.");
+      toast.error("현재보다 이후 시간을 선택해주세요.");
       return;
     }
 
@@ -69,10 +87,20 @@ export default function ScheduleModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
-      <div className="w-full max-w-sm bg-surface rounded-2xl shadow-2xl overflow-hidden border border-border-subtle">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="schedule-modal-title"
+        tabIndex={-1}
+        className="w-full max-w-sm bg-surface rounded-2xl shadow-2xl overflow-hidden border border-border-subtle"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border-subtle bg-surface">
-          <h3 className="font-bold text-primary text-lg flex items-center gap-2">
+          <h3
+            id="schedule-modal-title"
+            className="font-bold text-primary text-lg flex items-center gap-2"
+          >
             <CalendarIcon className="size-5 text-brand dark:text-brand-light" />
             약속 잡기
           </h3>
@@ -90,8 +118,14 @@ export default function ScheduleModal({
           {/* 날짜/시간 선택 */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <label className="text-xs font-bold text-muted">날짜</label>
+              <label
+                htmlFor="schedule-date"
+                className="text-xs font-bold text-muted"
+              >
+                날짜
+              </label>
               <input
+                id="schedule-date"
                 type="date"
                 value={dateStr}
                 onChange={(e) => setDateStr(e.target.value)}
@@ -99,8 +133,14 @@ export default function ScheduleModal({
               />
             </div>
             <div className="space-y-1.5">
-              <label className="text-xs font-bold text-muted">시간</label>
+              <label
+                htmlFor="schedule-time"
+                className="text-xs font-bold text-muted"
+              >
+                시간
+              </label>
               <input
+                id="schedule-time"
                 type="time"
                 value={timeStr}
                 onChange={(e) => setTimeStr(e.target.value)}
@@ -111,7 +151,7 @@ export default function ScheduleModal({
 
           {/* 장소 선택 */}
           <div className="space-y-2">
-            <label className="text-xs font-bold text-muted">만날 장소</label>
+            <span className="text-xs font-bold text-muted">만날 장소</span>
             {location ? (
               <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-brand/30 dark:border-brand-light/30 shadow-sm group">
                 <div className="flex items-center gap-3 min-w-0">

--- a/features/notification/components/KeywordAlertManager.tsx
+++ b/features/notification/components/KeywordAlertManager.tsx
@@ -15,6 +15,7 @@
  * 2026.03.19  임도헌   Modified  모바일에서 Select/입력 폼 줄바꿈을 허용해 좁은 폭 모달의 정보 밀도를 완화
  * 2026.03.22  임도헌   Modified  지역 범위 Select 고정 폭을 제거해 좁은 폭 설정 화면 밀도 완화
  * 2026.04.18  임도헌   Modified  모바일 키워드 입력 바가 한 줄 안에서 안정적으로 보이도록 입력/추가 버튼 배치를 재정리
+ * 2026.04.26  임도헌   Modified  키워드 알림 등록 성공 문구를 관리 목록의 삭제 문구와 같은 문법으로 정리
  */
 
 "use client";
@@ -110,7 +111,7 @@ export default function KeywordAlertManager({
       const res = await addKeywordAction(val, selectedRange);
       if (res.success) {
         // 등록 성공 뒤 입력 초기화와 목록 재동기화
-        toast.success(`'${val}' 알림이 등록되었습니다.`);
+        toast.success(`'${val}' 키워드 알림을 등록했어요.`);
         setKeyword("");
         router.refresh();
       } else {

--- a/features/notification/components/KeywordManagementList.tsx
+++ b/features/notification/components/KeywordManagementList.tsx
@@ -9,6 +9,7 @@
  * 2026.02.21  임도헌   Modified  regionRange 뱃지 노출 추가
  * 2026.02.26  임도헌   Modified  다크모드 가시성 개선
  * 2026.04.10  임도헌   Modified  notification 타이포 정책에 맞춰 지역 범위 칩 weight를 500 기준으로 정리
+ * 2026.04.26  임도헌   Modified  키워드 알림 삭제/빈 상태 문구와 아이콘 버튼 라벨을 구체화
  */
 "use client";
 
@@ -46,7 +47,7 @@ export default function KeywordManagementList({ items }: Props) {
     setDeletingId(id);
     startTransition(async () => {
       const res = await removeKeywordAction(id);
-      if (res.success) toast.success(`'${word}' 알림 해제`);
+      if (res.success) toast.success(`'${word}' 키워드 알림을 삭제했어요.`);
       setDeletingId(null);
     });
   };
@@ -54,7 +55,7 @@ export default function KeywordManagementList({ items }: Props) {
   if (items.length === 0) {
     return (
       <div className="py-6 text-center">
-        <p className="text-sm text-muted">등록된 키워드가 없습니다.</p>
+        <p className="text-sm text-muted">등록한 키워드 알림이 없어요.</p>
       </div>
     );
   }
@@ -78,7 +79,7 @@ export default function KeywordManagementList({ items }: Props) {
             onClick={() => handleDelete(item.id, item.keyword)}
             disabled={isPending}
             className="focus-ring-soft rounded-full p-0.5 text-muted transition-colors hover:bg-danger/10 hover:text-danger"
-            aria-label="삭제"
+            aria-label={`${item.keyword} 키워드 알림 삭제`}
           >
             <XMarkIcon className="size-3.5" />
           </button>

--- a/features/notification/components/NotificationListContainer.tsx
+++ b/features/notification/components/NotificationListContainer.tsx
@@ -27,6 +27,9 @@
  * 2026.04.02  임도헌   Modified  알림 필터 라벨과 타입을 notification constants/types 공용 정의로 분리
  * 2026.04.10  임도헌   Modified  notification 타이포 정책에 맞춰 상단 액션/필터/보조 CTA의 weight와 text-xs 스케일을 정리
  * 2026.04.18  임도헌   Modified  설정 링크 prefetch를 끄고 키워드 모달/읽은 알림 대비를 정리해 알림 목록 초기 렌더 부담을 완화
+ * 2026.04.26  임도헌   Modified  좁은 화면에서도 링크형 알림의 보기 버튼이 제목 행 오른쪽에 유지되도록 2열 배치로 정리
+ * 2026.04.26  임도헌   Modified  개별 읽음 처리를 "읽음으로 표시" 보조 버튼으로 정리해 보기 액션과 구분
+ * 2026.04.26  임도헌   Modified  읽음 액션 토스트 문구를 화면 버튼 라벨과 같은 표현으로 통일
  */
 "use client";
 
@@ -56,7 +59,6 @@ import {
   ChatBubbleLeftEllipsisIcon,
   CheckBadgeIcon,
   Cog6ToothIcon,
-  EnvelopeOpenIcon,
   ArrowUpRightIcon,
   MagnifyingGlassIcon,
   PlayCircleIcon,
@@ -135,7 +137,7 @@ export default function NotificationListContainer({
       // 알림 읽음 처리 완료 시 전역 뱃지 카운트 1 차감
       decrement(1);
     } else {
-      toast.error(res.error ?? "읽음 처리 실패");
+      toast.error(res.error ?? "알림을 읽음으로 표시하지 못했어요.");
     }
   };
 
@@ -149,11 +151,11 @@ export default function NotificationListContainer({
         setNotifications((prev) =>
           prev.map((noti) => ({ ...noti, isRead: true }))
         );
-        toast.success("모든 알림을 읽음 처리했습니다.");
-        // 모두 읽음 처리 완료 시 전역 뱃지 카운트 초기화
+        toast.success("모든 알림을 읽음으로 표시했어요.");
+        // 모든 알림을 읽음으로 표시하면 전역 뱃지 카운트를 초기화
         clear();
       } else {
-        toast.error(res.error ?? "모든 알림 읽음 처리 실패");
+        toast.error(res.error ?? "모든 알림을 읽음으로 표시하지 못했어요.");
       }
     });
   };
@@ -173,7 +175,7 @@ export default function NotificationListContainer({
         );
         decrement(1);
       } else {
-        toast.error(res.error ?? "읽음 처리 실패");
+        toast.error(res.error ?? "알림을 읽음으로 표시하지 못했어요.");
       }
     }
     router.push(href);
@@ -261,7 +263,9 @@ export default function NotificationListContainer({
             <button
               onClick={handleMarkAllAsRead}
               disabled={isMarkingAll}
-              className="focus-ring-soft flex min-h-[36px] items-center gap-1.5 rounded-lg bg-brand/10 px-2.5 py-1.5 text-xs font-medium text-brand transition-colors hover:bg-brand/20 dark:bg-brand-light/10 dark:text-brand-light sm:min-h-0 sm:gap-2 sm:px-3"
+              aria-label={`모든 알림 ${unreadCount}개를 읽음으로 표시`}
+              title="모든 알림을 읽음으로 표시"
+              className="focus-ring-soft inline-flex min-h-[36px] items-center gap-1.5 rounded-full border border-brand/30 bg-brand/10 px-3 py-1.5 text-xs font-semibold text-brand transition-colors hover:border-brand/45 hover:bg-brand/15 disabled:opacity-60 dark:border-brand-light/30 dark:bg-brand-light/10 dark:text-brand-light dark:hover:bg-brand-light/15 sm:min-h-0 sm:gap-2"
             >
               {isMarkingAll && (
                 <span className="size-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
@@ -343,7 +347,7 @@ export default function NotificationListContainer({
 
                 <div className="flex-1 min-w-0">
                   {notification.link ? (
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+                    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 sm:gap-3">
                       <button
                         type="button"
                         onClick={() => handleOpenNotification(notification)}
@@ -357,7 +361,7 @@ export default function NotificationListContainer({
                         {notification.title}
                       </button>
                       {/* 링크형 알림은 별도 CTA를 노출해 이동 동작 인지성 보강 */}
-                      <div className="flex justify-start sm:justify-end">
+                      <div className="flex justify-end">
                         <button
                           type="button"
                           onClick={() => handleOpenNotification(notification)}
@@ -385,28 +389,24 @@ export default function NotificationListContainer({
                   <p className="mt-0.5 line-clamp-2 text-sm leading-snug text-slate-600 dark:text-slate-300">
                     {notification.body}
                   </p>
-                  <div className="flex items-center gap-2 mt-2">
+                  <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
                     <TimeAgo
                       date={notification.created_at}
                       className="text-xs text-slate-500 dark:text-slate-300"
                     />
-                    {!notification.link && (
-                      <span className="text-xs text-slate-500 dark:text-slate-300">
-                        이동 없이 읽음 처리
-                      </span>
+                    {!notification.isRead && (
+                      <button
+                        type="button"
+                        onClick={() => handleMarkAsRead(notification.id)}
+                        aria-label={`${notification.title} 알림을 읽음으로 표시`}
+                        title="읽음으로 표시"
+                        className="focus-ring-soft inline-flex min-h-[24px] items-center rounded-full border border-brand/35 bg-brand/12 px-2.5 py-0.5 text-xs font-semibold text-brand shadow-[0_0_0_1px_rgba(59,130,246,0.04)] transition-colors hover:border-brand/50 hover:bg-brand/18 dark:border-brand-light/35 dark:bg-brand-light/12 dark:text-brand-light dark:hover:bg-brand-light/18"
+                      >
+                        읽음으로 표시
+                      </button>
                     )}
                   </div>
                 </div>
-
-                {!notification.isRead && (
-                  <button
-                    onClick={() => handleMarkAsRead(notification.id)}
-                    className="focus-ring-soft mt-0.5 rounded-lg p-2 text-slate-500 transition-colors hover:text-brand dark:text-slate-300 dark:hover:text-brand-light sm:mt-0"
-                    title="읽음 처리"
-                  >
-                    <EnvelopeOpenIcon className="size-5" />
-                  </button>
-                )}
               </li>
             ))}
           </ul>

--- a/features/notification/hooks/usePushNotification.ts
+++ b/features/notification/hooks/usePushNotification.ts
@@ -21,6 +21,7 @@
  * 2026.03.27  임도헌   Modified  iOS 설치 필요 상태를 포함할 수 있도록 푸시 상태 타입 확장
  * 2026.04.02  임도헌   Modified  푸시 상태 타입을 notification/types 공용 정의로 분리
  * 2026.04.17  임도헌   Modified  푸시 구독 훅의 초기 점검/재연결/해제 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.04.26  임도헌   Modified  초기 자동 점검의 Service Worker ready 타임아웃을 콘솔 오류/토스트로 노출하지 않도록 완화
  */
 
 "use client";
@@ -75,11 +76,15 @@ function checkSupport() {
  *
  * @param label - 로깅용 라벨 (check, subscribe 등)
  * @param timeoutMs - 대기 시간 (기본 10초)
+ * @param options.logError - 사용자 액션이 아닌 초기 점검에서는 콘솔 에러를 남기지 않도록 제어
  */
 async function waitForServiceWorkerReady(
   label: string,
-  timeoutMs = 10000
+  timeoutMs = 10000,
+  options: { logError?: boolean } = {}
 ): Promise<ServiceWorkerRegistration> {
+  const { logError = true } = options;
+
   if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
     throw new Error("SERVICE_WORKER_NOT_SUPPORTED");
   }
@@ -88,15 +93,21 @@ async function waitForServiceWorkerReady(
     // 1. 현재 등록된 SW 확인
     const existing = await navigator.serviceWorker.getRegistration();
     if (!existing) {
-      console.warn(
-        `[push] no existing ServiceWorker registration detected. (${label})`
-      );
+      if (logError) {
+        console.warn(
+          `[push] no existing ServiceWorker registration detected. (${label})`
+        );
+      }
       // 2. 수동 등록 시도 (Idempotent)
       try {
         await navigator.serviceWorker.register("/sw.js");
-        console.info("[push] tried manual ServiceWorker.register('/sw.js').");
+        if (logError) {
+          console.info("[push] tried manual ServiceWorker.register('/sw.js').");
+        }
       } catch (e) {
-        console.error("[push] manual ServiceWorker register failed:", e);
+        if (logError) {
+          console.error("[push] manual ServiceWorker register failed:", e);
+        }
       }
     }
 
@@ -116,9 +127,17 @@ async function waitForServiceWorkerReady(
 
     return registration;
   } catch (e: any) {
-    console.error(`[push] service worker not ready (${label}):`, e);
+    if (logError) {
+      console.error(`[push] service worker not ready (${label}):`, e);
+    }
     throw e;
   }
+}
+
+function isServiceWorkerReadyTimeout(error: unknown) {
+  return (
+    error instanceof Error && error.message === "SERVICE_WORKER_READY_TIMEOUT"
+  );
 }
 
 // -----------------------------------------------------------------------------
@@ -191,7 +210,9 @@ export function usePushNotification() {
         }
 
         // 2-2. Service Worker 준비
-        const registration = await waitForServiceWorkerReady("check");
+        const registration = await waitForServiceWorkerReady("check", 10000, {
+          logError: false,
+        });
         if (!mounted) return;
 
         // 2-3. 브라우저의 현재 Push 구독 정보 가져오기
@@ -268,17 +289,16 @@ export function usePushNotification() {
         }
       } catch (e: any) {
         if (!mounted) return;
-        console.error("[push] check failed:", e);
+        const readyTimeout = isServiceWorkerReadyTimeout(e);
+        if (!readyTimeout) {
+          console.error("[push] check failed:", e);
+        }
         clearLocalState();
         setStatus(
           Notification.permission === "denied"
             ? "permission_denied"
             : "disabled"
         );
-
-        if (e?.message === "SERVICE_WORKER_READY_TIMEOUT") {
-          toast.error("푸시 알림 초기화 지연. 새로고침 후 다시 시도해주세요.");
-        }
       }
     };
 
@@ -402,7 +422,7 @@ export function usePushNotification() {
       );
     } catch (e: any) {
       console.error("[push] subscribe failed:", e);
-      if (e?.message === "SERVICE_WORKER_READY_TIMEOUT") {
+      if (isServiceWorkerReadyTimeout(e)) {
         toast.error("초기화 실패. 새로고침 후 다시 시도해주세요.");
       } else {
         toast.error(`푸시 알림 설정 실패: ${e?.message ?? "오류 발생"}`);

--- a/features/notification/service/notification.ts
+++ b/features/notification/service/notification.ts
@@ -12,6 +12,7 @@
  * 2026.03.12  임도헌   Modified  페이지당 10개 기준과 currentPage 보정 로직 추가
  * 2026.03.16  임도헌   Modified  알림 센터 서버 필터와 전체 필터 개수 집계 응답 추가
  * 2026.04.02  임도헌   Modified  공용 알림 타입과 필터 상수를 types/constants 파일로 분리
+ * 2026.04.26  임도헌   Modified  읽음 처리 실패 문구를 알림 센터 UI 액션 라벨과 같은 표현으로 정리
  */
 
 import "server-only";
@@ -324,7 +325,7 @@ export async function markNotificationAsRead(
     return { success: true };
   } catch (error) {
     console.error("[markNotificationAsRead] Error:", error);
-    return { success: false, error: "알림 읽음 처리 실패" };
+    return { success: false, error: "알림을 읽음으로 표시하지 못했어요." };
   }
 }
 
@@ -343,6 +344,9 @@ export async function markAllNotificationsAsRead(
     return { success: true };
   } catch (error) {
     console.error("[markAllNotificationsAsRead] Error:", error);
-    return { success: false, error: "모든 알림 읽음 처리 실패" };
+    return {
+      success: false,
+      error: "모든 알림을 읽음으로 표시하지 못했어요.",
+    };
   }
 }

--- a/features/post/components/AddPostButton.tsx
+++ b/features/post/components/AddPostButton.tsx
@@ -13,6 +13,7 @@
  * 2026.03.09  임도헌   Modified  모바일 리스트 가림을 줄이기 위해 FAB 크기와 하단 여백 미세 조정
  * 2026.04.14  임도헌   Modified  /posts/add 선프리패치를 막아 목록 초기 JS 평가 비용을 완화
  * 2026.04.17  임도헌   Modified  게시글 FAB의 no-prefetch와 safe-area 배치 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.04.26  임도헌   Modified  다크모드 FAB 색조를 primary CTA 톤과 맞춰 정리
  */
 
 import Link from "next/link";
@@ -37,7 +38,7 @@ export default function AddPostButton() {
       aria-label="게시글 작성"
       className={cn(
         "focus-ring-strong fixed z-40 flex items-center justify-center rounded-full transition-[background-color,color,border-color,box-shadow] motion-safe:transition-transform duration-300",
-        "bg-brand text-white hover:bg-brand-dark dark:bg-brand-light dark:text-gray-100 dark:hover:bg-brand",
+        "bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark",
         "shadow-lg hover:shadow-xl hover:scale-105 active:scale-95",
         "size-12 sm:size-16 bottom-[80px] sm:bottom-24 right-4 sm:right-8",
         // 기기의 하단 안전 여백(Safe Area)을 고려하여 bottom 위치를 동적으로 계산

--- a/features/post/components/postComment/PostCommentForm.tsx
+++ b/features/post/components/postComment/PostCommentForm.tsx
@@ -22,6 +22,7 @@
  * 2026.03.19  임도헌   Modified  댓글 입력바 외곽 패널을 solid 톤으로 정리해 상세 섹션 시작 가시성을 보강
  * 2026.03.30  임도헌   Modified  게시글 카테고리 plain 라벨 정리에 맞춰 댓글 플레이스홀더를 일반 문맥으로 조정
  * 2026.04.20  임도헌   Modified  댓글 입력 포커스가 내부 textarea 기본 outline으로 보이지 않도록 외곽 패널 중심으로 정리
+ * 2026.04.26  임도헌   Modified  댓글 등록 버튼의 다크모드 hover 색조를 primary CTA 톤과 맞춰 정리
  */
 "use client";
 
@@ -114,7 +115,7 @@ export default function PostCommentForm({ postId }: { postId: number }) {
         disabled={isPending || !text.trim()}
         className={cn(
           "focus-ring-soft shrink-0 size-10 rounded-full flex items-center justify-center transition-[background-color,color,border-color,box-shadow] shadow-sm",
-          "bg-brand-light dark:bg-brand text-white hover:bg-brand hover:dark:bg-brand-light active:scale-95",
+          "bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:hover:bg-brand-dark active:scale-95",
           "disabled:bg-neutral-200 dark:disabled:bg-neutral-700 disabled:text-muted disabled:cursor-not-allowed disabled:scale-100 disabled:shadow-none"
         )}
         aria-label="댓글 등록"

--- a/features/post/components/postsDetail/PostDetailLocationSection.tsx
+++ b/features/post/components/postsDetail/PostDetailLocationSection.tsx
@@ -9,6 +9,8 @@
  * 2026.04.14  임도헌   Modified  상세 본문 제목 흐름에 맞춰 섹션 제목 레벨을 정리
  * 2026.04.14  임도헌   Modified  제품 상세와 동일하게 섹션 진입 시 실제 지도를 자동 준비/노출하도록 정책을 정렬
  * 2026.04.14  임도헌   Modified  자동 로드 정책에 맞춰 미리보기 카드를 정보 중심의 간소한 로딩 셸로 정리
+ * 2026.04.26  임도헌   Modified  지도 열기 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
+ * 2026.04.26  임도헌   Modified  위치 섹션 제목 아이콘을 위치 카드 아이콘과 같은 다크모드 톤으로 정리
  */
 "use client";
 
@@ -157,7 +159,7 @@ export default function PostDetailLocationSection({
       className="border-t border-border-subtle pt-4"
     >
       <h2 className="mb-4 flex items-center gap-2 text-sm font-bold text-primary">
-        <MapPinIcon className="size-4 text-brand" />
+        <MapPinIcon className="size-4 text-brand dark:text-brand-light" />
         모임 및 거래 희망 장소
       </h2>
 
@@ -222,7 +224,7 @@ export default function PostDetailLocationSection({
               <button
                 type="button"
                 onClick={() => setShouldLoadMap(true)}
-                className="inline-flex min-h-10 items-center rounded-lg bg-brand px-3.5 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-dark dark:bg-brand-light dark:text-background"
+                className="inline-flex min-h-10 items-center rounded-lg bg-brand px-3.5 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
               >
                 {willAutoOpenMap ? "지금 지도 먼저 보기" : "상세 지도 열기"}
               </button>

--- a/features/product/components/AddProductButton.tsx
+++ b/features/product/components/AddProductButton.tsx
@@ -14,6 +14,7 @@
  * 2026.03.15  임도헌   Modified  최근 본 상품 원형 진입점을 FAB 위에 함께 배치
  * 2026.04.13  임도헌   Modified  최근 본 상품 FAB를 idle 이후 지연 로딩해 products 초기 평가 비용을 완화
  * 2026.04.17  임도헌   Modified  메인 FAB와 최근 본 상품 진입점의 지연 노출 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.04.26  임도헌   Modified  다크모드 FAB 색조를 primary CTA 톤과 맞춰 정리
  */
 "use client";
 
@@ -74,7 +75,7 @@ export default function AddProductButton() {
         aria-label="제품 추가"
         className={cn(
           "focus-ring-strong fixed z-40 flex items-center justify-center rounded-full transition-[background-color,color,border-color,box-shadow] motion-safe:transition-transform duration-300",
-          "bg-brand text-white hover:bg-brand-dark dark:bg-brand-light dark:text-gray-100 dark:hover:bg-brand",
+          "bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark",
           "shadow-lg hover:shadow-xl hover:scale-105 active:scale-95",
           "size-12 sm:size-16 bottom-[80px] sm:bottom-24 right-4 sm:right-8",
           // 기기의 하단 안전 여백(Safe Area)을 고려하여 bottom 위치를 동적으로 계산

--- a/features/product/components/productDetail/ProductDetailLocationSection.tsx
+++ b/features/product/components/productDetail/ProductDetailLocationSection.tsx
@@ -10,6 +10,7 @@
  * 2026.04.14  임도헌   Modified  모바일도 위치 섹션 진입 시 실제 지도를 자동 준비하도록 조정해 미리보기 경험 보강
  * 2026.04.14  임도헌   Modified  지도 섹션의 지연 준비 전략과 사용자 흐름이 드러나도록 함수 상단 JSDoc 설명을 보강
  * 2026.04.14  임도헌   Modified  자동 로드 정책에 맞춰 미리보기 카드를 정보 중심의 간소한 로딩 셸로 정리
+ * 2026.04.26  임도헌   Modified  지도 열기 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 
 "use client";
@@ -225,7 +226,7 @@ export default function ProductDetailLocationSection({
               <button
                 type="button"
                 onClick={() => setShouldLoadMap(true)}
-                className="focus-ring-strong inline-flex min-h-10 items-center rounded-lg bg-brand px-3.5 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-dark dark:bg-brand-light dark:text-background"
+                className="focus-ring-strong inline-flex min-h-10 items-center rounded-lg bg-brand px-3.5 py-2 text-xs font-medium text-white transition-colors hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
               >
                 {willAutoOpenMap ? "지금 지도 먼저 보기" : "상세 지도 열기"}
               </button>

--- a/features/report/components/admin/AdminActionModal.tsx
+++ b/features/report/components/admin/AdminActionModal.tsx
@@ -12,9 +12,11 @@
  * 2026.04.06  임도헌   Modified  모바일 키보드가 열려도 사유 입력과 하단 액션이 덜 가려지도록 시트형 배치 적용
  * 2026.04.10  임도헌   Modified  관리자 액션 모달의 보조 라벨 크기를 공통 타이포 스케일로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.04.26  임도헌   Modified  관리자 액션 모달에 dialog 의미와 설명/입력 라벨 연결, ESC 닫기 흐름을 보강
+ * 2026.04.26  임도헌   Modified  primary 확인 버튼의 다크모드 색조를 공용 CTA 톤과 맞춰 정리
  */
 
-import { useState, useTransition, useEffect } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { cn } from "@/lib/utils";
 import Select from "@/components/ui/Select";
 
@@ -72,6 +74,7 @@ export default function AdminActionModal({
   const [reason, setReason] = useState("");
   const [banDuration, setBanDuration] = useState(0); // 0: 영구
   const [isPending, startTransition] = useTransition();
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // 모달 종료 시 입력 상태 초기화
   // 같은 모달을 여러 대상에 재사용하므로 닫힐 때 사유와 기간을 기본값으로 초기화
@@ -81,6 +84,21 @@ export default function AdminActionModal({
       setBanDuration(0);
     }
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isPending) onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isPending, onClose, open]);
 
   if (!open) return null;
 
@@ -102,27 +120,44 @@ export default function AdminActionModal({
 
   const variantClasses = {
     primary:
-      "bg-brand dark:bg-brand-light text-white dark:text-gray-900 hover:opacity-90",
+      "bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark",
     danger: "bg-danger text-white hover:bg-red-600",
     success: "bg-emerald-600 text-white hover:bg-emerald-700",
   };
 
   return (
     <div className="fixed inset-0 z-[100] flex items-end justify-center bg-black/60 px-4 pt-6 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-sm sm:items-center sm:p-4">
-      <div className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="admin-action-title"
+        aria-describedby="admin-action-description"
+        tabIndex={-1}
+        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl"
+      >
         <div className="flex-1 overflow-y-auto p-6">
-          <h3 className="text-xl font-bold text-primary">{title}</h3>
-          <p className="text-sm text-muted mt-2 mb-6 leading-relaxed">
+          <h3 id="admin-action-title" className="text-xl font-bold text-primary">
+            {title}
+          </h3>
+          <p
+            id="admin-action-description"
+            className="text-sm text-muted mt-2 mb-6 leading-relaxed"
+          >
             {description}
           </p>
 
           <div className="space-y-4">
             {showBanOptions && (
               <div>
-                <label className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block">
+                <label
+                  htmlFor="admin-action-ban-duration"
+                  className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
+                >
                   정지 기간
                 </label>
                 <Select
+                  id="admin-action-ban-duration"
                   value={banDuration}
                   onChange={(e) => setBanDuration(Number(e.target.value))}
                   className="bg-surface-dim border-transparent"
@@ -137,10 +172,14 @@ export default function AdminActionModal({
             )}
 
             <div className="space-y-2">
-              <label className="text-xs font-bold text-muted uppercase tracking-wider">
+              <label
+                htmlFor="admin-action-reason"
+                className="text-xs font-bold text-muted uppercase tracking-wider"
+              >
                 사유 입력 <span className="text-danger">*</span>
               </label>
               <textarea
+                id="admin-action-reason"
                 value={reason}
                 onChange={(e) => setReason(e.target.value)}
                 disabled={isPending}

--- a/features/report/components/admin/ReportActionDialog.tsx
+++ b/features/report/components/admin/ReportActionDialog.tsx
@@ -17,10 +17,11 @@
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.18  임도헌   Modified  내부 대상 링크 프리패치를 비활성화해 모달 진입 전 불필요한 선요청을 줄임
  * 2026.04.19  임도헌   Modified  관련 콘텐츠 삭제 체크박스에 공용 포커스 링을 적용해 관리자 폼 포커스 문법을 통일
+ * 2026.04.26  임도헌   Modified  신고 처리 모달에 dialog 의미와 설명/폼 라벨 연결, ESC 닫기 흐름을 보강
  */
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { updateReportAction } from "@/features/report/actions/admin";
 import Select from "@/components/ui/Select";
@@ -105,6 +106,7 @@ export default function ReportActionDialog({
   );
   const [deleteContent, setDeleteContent] = useState(recommended.deleteContent);
   const [isPending, startTransition] = useTransition();
+  const dialogRef = useRef<HTMLDivElement>(null);
   const isReadOnly = reportStatus !== "PENDING";
 
   useEffect(() => {
@@ -117,6 +119,21 @@ export default function ReportActionDialog({
     );
     setDeleteContent(recommended.deleteContent);
   }, [existingAdminComment, open, recommended]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isPending) onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isPending, onClose, open]);
 
   if (!open) return null;
 
@@ -171,10 +188,23 @@ export default function ReportActionDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 px-4 pt-6 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-sm sm:items-center sm:p-4">
-      <div className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-action-title"
+        aria-describedby="report-action-description"
+        tabIndex={-1}
+        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl"
+      >
         <div className="flex-1 overflow-y-auto p-6">
-          <h3 className="text-lg font-bold text-primary mb-2">신고 처리</h3>
-          <p className="text-sm text-muted mb-4">
+          <h3
+            id="report-action-title"
+            className="text-lg font-bold text-primary mb-2"
+          >
+            신고 처리
+          </h3>
+          <p id="report-action-description" className="text-sm text-muted mb-4">
             {isReadOnly
               ? "이미 처리된 신고의 조치 내역입니다."
               : "조치 내용이나 기각 사유를 입력하세요."}
@@ -327,10 +357,14 @@ export default function ReportActionDialog({
           {!isReadOnly && (
             <div className="space-y-4 mb-4">
               <div>
-                <label className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block">
+                <label
+                  htmlFor="report-resolution-action"
+                  className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
+                >
                   승인 시 조치 유형
                 </label>
                 <Select
+                  id="report-resolution-action"
                   value={action}
                   onChange={(e) =>
                     setAction(e.target.value as ReportResolutionAction)
@@ -349,10 +383,14 @@ export default function ReportActionDialog({
 
               {action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN && (
                 <div>
-                  <label className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block">
+                  <label
+                    htmlFor="report-ban-duration"
+                    className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
+                  >
                     정지 기간
                   </label>
                   <Select
+                    id="report-ban-duration"
                     value={durationDays}
                     onChange={(e) => setDurationDays(Number(e.target.value))}
                     disabled={isPending}
@@ -381,6 +419,7 @@ export default function ReportActionDialog({
           )}
 
           <textarea
+            aria-label={isReadOnly ? "관리자 기록" : "처리 내용"}
             className="input-primary w-full h-32 p-4 text-sm resize-none mb-6 bg-surface-dim border-none"
             placeholder={
               isReadOnly ? "관리자 기록" : "처리 내용을 입력하세요..."

--- a/features/search/components/RegionSearchModal.tsx
+++ b/features/search/components/RegionSearchModal.tsx
@@ -13,6 +13,8 @@
  * 2026.04.02  임도헌   Modified  카카오 장소 검색 결과 타입을 search 도메인 공용 타입 기준으로 정리
  * 2026.04.07  임도헌   Modified  모바일에서는 BottomSheet를 사용해 지역 검색 흐름을 하단 시트로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.04.26  임도헌   Modified  데스크톱 지역 검색 모달의 dialog 의미와 검색 입력 라벨을 보강
+ * 2026.04.26  임도헌   Modified  지역 검색 로딩/빈 결과 안내 문구를 사용자 행동 기준으로 정리
  */
 
 import { useState } from "react";
@@ -47,7 +49,7 @@ export default function RegionSearchModal({ onSelect, onClose }: Props) {
   const handleSearch = () => {
     if (!keyword.trim()) return;
     if (loading || !window.kakao?.maps?.services) {
-      toast.error("검색 시스템을 로딩 중입니다.");
+      toast.error("지역 검색을 준비 중이에요. 잠시 후 다시 시도해주세요.");
       return;
     }
 
@@ -57,7 +59,7 @@ export default function RegionSearchModal({ onSelect, onClose }: Props) {
         // 행정구역 정보가 있는 결과 위주로 필터링하거나 그대로 노출
         setResults(data);
       } else if (status === window.kakao.maps.services.Status.ZERO_RESULT) {
-        toast.info("검색 결과가 없습니다.");
+        toast.info("일치하는 지역이나 장소가 없어요.");
         setResults([]);
       }
     });
@@ -111,7 +113,7 @@ export default function RegionSearchModal({ onSelect, onClose }: Props) {
           </h4>
           <p className="state-description">
             {loading
-              ? "카카오 지도 SDK를 불러오는 중입니다. 잠시 후 다시 시도해주세요."
+              ? "지역 검색을 준비 중이에요. 잠시 후 다시 시도해주세요."
               : "네트워크 상태를 확인한 뒤 다시 시도해주세요."}
           </p>
         </div>
@@ -124,6 +126,7 @@ export default function RegionSearchModal({ onSelect, onClose }: Props) {
               type="text"
               className="input-primary bg-surface pl-10"
               placeholder="예: 강남구, 부산, 해운대"
+              aria-label="지역 검색어"
               value={keyword}
               onChange={(e) => setKeyword(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -142,7 +145,7 @@ export default function RegionSearchModal({ onSelect, onClose }: Props) {
         <div className="flex-1 overflow-y-auto bg-surface p-2">
           {results.length === 0 ? (
             <div className="py-10 text-center text-sm text-muted">
-              지역명이나 장소를 검색해주세요.
+              지역명이나 장소 이름을 입력해 검색해보세요.
             </div>
           ) : (
             <ul className="space-y-1">
@@ -186,10 +189,17 @@ export default function RegionSearchModal({ onSelect, onClose }: Props) {
 
   return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-      <div className="bg-surface flex max-h-[80dvh] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-border-subtle shadow-2xl sm:max-w-lg">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="region-search-title"
+        className="bg-surface flex max-h-[80dvh] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-border-subtle shadow-2xl sm:max-w-lg"
+      >
         {/* 헤더 */}
         <div className="p-4 border-b border-border-subtle flex items-center justify-between bg-surface shrink-0">
-          <h3 className="font-bold text-primary">다른 지역 검색</h3>
+          <h3 id="region-search-title" className="font-bold text-primary">
+            다른 지역 검색
+          </h3>
           <button
             onClick={onClose}
             className="focus-ring-soft rounded p-1 text-muted hover:text-primary"

--- a/features/search/components/SearchModal.tsx
+++ b/features/search/components/SearchModal.tsx
@@ -19,6 +19,8 @@
  * 2026.04.02  임도헌   Modified  검색 기록/인기 검색 타입 import를 search 도메인 공용 타입 기준으로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.17  임도헌   Modified  모바일 검색 모달 상단 검색창과 닫기 버튼 톤을 탭 헤더 검색바와 같은 계열로 정리
+ * 2026.04.26  임도헌   Modified  모바일/데스크톱 검색 모달에 dialog 의미와 스크린리더 제목을 보강
+ * 2026.04.26  임도헌   Modified  닫기 버튼의 visible copy에서 단축키 설명을 제거해 액션 라벨만 남김
  */
 
 import { useState, useEffect } from "react";
@@ -102,7 +104,12 @@ export default function SearchModal({
   // [Mobile Layout] Full Screen Fixed
   if (isMobile) {
     return createPortal(
-      <div className="fixed inset-0 z-[100] flex flex-col bg-background">
+      <div
+        className="fixed inset-0 z-[100] flex flex-col bg-background"
+        role="dialog"
+        aria-modal="true"
+        aria-label="검색"
+      >
         {/* Header */}
         <div className="flex items-center gap-2 border-b border-border-subtle bg-background px-3 py-3 shrink-0">
           <button
@@ -159,9 +166,15 @@ export default function SearchModal({
 
       {/* Modal Card */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-modal-title"
         className="relative flex h-fit max-h-[75vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border-subtle bg-surface shadow-2xl"
         onClick={(e) => e.stopPropagation()} // 내부 클릭 시 닫힘 방지
       >
+        <h2 id="search-modal-title" className="sr-only">
+          검색
+        </h2>
         {/* Search Input Area */}
         <div className="shrink-0 border-b border-border-subtle bg-surface p-6">
           <SearchBar
@@ -198,7 +211,7 @@ export default function SearchModal({
             onClick={onClose}
             className="focus-ring-soft flex items-center gap-2 rounded-xl px-5 py-2 text-sm font-bold text-muted transition-colors hover:bg-surface-dim hover:text-primary"
           >
-            <XMarkIcon className="size-4 stroke-2" /> 닫기 (ESC)
+            <XMarkIcon className="size-4 stroke-2" /> 닫기
           </button>
         </div>
       </div>

--- a/features/stream/components/AddStreamButton.tsx
+++ b/features/stream/components/AddStreamButton.tsx
@@ -13,6 +13,7 @@
  * 2026.03.11  임도헌   Modified  모바일 FAB 크기와 하단 여백을 제품/게시글 탭과 통일
  * 2026.04.16  임도헌   Modified  초기 자동 프리패치 대신 hover/touch 시점 프리패치로 이동 체감 보강
  * 2026.04.17  임도헌   Modified  FAB의 의도 기반 프리패치 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.04.26  임도헌   Modified  다크모드 FAB 색조를 primary CTA 톤과 맞춰 정리
  */
 "use client";
 
@@ -53,7 +54,7 @@ export default function AddStreamButton() {
       title="새 스트리밍 생성"
       className={cn(
         "focus-ring-strong fixed z-40 flex items-center justify-center rounded-full transition-[background-color,color,border-color,box-shadow] motion-safe:transition-transform duration-300",
-        "bg-brand text-white hover:bg-brand-dark dark:bg-brand-light dark:text-gray-100 dark:hover:bg-brand",
+        "bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark",
         "shadow-lg hover:shadow-xl hover:scale-105 active:scale-95",
         "size-12 sm:size-16 bottom-[80px] sm:bottom-24 right-4 sm:right-8",
         // 기기의 하단 안전 여백(Safe Area)을 고려하여 bottom 위치를 동적으로 계산

--- a/features/stream/components/StreamChatPinnedNoticeEditor.tsx
+++ b/features/stream/components/StreamChatPinnedNoticeEditor.tsx
@@ -5,6 +5,7 @@
  *
  * History
  * 2026.04.21  임도헌   Created   StreamChatRoom에서 고정 공지 편집 UI를 분리
+ * 2026.04.26  임도헌   Modified  저장 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 "use client";
 
@@ -76,7 +77,7 @@ export default function StreamChatPinnedNoticeEditor({
             type="button"
             onClick={onSave}
             disabled={isSaving}
-            className="focus-ring-strong rounded-full bg-brand px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-brand-light dark:text-slate-950"
+            className="focus-ring-strong rounded-full bg-brand px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-dark disabled:cursor-not-allowed disabled:opacity-60 dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
           >
             {isSaving ? "저장 중..." : initialNotice ? "저장" : "등록"}
           </button>

--- a/features/stream/components/StreamChatUserModal.tsx
+++ b/features/stream/components/StreamChatUserModal.tsx
@@ -22,9 +22,10 @@
  * 2026.04.04  임도헌   Modified  호스트 운영 안내 문구를 confirm 문구와 같은 차단 정책 톤으로 미세 정리
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 운영 안내와 액션 버튼 weight를 500 기준으로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.04.26  임도헌   Modified  스트림 채팅 유저 모달에 dialog 의미와 제목/닫기 라벨, ESC 닫기 흐름을 보강
  */
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { createPortal } from "react-dom";
@@ -111,10 +112,28 @@ export default function StreamChatUserModal({
     useState<ModerationIntent | null>(null);
   const [reportOpen, setReportOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (!isOpen || !targetUser || !mounted || isConfirmOpen || reportOpen) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isConfirmOpen, isOpen, mounted, onClose, reportOpen, targetUser]);
 
   if (!isOpen || !targetUser || !mounted) return null;
   const isMe = viewerId === targetUser.id;
@@ -267,6 +286,11 @@ export default function StreamChatUserModal({
       >
         {/* 모달 본체 */}
         <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="stream-chat-user-title"
+          tabIndex={-1}
           className={cn(
             "relative my-auto w-full max-w-xs overflow-hidden rounded-2xl shadow-2xl",
             "max-h-[calc(100dvh-2rem)] sm:max-h-[calc(100dvh-3rem)]",
@@ -279,6 +303,7 @@ export default function StreamChatUserModal({
             <button
               onClick={onClose}
               className="focus-ring-soft rounded-full p-1 text-muted transition-colors hover:bg-surface-dim hover:text-primary"
+              aria-label="유저 메뉴 닫기"
             >
               <XMarkIcon className="size-6" />
             </button>
@@ -294,7 +319,10 @@ export default function StreamChatUserModal({
               disabled
               className="mb-3 ring-1 ring-brand/10 dark:ring-white/6"
             />
-            <h3 className="mb-6 text-lg font-bold text-primary">
+            <h3
+              id="stream-chat-user-title"
+              className="mb-6 text-lg font-bold text-primary"
+            >
               {targetUser.username}
             </h3>
 

--- a/features/stream/components/StreamDetail/LiveStatusButton.tsx
+++ b/features/stream/components/StreamDetail/LiveStatusButton.tsx
@@ -21,6 +21,7 @@
  * 2026.03.20  임도헌   Modified  플레이어 상태 메타를 항해 로그 칩처럼 읽히도록 타이포와 대비를 추가 정리
  * 2026.03.20  임도헌   Modified  방송 종료 상태는 danger 계열 칩으로 조정해 라이브 종료 의미를 더 분명하게 전달
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 상태 칩 타이포를 text-xs·500 기준으로 정리
+ * 2026.04.26  임도헌   Modified  라이브 상태 칩의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 
 "use client";
@@ -99,7 +100,7 @@ export default function LiveStatusButton({
           : "상태 확인중";
 
   const colorClass = isLive
-    ? "bg-brand text-white dark:bg-brand-light"
+    ? "bg-brand text-white dark:bg-brand"
     : isEnded
       ? "border border-danger/20 bg-danger/10 text-danger dark:border-danger/30 dark:bg-danger/15 dark:text-danger"
       : "border border-border-subtle bg-surface text-muted";

--- a/features/user/components/admin/AdminNavLink.tsx
+++ b/features/user/components/admin/AdminNavLink.tsx
@@ -8,6 +8,7 @@
  * 2026.02.06  임도헌   Created   usePathname을 활용한 활성화 스타일 적용
  * 2026.03.30  임도헌   Modified  관리자 모바일/데스크톱 공통 네비게이션에서 같은 활성 상태 문법을 재사용하도록 정리
  * 2026.04.18  임도헌   Modified  관리자 셸 링크 프리패치를 비활성화해 과도한 백그라운드 라우트 요청을 줄임
+ * 2026.04.26  임도헌   Modified  활성 링크의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 
 "use client";
@@ -42,7 +43,7 @@ export default function AdminNavLink({ href, icon, label }: AdminNavLinkProps) {
       className={cn(
         "focus-ring-soft flex items-center gap-3 px-4 py-2.5 text-sm font-bold rounded-xl transition-colors group",
         isActive
-          ? "bg-brand dark:bg-brand-light text-white dark:text-gray-900 shadow-md"
+          ? "bg-brand text-white shadow-md dark:bg-brand dark:text-white"
           : "text-muted hover:bg-surface-dim hover:text-primary"
       )}
     >

--- a/features/user/components/follow/FollowListItem.tsx
+++ b/features/user/components/follow/FollowListItem.tsx
@@ -18,6 +18,7 @@
  * 2026.03.28  임도헌   Modified  팔로우 리스트 행을 카드형으로 정리하고 버튼 무게를 조정해 프로필 모달 밀도 개선
  * 2026.03.29  임도헌   Modified  행 레이아웃을 리스트 문법으로 되돌려 아바타/닉네임을 좌정렬하고 과한 보더를 제거
  * 2026.03.29  임도헌   Modified  팔로우 CTA를 outline 대신 채움형으로 조정해 모달 내 가시성 보강
+ * 2026.04.26  임도헌   Modified  팔로우 목록 CTA와 맞팔로잉 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 
 "use client";
@@ -85,8 +86,8 @@ export default function FollowListItem({
             following
               ? "bg-surface text-muted border-border-subtle hover:bg-surface-dim hover:border-border dark:bg-surface-dim dark:text-primary dark:border-border dark:hover:bg-border/40" // Unfollow
               : buttonVariant === "primary"
-                ? "bg-brand text-white border-transparent hover:bg-brand-dark dark:bg-brand-dark dark:hover:bg-brand-dark/85" // Primary Follow
-                : "bg-brand text-white border-transparent hover:bg-brand-dark dark:bg-brand-light dark:text-gray-100 dark:hover:bg-brand"
+                ? "bg-brand text-white border-transparent hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark" // Primary Follow
+                : "bg-brand text-white border-transparent hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
           )}
         >
           {pending ? "..." : following ? "팔로우 취소" : "팔로우"}

--- a/features/user/components/follow/FollowSection.tsx
+++ b/features/user/components/follow/FollowSection.tsx
@@ -23,6 +23,7 @@
  * 2026.03.28  임도헌   Modified  compact 팔로우 CTA의 높이/패딩/그림자를 한 단계 낮춰 헤더에서 과하게 커 보이던 무게를 보정
  * 2026.04.06  임도헌   Modified  좁은 모바일 폭 헤더에서 compact 카운트/버튼이 한 줄에 더 안정적으로 머물도록 간격과 크기 재조정
  * 2026.04.10  임도헌   Modified  follow 타이포 정책에 맞춰 compact 카운트/CTA 크기와 weight를 400·500·700 기준으로 정리
+ * 2026.04.26  임도헌   Modified  채널 팔로우 CTA의 다크모드 대비와 색조를 primary CTA 톤에 맞춰 보강
  */
 "use client";
 
@@ -216,7 +217,7 @@ export default function FollowSection({
             isFollowing ? "focus-ring-soft" : "focus-ring-strong",
             isFollowing
               ? "border-border-strong bg-surface text-muted hover:border-danger/30 hover:bg-danger/5 hover:text-danger dark:border-border dark:bg-surface-dim dark:text-primary dark:hover:border-danger/30 dark:hover:bg-danger/10 dark:hover:text-danger"
-              : "border-transparent bg-brand text-white hover:bg-brand-dark dark:bg-brand-light dark:text-gray-100 dark:hover:bg-brand",
+              : "border-transparent bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark",
           ].join(" ")}
         >
           {isPending ? "처리 중..." : isFollowing ? "팔로우 취소" : "팔로우"}

--- a/features/user/components/profile/BlockedUsersModal.tsx
+++ b/features/user/components/profile/BlockedUsersModal.tsx
@@ -13,9 +13,10 @@
  * 2026.04.10  임도헌   Modified  profile 타이포 정책에 맞춰 차단 해제 액션 weight를 500 기준으로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.22  임도헌   Modified  차단 해제 액션을 텍스트 링크 대신 명확한 보조 버튼으로 정리
+ * 2026.04.26  임도헌   Modified  차단 관리 모달에 dialog 의미와 제목 연결, ESC 닫기 포커스 흐름을 보강
  */
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { toggleBlockAction } from "@/features/user/actions/block";
 import UserAvatar from "@/components/global/UserAvatar";
 import { XMarkIcon } from "@heroicons/react/24/outline";
@@ -49,11 +50,27 @@ export default function BlockedUsersModal({
 }) {
   const [users, setUsers] = useState(initialBlockedUsers);
   const [isPending, startTransition] = useTransition();
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // 모달 재오픈이나 서버 목록 변경 뒤에는 낙관 상태보다 최신 서버 목록을 우선 반영
     setUsers(initialBlockedUsers);
   }, [initialBlockedUsers, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isPending) onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, isPending, onClose]);
 
   if (!isOpen) return null;
 
@@ -73,9 +90,18 @@ export default function BlockedUsersModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-      <div className="bg-surface w-full max-w-md rounded-2xl shadow-xl overflow-hidden border border-border-subtle">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="blocked-users-title"
+        tabIndex={-1}
+        className="bg-surface w-full max-w-md rounded-2xl shadow-xl overflow-hidden border border-border-subtle"
+      >
         <div className="px-6 py-4 border-b border-border-subtle flex justify-between items-center bg-surface">
-          <h2 className="font-bold text-primary">차단한 선원 관리</h2>
+          <h2 id="blocked-users-title" className="font-bold text-primary">
+            차단한 선원 관리
+          </h2>
           <button
             onClick={onClose}
             type="button"

--- a/features/user/components/profile/CreateReviewModal.tsx
+++ b/features/user/components/profile/CreateReviewModal.tsx
@@ -17,9 +17,10 @@
  * 2026.03.12  임도헌   Modified  리뷰 작성 별점 색상을 채움형 노란 별 기준으로 복원
  * 2026.03.22  임도헌   Modified  최근 모달 톤 기준으로 외곽선과 헤더/푸터 보더 강도 정리
  * 2026.04.06  임도헌   Modified  모바일 키보드가 열려도 textarea와 하단 액션 버튼이 덜 가려지도록 시트형 배치 적용
+ * 2026.04.26  임도헌   Modified  리뷰 작성 모달에 dialog 의미와 별점 radiogroup, 후기 입력 라벨을 추가해 접근성을 보강
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import UserAvatar from "@/components/global/UserAvatar";
 import { StarIcon } from "@heroicons/react/24/solid";
 import { cn } from "@/lib/utils";
@@ -51,6 +52,7 @@ export default function CreateReviewModal({
   const [hoverRating, setHoverRating] = useState(0); // 별점 호버 효과용
   const [reviewText, setReviewText] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // 모달 닫힐 때 폼 리셋
   const resetForm = useCallback(() => {
@@ -63,6 +65,21 @@ export default function CreateReviewModal({
   useEffect(() => {
     if (!isOpen) resetForm();
   }, [isOpen, resetForm]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isSubmitting) onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, isSubmitting, onClose]);
 
   if (!isOpen) return null;
 
@@ -96,6 +113,11 @@ export default function CreateReviewModal({
       />
 
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-review-title"
+        tabIndex={-1}
         className={cn(
           "relative flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col overflow-hidden rounded-t-3xl shadow-xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl",
           "bg-surface border border-border-subtle"
@@ -103,7 +125,9 @@ export default function CreateReviewModal({
       >
         {/* 헤더 */}
         <div className="px-6 py-4 border-b border-border-subtle bg-surface">
-          <h2 className="text-lg font-bold text-primary">거래 후기 작성</h2>
+          <h2 id="create-review-title" className="text-lg font-bold text-primary">
+            거래 후기 작성
+          </h2>
         </div>
 
         {/* 본문 */}
@@ -120,21 +144,35 @@ export default function CreateReviewModal({
           </div>
 
           {/* 별점 선택 */}
-          <div className="flex justify-center gap-1">
+          <div
+            className="flex justify-center gap-1"
+            role="radiogroup"
+            aria-label="거래 별점"
+          >
             {[1, 2, 3, 4, 5].map((star) => (
-              <StarIcon
+              <button
                 key={star}
-                className={cn(
-                  "cursor-pointer w-10 h-10 transition-colors motion-safe:transition-transform duration-200",
-                  star <= (hoverRating || rating)
-                    ? "text-yellow-400 scale-110"
-                    : "text-neutral-300 dark:text-neutral-700",
-                  !isSubmitting && "hover:scale-125"
-                )}
+                type="button"
+                role="radio"
+                aria-checked={rating === star}
+                aria-label={`${star}점`}
+                disabled={isSubmitting}
+                className="focus-ring-soft rounded-full p-0.5 disabled:cursor-not-allowed disabled:opacity-60"
                 onMouseEnter={() => !isSubmitting && setHoverRating(star)}
                 onMouseLeave={() => !isSubmitting && setHoverRating(0)}
                 onClick={() => !isSubmitting && setRating(star)}
-              />
+              >
+                <StarIcon
+                  aria-hidden="true"
+                  className={cn(
+                    "h-10 w-10 transition-colors motion-safe:transition-transform duration-200",
+                    star <= (hoverRating || rating)
+                      ? "text-yellow-400 scale-110"
+                      : "text-neutral-300 dark:text-neutral-700",
+                    !isSubmitting && "hover:scale-125"
+                  )}
+                />
+              </button>
             ))}
           </div>
 
@@ -143,6 +181,7 @@ export default function CreateReviewModal({
             value={reviewText}
             onChange={(e) => setReviewText(e.target.value)}
             placeholder="솔직한 거래 경험을 남겨주세요."
+            aria-label="거래 후기 내용"
             className={cn(
               "w-full h-32 p-4 rounded-xl resize-none",
               "bg-surface-dim border-transparent focus:bg-surface focus:border-brand/50",

--- a/features/user/components/profile/NeighborhoodSearchModal.tsx
+++ b/features/user/components/profile/NeighborhoodSearchModal.tsx
@@ -13,6 +13,8 @@
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.17  임도헌   Modified  모바일 BottomSheet 검색행을 공용 검색 모달 패턴(입력 내부 CTA)으로 맞춰 줄바꿈/높이 불균형을 정리
  * 2026.04.20  임도헌   Modified  동 이름 단일 검색에서도 누락이 덜 생기도록 카카오 주소 검색 결과 확장과 추가 로딩을 지원
+ * 2026.04.26  임도헌   Modified  데스크톱 동네 검색 모달의 dialog 의미와 검색 입력/닫기 버튼 라벨을 보강
+ * 2026.04.26  임도헌   Modified  동네 검색 로딩/오류/빈 결과 문구를 사용자 행동 기준으로 정리
  */
 
 import { useState } from "react";
@@ -120,7 +122,7 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
     const trimmedKeyword = searchKeyword.trim();
     if (!trimmedKeyword) return;
     if (loading || !window.kakao?.maps?.services) {
-      toast.error("지도 시스템을 로딩 중입니다. 잠시 후 시도해주세요.");
+      toast.error("동네 검색을 준비 중이에요. 잠시 후 다시 시도해주세요.");
       return;
     }
 
@@ -156,7 +158,7 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
           if (page > 1) return;
 
           toast.info(
-            "검색 결과가 없습니다. '동', '읍', '면' 단위로 검색해보세요."
+            "일치하는 동네가 없어요. '동', '읍', '면' 이름으로 검색해보세요."
           );
         } else {
           setHasNextPage(false);
@@ -165,7 +167,7 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
             return;
           }
 
-          toast.error("검색 중 오류가 발생했습니다.");
+          toast.error("동네를 검색하지 못했어요. 잠시 후 다시 시도해주세요.");
         }
       },
       {
@@ -208,8 +210,8 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
 
   const searchContent = error ? (
     <div className="flex flex-col items-center justify-center px-6 py-20 text-center">
-      <p className="mb-2 font-bold text-danger">시스템 로드 실패</p>
-      <p className="text-sm text-muted">네트워크 상태를 확인해주세요.</p>
+      <p className="mb-2 font-bold text-danger">동네 검색을 열지 못했어요</p>
+      <p className="text-sm text-muted">네트워크 상태를 확인한 뒤 다시 시도해주세요.</p>
     </div>
   ) : loading ? (
     <div className="flex flex-col items-center justify-center px-6 py-20">
@@ -226,6 +228,7 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
             type="text"
             className="input-primary h-12 w-full bg-surface-dim pl-10 pr-16 text-sm shadow-sm focus:bg-surface"
             placeholder="동, 읍, 면으로 검색 (예: 서초동)"
+            aria-label="동네 이름 검색어"
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -245,10 +248,10 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
         {results.length === 0 ? (
           <div className="py-10 text-center text-sm text-muted">
             {isSearching
-              ? "검색 결과를 불러오는 중입니다."
+              ? "동네 검색 결과를 불러오는 중이에요."
               : activeKeyword
-                ? "검색 결과가 없습니다. 검색어를 조금 더 구체적으로 입력해보세요."
-                : "현재 위치한 동네 이름을 검색해주세요."}
+                ? "일치하는 동네가 없어요. 동/읍/면 이름을 조금 더 구체적으로 입력해보세요."
+                : "현재 위치한 동네 이름을 입력해 검색해보세요."}
           </div>
         ) : (
           <div className="space-y-3">
@@ -291,12 +294,20 @@ export default function NeighborhoodSearchModal({ onClose, onSelect }: Props) {
   // 모달 기본 뼈대
   const modalWrapper = (content: React.ReactNode) => (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-      <div className="bg-surface flex max-h-[80dvh] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-border-subtle shadow-2xl sm:max-w-lg">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="neighborhood-search-title"
+        className="bg-surface flex max-h-[80dvh] w-full max-w-md flex-col overflow-hidden rounded-2xl border border-border-subtle shadow-2xl sm:max-w-lg"
+      >
         <div className="p-4 border-b border-border-subtle flex items-center justify-between bg-surface shrink-0">
-          <h3 className="font-bold text-primary">내 동네 검색</h3>
+          <h3 id="neighborhood-search-title" className="font-bold text-primary">
+            내 동네 검색
+          </h3>
           <button
             onClick={onClose}
             className="focus-ring-soft rounded-full p-1 text-muted hover:text-primary transition-colors"
+            aria-label="내 동네 검색 모달 닫기"
           >
             <XMarkIcon className="size-6" />
           </button>

--- a/features/user/components/profile/ProfileEditForm.tsx
+++ b/features/user/components/profile/ProfileEditForm.tsx
@@ -35,6 +35,7 @@
  * 2026.03.23  임도헌   Modified  프로필 편집 섹션 구분선과 안내 카드 셸을 구조선 기준으로 border-border-subtle에 맞춰 정리
  * 2026.04.10  임도헌   Modified  profile 타이포 정책에 맞춰 전화번호 인증 CTA weight를 500 기준으로 정리
  * 2026.04.25  임도헌   Modified  서버 액션 prop 전달을 제거하고 소셜 유저 설정 안내의 다크모드 대비를 개선
+ * 2026.04.26  임도헌   Modified  전화번호 인증 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 "use client";
 
@@ -689,7 +690,7 @@ export default function ProfileEditForm({
                     type="button"
                     onClick={handleSendVerification}
                     disabled={submitting}
-                    className="focus-ring-strong h-input-md w-full whitespace-nowrap rounded-xl bg-brand px-4 text-xs font-medium text-white shadow-sm transition-colors hover:bg-brand-dark disabled:opacity-50 sm:w-auto dark:bg-brand-light dark:hover:bg-brand"
+                    className="focus-ring-strong h-input-md w-full whitespace-nowrap rounded-xl bg-brand px-4 text-xs font-medium text-white shadow-sm transition-colors hover:bg-brand-dark disabled:opacity-50 sm:w-auto dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
                   >
                     인증 요청
                   </button>
@@ -711,7 +712,7 @@ export default function ProfileEditForm({
                   type="button"
                   onClick={handleVerifyToken}
                   disabled={submitting}
-                  className="focus-ring-strong h-input-md w-full whitespace-nowrap rounded-xl bg-brand px-4 text-xs font-medium text-white shadow-sm transition-colors hover:bg-brand-dark sm:w-auto dark:bg-brand-light dark:hover:bg-brand"
+                  className="focus-ring-strong h-input-md w-full whitespace-nowrap rounded-xl bg-brand px-4 text-xs font-medium text-white shadow-sm transition-colors hover:bg-brand-dark sm:w-auto dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
                 >
                   확인
                 </button>

--- a/features/user/components/profile/ReviewDetailModal.tsx
+++ b/features/user/components/profile/ReviewDetailModal.tsx
@@ -17,6 +17,7 @@
  * 2026.03.22  임도헌   Modified  최근 모달 톤 기준으로 외곽선과 헤더/푸터 보더 강도 정리
  * 2026.03.23  임도헌   Modified  데스크톱에서 텍스트형 모달이 세로로만 길어지지 않도록 폭을 한 단계 확장
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.04.26  임도헌   Modified  리뷰 상세 별점 aria-label을 sr-only 텍스트와 장식용 아이콘 구조로 정리
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -119,13 +120,12 @@ export default function ReviewDetailModal({
               {title}
             </h3>
             {review && (
-              <div
-                className="flex gap-0.5"
-                aria-label={`별점 ${review.rate}점`}
-              >
+              <div className="flex gap-0.5">
+                <span className="sr-only">별점 {review.rate}점</span>
                 {[1, 2, 3, 4, 5].map((star) => (
                   <StarIcon
                     key={star}
+                    aria-hidden="true"
                     className={cn(
                       "w-4 h-4",
                       star <= review.rate

--- a/features/user/components/profile/ReviewsItem.tsx
+++ b/features/user/components/profile/ReviewsItem.tsx
@@ -21,6 +21,7 @@
  * 2026.03.14  임도헌   Modified  리뷰에 표시되는 상품명을 상세 링크로 연결해 거래 맥락 진입성을 보강
  * 2026.03.18  임도헌   Modified  리뷰 상품 링크용 현재 경로도 내부 경로 기준으로 정규화해 nested returnTo 예외를 완화
  * 2026.04.10  임도헌   Modified  profile 타이포 정책에 맞춰 작성자 라벨 weight와 메타 text-xs 스케일을 정리
+ * 2026.04.26  임도헌   Modified  리뷰 별점 aria-label을 sr-only 텍스트로 교체해 금지 ARIA 속성 경고를 해소
  */
 "use client";
 
@@ -100,13 +101,12 @@ export default function ReviewItem({
               <span className="text-sm font-medium text-primary">
                 {review.user?.username || "알 수 없음"}
               </span>
-              <div
-                className="mt-0.5 flex items-center gap-0.5"
-                aria-label={`평점 ${review.rate}점`}
-              >
+              <div className="mt-0.5 flex items-center gap-0.5">
+                <span className="sr-only">평점 {review.rate}점</span>
                 {[1, 2, 3, 4, 5].map((star) => (
                   <StarIcon
                     key={star}
+                    aria-hidden="true"
                     className={cn(
                       "size-3 sm:size-3.5",
                       star <= review.rate

--- a/features/user/components/profile/UserProfile.tsx
+++ b/features/user/components/profile/UserProfile.tsx
@@ -47,6 +47,7 @@
  * 2026.04.17  임도헌   Modified   방송국 링크/후기·뱃지/판매 목록 섹션 주석을 현재 구조 기준으로 최신화
  * 2026.04.19  임도헌   Modified   타인 프로필 판매 목록 탭 active 톤을 판매내역과 같은 기준으로 정리
  * 2026.04.24  임도헌   Modified   타인 프로필 제품 카드에 현재 프로필 returnTo를 전달해 상세 복귀 문맥 유지
+ * 2026.04.26  임도헌   Modified   차단 해제 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  */
 
 "use client";
@@ -250,7 +251,7 @@ export default function UserProfile({
             disabled={isUnblocking}
             className={cn(
               "mt-6 h-10 px-6 text-sm font-medium rounded-xl transition-colors",
-              "bg-brand text-white shadow-sm hover:bg-brand-dark dark:bg-brand-light dark:hover:bg-brand",
+              "bg-brand text-white shadow-sm hover:bg-brand-dark dark:bg-brand dark:hover:bg-brand-dark",
               "disabled:opacity-50 disabled:cursor-not-allowed"
             )}
           >

--- a/features/user/components/profile/UserRating.tsx
+++ b/features/user/components/profile/UserRating.tsx
@@ -14,6 +14,7 @@
  * 2026.01.29  임도헌   Modified  주석 보강 및 컴포넌트 구조 설명 추가
  * 2026.03.12  임도헌   Modified  평점 별 색상을 채움형 노란 별 기준으로 복원
  * 2026.03.14  임도헌   Modified  프로필 헤더용 반응형 size 프리셋을 추가해 JS matchMedia 없이 CSS만으로 크기 제어
+ * 2026.04.26  임도헌   Modified  평점 표시를 sr-only 텍스트와 장식용 별 아이콘 구조로 정리해 ARIA 경고를 해소
  */
 "use client";
 
@@ -74,12 +75,11 @@ export default function UserRating({
   };
 
   return (
-    <div
-      className={cn("flex items-center gap-1.5", className)}
-      role="img"
-      aria-label={`평점 ${displayAvg}점, 후기 ${totalReviews}개`}
-    >
-      <div className="flex gap-0.5">
+    <div className={cn("flex items-center gap-1.5", className)}>
+      <span className="sr-only">
+        평점 {displayAvg}점, 후기 {totalReviews}개
+      </span>
+      <div className="flex gap-0.5" aria-hidden="true">
         {[0, 1, 2, 3, 4].map((i) => {
           const pct = fillFor(i);
           return (
@@ -109,7 +109,10 @@ export default function UserRating({
         })}
       </div>
       {/* 평점 갯수 */}
-      <span className={cn("font-medium text-muted", textSizes[size])}>
+      <span
+        className={cn("font-medium text-muted", textSizes[size])}
+        aria-hidden="true"
+      >
         {displayAvg} <span className="text-muted/60">({totalReviews})</span>
       </span>
     </div>


### PR DESCRIPTION
## Summary
Lighthouse 3차 QA 중 확인한 접근성, UX 문구, 다크모드 CTA, 모바일/좁은 뷰포트 상호작용 후속 이슈를 정리했습니다.
이번 PR은 보안 헤더 정책 변경이 아니라, Lighthouse 측정 과정에서 분리된 접근성 경고와 실제 화면 검수 중 발견한 UI/UX 후속 Fix입니다.

## Changes
[♿ Accessibility]
- 프로필 평점/후기 별점 UI의 div aria-label 사용을 제거하고, sr-only 텍스트와 aria-hidden 별점 아이콘 구조로 정리했습니다.
- 후기 작성/상세, 검색, 지역/동네 검색, 신고 처리, 차단 유저, 스트림 유저 메뉴, 약속 모달에 dialog 의미와 닫기/입력 라벨을 보강했습니다.
- 후기 작성 별점 선택을 radiogroup/radio 구조로 정리해 스크린리더가 선택 상태를 읽을 수 있도록 개선했습니다.

[🔔 Notification UX]
- 알림 센터의 보기 액션과 읽음 액션을 분리하고, 개별 읽음 버튼을 `읽음으로 표시` 보조 pill 버튼으로 정리했습니다.
- 좁은 화면에서도 링크형 알림의 보기 버튼이 제목 행 오른쪽에 유지되도록 레이아웃을 보정했습니다.
- 알림/키워드/검색/약속 관련 토스트와 빈 상태 문구를 사용자 행동 기준으로 정리했습니다.
- 서버 읽음 처리 실패 문구도 알림 센터 UI 라벨과 같은 표현으로 통일했습니다.

[🎨 Dark Mode]
- 팔로우, 맞팔로잉, FAB, 지도 열기, 댓글 등록, 전화번호 인증, 관리자 primary CTA의 다크모드 색조를 primary CTA 톤으로 통일했습니다.
- 게시글 위치 섹션 제목 아이콘을 위치 카드 아이콘과 같은 brand-light 톤으로 보정했습니다.
- 유저 채널 팔로우 버튼의 다크모드 대비를 개선해 Lighthouse contrast 경고를 완화했습니다.

[📱 Interaction]
- BottomSheet 드래그 닫기를 pointer event 기반으로 변경해 좁은 PC 뷰포트에서도 마우스 드래그가 동작하도록 보강했습니다.
- 푸시 알림 초기 자동 점검의 Service Worker ready 타임아웃을 콘솔 오류/토스트로 노출하지 않도록 완화했습니다.

## Verification
- 시크릿 모드 Lighthouse 재측정 기준 접근성/권장사항 후속 항목 확인
- 다크모드에서 팔로우, 맞팔로잉, FAB, 알림 센터, 위치 섹션 CTA 톤 확인
- 좁은 PC 뷰포트에서 BottomSheet 마우스 드래그 닫기 확인

## Notes
- README 및 docs 관련 변경은 이번 PR에 포함하지 않고 별도 문서 정리 커밋에서 처리합니다.
- Lighthouse Trust & Safety 보안 후속 작업은 별도 브랜치에서 이어서 진행합니다.
- 이번 PR에는 HSTS preload/includeSubDomains, enforced CSP 전환, Trusted Types 같은 보안 정책 변경은 포함하지 않았습니다.
