### PR TITLE
🤝 Merge : CSP Report-Only 3차 QA 보정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -46,6 +46,8 @@ const cloudflareStreamOrigin = normalizeOrigin(
   process.env.NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN
 );
 const kakaoMapsOrigin = "https://dapi.kakao.com";
+const enableStrictScriptReportOnly =
+  process.env.CSP_STRICT_SCRIPT_REPORT_ONLY === "true";
 
 const imageOrigins = unique([
   "https://avatars.githubusercontent.com",
@@ -60,6 +62,12 @@ const imageOrigins = unique([
 ]);
 
 const scriptOrigins = unique([kakaoMapsOrigin, "https://t1.daumcdn.net"]);
+const scriptSources = unique([
+  "'self'",
+  // Preview 전용 실험 플래그가 켜지면 unsafe-inline 없이 Report-Only 위반을 관찰한다.
+  enableStrictScriptReportOnly ? null : "'unsafe-inline'",
+  ...scriptOrigins,
+]);
 const connectOrigins = unique([
   supabaseOrigin,
   supabaseWsOrigin,
@@ -86,8 +94,7 @@ const cspReportOnly = [
   buildDirective("font-src", ["'self'", "data:"]),
   // next-themes 초기 인라인 스크립트 가능성을 고려한 1차 관찰용 임시 허용값
   buildDirective("style-src", ["'self'", "'unsafe-inline'"]),
-  // Report-Only 관찰 단계에서는 인라인 스크립트를 임시 허용하고 2차에서 축소를 검토
-  buildDirective("script-src", ["'self'", "'unsafe-inline'", ...scriptOrigins]),
+  buildDirective("script-src", scriptSources),
   buildDirective("connect-src", ["'self'", ...connectOrigins]),
   buildDirective("frame-src", ["'self'", ...frameOrigins]),
   buildDirective("worker-src", ["'self'", "blob:"]),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -46,8 +46,6 @@ const cloudflareStreamOrigin = normalizeOrigin(
   process.env.NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN
 );
 const kakaoMapsOrigin = "https://dapi.kakao.com";
-const enableStrictScriptReportOnly =
-  process.env.CSP_STRICT_SCRIPT_REPORT_ONLY === "true";
 
 const imageOrigins = unique([
   "https://avatars.githubusercontent.com",
@@ -62,17 +60,12 @@ const imageOrigins = unique([
 ]);
 
 const scriptOrigins = unique([kakaoMapsOrigin, "https://t1.daumcdn.net"]);
-const scriptSources = unique([
-  "'self'",
-  // Preview 전용 실험 플래그가 켜지면 unsafe-inline 없이 Report-Only 위반을 관찰한다.
-  enableStrictScriptReportOnly ? null : "'unsafe-inline'",
-  ...scriptOrigins,
-]);
 const connectOrigins = unique([
   supabaseOrigin,
   supabaseWsOrigin,
   kakaoMapsOrigin,
   "https://t1.daumcdn.net",
+  "https://mts.daumcdn.net",
   "https://imagedelivery.net",
   "https://upload.imagedelivery.net",
   "https://upload.cloudflarestream.com",
@@ -92,9 +85,10 @@ const cspReportOnly = [
   buildDirective("frame-ancestors", ["'self'"]),
   buildDirective("img-src", ["'self'", "data:", "blob:", ...imageOrigins]),
   buildDirective("font-src", ["'self'", "data:"]),
-  // next-themes 초기 인라인 스크립트 가능성을 고려한 1차 관찰용 임시 허용값
+  // next-themes 초기 인라인 스크립트 가능성을 고려해 Report-Only 정책에서는 유지한다.
   buildDirective("style-src", ["'self'", "'unsafe-inline'"]),
-  buildDirective("script-src", scriptSources),
+  // Next/App Router 초기 inline payload와 next-themes bootstrap을 고려해 Report-Only 정책에서는 유지한다.
+  buildDirective("script-src", ["'self'", "'unsafe-inline'", ...scriptOrigins]),
   buildDirective("connect-src", ["'self'", ...connectOrigins]),
   buildDirective("frame-src", ["'self'", ...frameOrigins]),
   buildDirective("worker-src", ["'self'", "blob:"]),


### PR DESCRIPTION
## Summary
보안 헤더 3차 QA에서 확인한 CSP Report-Only 정책 보정 사항을 코드에 반영했습니다.

이번 PR은 enforced CSP 전환이 아니라, `script-src 'unsafe-inline'` 제거 가능성을 Preview 환경에서 검증하고, 운영 기본 정책에서는 안정성을 우선해 기존 Report-Only 범위를 유지하는 보정 작업입니다.

## Changes
[🧪 CSP QA]
- Preview 환경에서 `script-src 'unsafe-inline'` 제거 실험을 진행할 수 있도록 임시 실험 플래그를 추가했습니다.
- 직접 진입/새로고침 흐름에서 Next/App Router 초기 inline payload와 `next-themes` bootstrap 계열 위반이 관찰되어, 운영 기본 정책에서는 `script-src 'unsafe-inline'`을 유지하는 방향으로 정리했습니다.
- QA 이후 strict script 실험 플래그는 최종 코드에서 제거했습니다.

[🛡️ Security Headers]
- Kakao Maps 지도 타일이 Workbox fetch 경로로 처리되는 것을 반영해 `connect-src`에 `https://mts.daumcdn.net`을 추가했습니다.
- enforced CSP, nonce 기반 strict CSP, Trusted Types, COEP/CORP는 코드 반영 범위에 포함하지 않았습니다.
- Kakao Maps `unsafe-eval`은 허용하지 않고, 현행 CSP Report-Only 관찰 범위를 유지했습니다.

## Verification
- Vercel Preview에서 CSP Report-Only 응답 헤더 확인
- `/`, `/products`, `/profile`, 녹화 상세 직접 진입/새로고침 기준 `unsafe-inline` 제거 실험 로그 확인
- Kakao Maps 지도 타일 Workbox 경유 `connect-src` 위반 출처 확인
- PWA Service Worker `activated and is running` 상태 확인
- Cloudflare Images 업로드 및 Cloudflare Stream iframe 재생 흐름 확인
- YouTube embed 재생 흐름 확인

## Notes
- 이번 PR에는 enforced `Content-Security-Policy` 전환을 포함하지 않았습니다.
- CSP report 자동 수집 endpoint는 추가하지 않았습니다.
- Vercel Live, YouTube player 통계/추적 요청 출처는 whitelist에 추가하지 않았습니다.
