### PR TITLE
🤝 Merge : 관리자 신고 처리 UX 및 감사 로그 표시 보강

### DIFF
--- a/components/global/BottomSheet.tsx
+++ b/components/global/BottomSheet.tsx
@@ -9,6 +9,7 @@
  * 2026.03.12  임도헌   Modified  공용 bodyScrollLock 유틸 적용으로 검색 모달 등과 중첩되어도 스크롤 잠금/복구 안정화
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.26  임도헌   Modified  드래그 닫기를 pointer 이벤트로 통합해 PC 좁은 viewport의 마우스 드래그도 지원
+ * 2026.04.28  임도헌   Modified  닫기 버튼 등 상호작용 요소 클릭이 드래그 시작으로 처리되지 않도록 보강
  */
 
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
@@ -34,6 +35,7 @@ interface BottomSheetProps {
  * [상호작용]
  * - 포털 렌더링으로 상위 stacking context 영향 없이 화면 최상단에 노출
  * - ESC, 백드롭 클릭, 드래그 다운 제스처로 닫기 지원
+ * - 닫기 버튼, 링크, 입력 요소처럼 클릭 가능한 영역은 드래그 시작 대상에서 제외
  * - 열릴 때 포커스를 시트 내부로 이동시키고 닫힐 때 기존 포커스로 복귀
  */
 export default function BottomSheet({
@@ -119,6 +121,15 @@ export default function BottomSheet({
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.pointerType === "mouse" && event.button !== 0) return;
+    const target = event.target as HTMLElement | null;
+    // 닫기 버튼이나 입력 컨트롤 조작이 드래그 시작으로 오인되지 않도록 제외
+    if (
+      target?.closest(
+        'a,button,input,textarea,select,[role="button"],[data-drag-ignore="true"]'
+      )
+    ) {
+      return;
+    }
 
     dragStartYRef.current = event.clientY;
     dragCurrentYRef.current = 0;

--- a/features/report/actions/admin.ts
+++ b/features/report/actions/admin.ts
@@ -9,6 +9,7 @@
  * 2026.03.10  임도헌   Modified  신고 승인 시 조치 유형(payload) 전달과 목록 리밸리데이션 흐름 반영
  * 2026.03.30  임도헌   Modified  신고 인사이트 조회 액션을 추가하고 관리자 페이지를 action 계층으로 통일
  * 2026.04.03  임도헌   Modified  관리자 신고 목록 필터 타입 import를 report/types 공용 정의로 정리
+ * 2026.04.27  임도헌   Modified  기각 처리도 관리자 코멘트 payload를 전달할 수 있도록 입력 타입 확장
  */
 
 "use server";
@@ -25,8 +26,8 @@ import type {
   AdminReportInsights,
   AdminReportListResponse,
   ReportFilter,
+  ReportStatusInput,
 } from "@/features/report/types";
-import type { ReportResolutionInput } from "@/features/report/types";
 
 /**
  * 신고 목록 조회 Action
@@ -79,13 +80,13 @@ export async function getReportInsightsAction(): Promise<
  *
  * @param reportId - 대상 신고 ID
  * @param status - 변경할 상태
- * @param resolution - 관리자 처리 payload (선택)
+ * @param resolution - 승인 조치 또는 기각 사유 payload (선택)
  * @returns {Promise<ServiceResult>} 처리 결과
  */
 export async function updateReportAction(
   reportId: number,
   status: "RESOLVED" | "DISMISSED",
-  resolution?: ReportResolutionInput
+  resolution?: ReportStatusInput
 ): Promise<ServiceResult> {
   // 권한 및 adminId 확보
   const auth = await verifyAdminAccess();

--- a/features/report/components/admin/AdminActionModal.tsx
+++ b/features/report/components/admin/AdminActionModal.tsx
@@ -14,11 +14,14 @@
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.26  임도헌   Modified  관리자 액션 모달에 dialog 의미와 설명/입력 라벨 연결, ESC 닫기 흐름을 보강
  * 2026.04.26  임도헌   Modified  primary 확인 버튼의 다크모드 색조를 공용 CTA 톤과 맞춰 정리
+ * 2026.04.28  임도헌   Modified  모바일 관리자 액션을 공용 BottomSheet로 분기해 작은 화면의 입력/버튼 잘림을 완화
  */
 
 import { useEffect, useRef, useState, useTransition } from "react";
+import BottomSheet from "@/components/global/BottomSheet";
 import { cn } from "@/lib/utils";
 import Select from "@/components/ui/Select";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 interface AdminActionModalProps {
   open: boolean;
@@ -56,6 +59,7 @@ interface AdminActionModalProps {
  * 3. 비동기 처리 중 로딩 상태 표시 및 버튼 비활성화
  * 4. 삭제/정지/권한 변경처럼 관리자 확인이 필요한 액션을 공통 문법으로 재사용
  * 5. Audit Log 기록을 위한 필수 메타데이터 확보
+ * 6. 모바일은 BottomSheet, 데스크톱은 중앙 모달로 분기해 입력/버튼 접근성 유지
  */
 export default function AdminActionModal({
   open,
@@ -75,6 +79,7 @@ export default function AdminActionModal({
   const [banDuration, setBanDuration] = useState(0); // 0: 영구
   const [isPending, startTransition] = useTransition();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
   // 모달 종료 시 입력 상태 초기화
   // 같은 모달을 여러 대상에 재사용하므로 닫힐 때 사유와 기간을 기본값으로 초기화
@@ -86,7 +91,7 @@ export default function AdminActionModal({
   }, [open]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || isMobile) return;
 
     const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -98,7 +103,7 @@ export default function AdminActionModal({
       window.clearTimeout(timer);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isPending, onClose, open]);
+  }, [isMobile, isPending, onClose, open]);
 
   if (!open) return null;
 
@@ -125,8 +130,107 @@ export default function AdminActionModal({
     success: "bg-emerald-600 text-white hover:bg-emerald-700",
   };
 
+  const content = (
+    <div className="space-y-4">
+      {showBanOptions && (
+        <div>
+          <label
+            htmlFor="admin-action-ban-duration"
+            className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
+          >
+            정지 기간
+          </label>
+          <Select
+            id="admin-action-ban-duration"
+            value={banDuration}
+            onChange={(e) => setBanDuration(Number(e.target.value))}
+            className="bg-surface-dim border-transparent"
+          >
+            <option value={0}>영구 정지 (Permanent)</option>
+            <option value={1}>1일 정지</option>
+            <option value={3}>3일 정지</option>
+            <option value={7}>7일 정지</option>
+            <option value={30}>30일 정지</option>
+          </Select>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label
+          htmlFor="admin-action-reason"
+          className="text-xs font-bold text-muted uppercase tracking-wider"
+        >
+          사유 입력 <span className="text-danger">*</span>
+        </label>
+        <textarea
+          id="admin-action-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          disabled={isPending}
+          placeholder={placeholder}
+          className="input-primary h-32 w-full resize-none border-none bg-surface-dim p-4 text-sm focus:ring-brand/15 dark:focus:ring-brand-light/15"
+        />
+        <p className="text-xs text-right text-muted">
+          {reason.length} / {minReasonLength}자 이상
+        </p>
+      </div>
+    </div>
+  );
+
+  const footer = (
+    <div className="flex flex-col justify-end gap-3 sm:flex-row">
+      <button
+        onClick={onClose}
+        disabled={isPending}
+        className="btn-secondary-modal flex-1 px-4 text-sm font-medium sm:flex-none"
+      >
+        취소
+      </button>
+
+      {secondaryLabel && onSecondaryAction && (
+        <button
+          onClick={handleSecondary}
+          disabled={isPending}
+          className="btn-secondary flex-1 sm:flex-none border-border"
+        >
+          {secondaryLabel}
+        </button>
+      )}
+
+      <button
+        onClick={handleConfirm}
+        disabled={isPending || reason.trim().length < minReasonLength}
+        className={cn(
+          "focus-ring-strong flex items-center justify-center gap-2 rounded-xl px-6 py-2.5 text-sm font-bold shadow-sm transition-[background-color,color,border-color,box-shadow,opacity] disabled:opacity-50",
+          variantClasses[confirmVariant]
+        )}
+      >
+        {isPending && (
+          <span className="size-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+        )}
+        {confirmLabel}
+      </button>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open
+        title={title}
+        description={description}
+        onClose={onClose}
+        footer={footer}
+        contentClassName="pt-4"
+        panelClassName="max-h-[90dvh]"
+      >
+        {content}
+      </BottomSheet>
+    );
+  }
+
   return (
-    <div className="fixed inset-0 z-[100] flex items-end justify-center bg-black/60 px-4 pt-6 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-sm sm:items-center sm:p-4">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
       <div
         ref={dialogRef}
         role="dialog"
@@ -134,7 +238,7 @@ export default function AdminActionModal({
         aria-labelledby="admin-action-title"
         aria-describedby="admin-action-description"
         tabIndex={-1}
-        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl"
+        className="flex max-h-[calc(100dvh-2rem)] w-full max-w-md flex-col overflow-hidden rounded-3xl border border-border-subtle bg-surface shadow-2xl"
       >
         <div className="flex-1 overflow-y-auto p-6">
           <h3 id="admin-action-title" className="text-xl font-bold text-primary">
@@ -146,85 +250,11 @@ export default function AdminActionModal({
           >
             {description}
           </p>
-
-          <div className="space-y-4">
-            {showBanOptions && (
-              <div>
-                <label
-                  htmlFor="admin-action-ban-duration"
-                  className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
-                >
-                  정지 기간
-                </label>
-                <Select
-                  id="admin-action-ban-duration"
-                  value={banDuration}
-                  onChange={(e) => setBanDuration(Number(e.target.value))}
-                  className="bg-surface-dim border-transparent"
-                >
-                  <option value={0}>영구 정지 (Permanent)</option>
-                  <option value={1}>1일 정지</option>
-                  <option value={3}>3일 정지</option>
-                  <option value={7}>7일 정지</option>
-                  <option value={30}>30일 정지</option>
-                </Select>
-              </div>
-            )}
-
-            <div className="space-y-2">
-              <label
-                htmlFor="admin-action-reason"
-                className="text-xs font-bold text-muted uppercase tracking-wider"
-              >
-                사유 입력 <span className="text-danger">*</span>
-              </label>
-              <textarea
-                id="admin-action-reason"
-                value={reason}
-                onChange={(e) => setReason(e.target.value)}
-                disabled={isPending}
-                placeholder={placeholder}
-                className="input-primary h-32 w-full resize-none border-none bg-surface-dim p-4 text-sm focus:ring-brand/15 dark:focus:ring-brand-light/15"
-              />
-              <p className="text-xs text-right text-muted">
-                {reason.length} / {minReasonLength}자 이상
-              </p>
-            </div>
-          </div>
+          {content}
         </div>
 
-        <div className="shrink-0 flex flex-col justify-end gap-3 border-t border-border-subtle bg-surface px-6 py-4 sm:flex-row">
-          <button
-            onClick={onClose}
-            disabled={isPending}
-            className="btn-secondary-modal flex-1 px-4 text-sm font-medium sm:flex-none"
-          >
-            취소
-          </button>
-
-          {secondaryLabel && onSecondaryAction && (
-            <button
-              onClick={handleSecondary}
-              disabled={isPending}
-              className="btn-secondary flex-1 sm:flex-none border-border"
-            >
-              {secondaryLabel}
-            </button>
-          )}
-
-          <button
-            onClick={handleConfirm}
-            disabled={isPending || reason.trim().length < minReasonLength}
-            className={cn(
-              "focus-ring-strong px-6 py-2.5 text-sm font-bold rounded-xl shadow-sm transition-[background-color,color,border-color,box-shadow,opacity] disabled:opacity-50 flex items-center justify-center gap-2",
-              variantClasses[confirmVariant]
-            )}
-          >
-            {isPending && (
-              <span className="size-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-            )}
-            {confirmLabel}
-          </button>
+        <div className="shrink-0 border-t border-border-subtle bg-surface px-6 py-4">
+          {footer}
         </div>
       </div>
     </div>

--- a/features/report/components/admin/AdminAuditLogListContainer.tsx
+++ b/features/report/components/admin/AdminAuditLogListContainer.tsx
@@ -13,6 +13,8 @@
  * 2026.04.10  임도헌   Modified  감사 로그 카드와 테이블의 배지·메타 타이포를 400·500·700 정책에 맞춰 정리
  * 2026.04.18  임도헌   Modified  모바일 카드 lazy paint, 액션/ID 배지 대비, 상세 링크 프리패치를 최적화
  * 2026.04.19  임도헌   Modified  액션/대상 타입 필터 칩에 공용 포커스 링을 적용해 관리자 목록 포커스 문법을 통일
+ * 2026.04.28  임도헌   Modified  신고 제재 관련 감사 로그 사유를 운영자가 읽기 쉬운 한글 요약으로 포맷
+ * 2026.04.28  임도헌   Modified  삭제 감사 로그의 OwnerID 옆에 유저명을 함께 표시
  */
 
 "use client";
@@ -24,7 +26,10 @@ import AdminSearchBar from "@/features/report/components/admin/AdminSearchBar";
 import TimeAgo from "@/components/ui/TimeAgo";
 import AdminPagination from "@/features/report/components/admin/AdminPagination";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
-import { getAuditLogTargetUrl } from "@/features/report/utils/adminFormatter";
+import {
+  formatAuditReason,
+  getAuditLogTargetUrl,
+} from "@/features/report/utils/adminFormatter";
 import { cn } from "@/lib/utils";
 import {
   AUDIT_ACTION_LABELS,
@@ -46,6 +51,7 @@ interface Props {
  * 2. 데스크톱 테이블과 모바일 카드형 레이아웃으로 감사 로그를 읽기 쉽게 분기
  * 3. 로그 액션 타입에 따라 시각적 배지를 차별화하고, 추적 가능한 대상은 바로가기 링크를 연결
  * 4. 구조화된 사유를 파싱해 원인과 메타 정보를 분리해 보여주고 페이지네이션을 통합
+ * 5. 삭제 로그의 소유자 ID는 유저명과 함께 표시해 삭제 후에도 대상 식별성을 유지
  */
 export default function AdminAuditLogListContainer({
   data,
@@ -167,15 +173,11 @@ export default function AdminAuditLogListContainer({
             const isInfo = ["CHANGE_ROLE", "DISMISS_REPORT"].includes(
               log.action
             );
-            const isStructured = log.reason?.includes("Title:");
-            let displayReason = log.reason;
-            let metaInfo = "";
-
-            if (isStructured && log.reason) {
-              const parts = log.reason.split(" / ");
-              displayReason = parts[parts.length - 1].replace("Reason: ", "");
-              metaInfo = parts.slice(0, parts.length - 1).join(" | ");
-            }
+            const { displayReason, metaInfo } = formatAuditReason(
+              log.action,
+              log.reason,
+              { reasonOwnerUsername: log.reasonOwnerUsername }
+            );
 
             return (
               <article
@@ -292,19 +294,11 @@ export default function AdminAuditLogListContainer({
                     log.action
                   );
 
-                  // 구조화된 감사 로그 문구는 메타와 실제 사유를 분리해 스캔하기 쉽게 노출
-                  const isStructured = log.reason?.includes("Title:");
-                  let displayReason = log.reason;
-                  let metaInfo = "";
-
-                  if (isStructured && log.reason) {
-                    const parts = log.reason.split(" / ");
-                    displayReason = parts[parts.length - 1].replace(
-                      "Reason: ",
-                      ""
-                    );
-                    metaInfo = parts.slice(0, parts.length - 1).join(" | ");
-                  }
+                  const { displayReason, metaInfo } = formatAuditReason(
+                    log.action,
+                    log.reason,
+                    { reasonOwnerUsername: log.reasonOwnerUsername }
+                  );
 
                   return (
                     <tr
@@ -366,7 +360,7 @@ export default function AdminAuditLogListContainer({
                       </td>
                       <td className="px-6 py-4">
                         <div className="flex flex-col gap-0.5 max-w-md whitespace-normal">
-                          {isStructured && metaInfo && (
+                          {metaInfo && (
                             <span className="text-xs text-muted/60 truncate">
                               {metaInfo}
                             </span>

--- a/features/report/components/admin/AdminReportListContainer.tsx
+++ b/features/report/components/admin/AdminReportListContainer.tsx
@@ -16,6 +16,8 @@
  * 2026.03.30  임도헌   Modified  신고 처리 모달 자동 오픈, 대상 식별자/부모 문맥 표시, 내부 admin 링크 same-tab 동선을 함께 보강
  * 2026.04.10  임도헌   Modified  신고 목록 카드와 테이블의 배지·메타 타이포를 400·500·700 정책에 맞춰 정리
  * 2026.04.18  임도헌   Modified  초기 번들 부담을 줄이기 위해 처리 모달을 지연 로딩하고 내부 링크 프리패치를 제한
+ * 2026.04.27  임도헌   Modified  신고 처리 모달이 대상 타입에 맞춰 조치 추천을 보정할 수 있도록 targetType 전달
+ * 2026.04.28  임도헌   Modified  신고 처리 모달에 실제 조치 대상 유저 메타를 전달
  */
 
 "use client";
@@ -36,6 +38,7 @@ import {
   getReportTargetId,
   getReportTargetParentId,
   getReportTargetParentLabel,
+  getReportTargetType,
   getParentContextUrl,
   getTargetUrl,
 } from "@/features/report/utils/adminFormatter";
@@ -67,6 +70,7 @@ interface AdminReportListContainerProps {
  * 4. 최근 90일 strike 누적치와 관리자 조치 내역을 함께 보여줌
  * 5. `open` 파라미터로 특정 신고 처리 모달을 자동으로 열 수 있음
  * 6. 처리 성공 시 현재 탭 기준에 맞춰 낙관적 업데이트와 목록 제거를 반영
+ * 7. 처리 모달이 조치 대상 유저와 대상 타입을 알 수 있도록 메타를 전달
  */
 export default function AdminReportListContainer({
   data,
@@ -463,6 +467,8 @@ export default function AdminReportListContainer({
             selectedReport ? getReportTargetParentId(selectedReport) : null
           }
           targetParentPreview={selectedReport?.targetParentPreview ?? null}
+          targetResolvedUserId={selectedReport?.targetResolvedUserId ?? null}
+          targetResolvedUsername={selectedReport?.targetResolvedUsername ?? null}
           targetUrl={
             selectedReport ? getDirectTargetUrl(selectedReport, returnTo) : null
           }
@@ -470,6 +476,9 @@ export default function AdminReportListContainer({
             selectedReport
               ? getParentContextUrl(selectedReport, returnTo)
               : null
+          }
+          targetType={
+            selectedReport ? getReportTargetType(selectedReport) : undefined
           }
           reportStatus={selectedReport?.status}
           existingAdminComment={selectedReport?.adminComment ?? null}

--- a/features/report/components/admin/ReportActionDialog.tsx
+++ b/features/report/components/admin/ReportActionDialog.tsx
@@ -18,11 +18,15 @@
  * 2026.04.18  임도헌   Modified  내부 대상 링크 프리패치를 비활성화해 모달 진입 전 불필요한 선요청을 줄임
  * 2026.04.19  임도헌   Modified  관련 콘텐츠 삭제 체크박스에 공용 포커스 링을 적용해 관리자 폼 포커스 문법을 통일
  * 2026.04.26  임도헌   Modified  신고 처리 모달에 dialog 의미와 설명/폼 라벨 연결, ESC 닫기 흐름을 보강
+ * 2026.04.27  임도헌   Modified  기각 사유 전달과 유저 단독 신고의 콘텐츠 삭제 추천 제외 흐름 보강
+ * 2026.04.28  임도헌   Modified  모바일 신고 처리 UI를 공용 BottomSheet로 분기해 작은 화면의 잘림을 완화
+ * 2026.04.28  임도헌   Modified  신고 처리 전 실제 조치 대상 유저를 모달에서 확인할 수 있도록 표시 보강
  */
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
+import BottomSheet from "@/components/global/BottomSheet";
 import { updateReportAction } from "@/features/report/actions/admin";
 import Select from "@/components/ui/Select";
 import {
@@ -35,6 +39,7 @@ import {
 } from "@/features/report/constants";
 import type { ReportReason } from "@/generated/prisma/client";
 import type { ReportResolutionAction } from "@/features/report/types";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { cn } from "@/lib/utils";
 
 interface ReportActionDialogProps {
@@ -49,8 +54,11 @@ interface ReportActionDialogProps {
   targetParentLabel?: string | null;
   targetParentId?: number | null;
   targetParentPreview?: string | null;
+  targetResolvedUserId?: number | null;
+  targetResolvedUsername?: string | null;
   targetUrl?: string | null;
   targetParentUrl?: string | null;
+  targetType?: string;
   reportStatus?: string;
   existingAdminComment?: string | null;
   open: boolean;
@@ -71,7 +79,9 @@ interface ReportActionDialogProps {
  * 2. 신고 원문과 신고 대상 요약을 직접 대상·상위 문맥 2단 구조로 표시
  * 3. 대상과 상위 문맥 화면으로 바로 이동해 실제 원본을 검토할 수 있음
  * 4. '조치 완료(승인)' 또는 '기각' 버튼으로 상태 변경 요청을 수행
- * 5. 이미 처리된 신고는 권장 조치 입력 UI 없이 읽기 전용 기록으로 열람
+ * 5. 댓글/리뷰/메시지처럼 간접 대상도 실제 조치 대상 유저를 함께 표시
+ * 6. 모바일은 BottomSheet, 데스크톱은 중앙 모달로 분기
+ * 7. 이미 처리된 신고는 권장 조치 입력 UI 없이 읽기 전용 기록으로 열람
  */
 export default function ReportActionDialog({
   reportId,
@@ -85,43 +95,72 @@ export default function ReportActionDialog({
   targetParentLabel,
   targetParentId,
   targetParentPreview,
+  targetResolvedUserId,
+  targetResolvedUsername,
   targetUrl,
   targetParentUrl,
+  targetType,
   reportStatus = "PENDING",
   existingAdminComment,
   open,
   onClose,
   onSuccess,
 }: ReportActionDialogProps) {
+  // 유저 단독 신고는 삭제 가능한 직접 콘텐츠가 없으므로 삭제 조치를 추천/선택지에서 제외
+  const supportsContentDeletion = targetType !== "USER";
   const recommended = useMemo(
     () => getRecommendedResolution(reportReason, currentStrikeTotal),
     [reportReason, currentStrikeTotal]
   );
+  const effectiveRecommended = useMemo(() => {
+    if (supportsContentDeletion) return recommended;
+
+    return {
+      ...recommended,
+      action:
+        recommended.action === REPORT_RESOLUTION_ACTIONS.DELETE_CONTENT
+          ? REPORT_RESOLUTION_ACTIONS.WARN
+          : recommended.action,
+      deleteContent: false,
+    };
+  }, [recommended, supportsContentDeletion]);
+  const availableActions = useMemo(
+    () =>
+      Object.entries(REPORT_RESOLUTION_ACTION_LABELS).filter(
+        ([value]) =>
+          supportsContentDeletion ||
+          value !== REPORT_RESOLUTION_ACTIONS.DELETE_CONTENT
+      ),
+    [supportsContentDeletion]
+  );
   const [comment, setComment] = useState("");
   const [action, setAction] = useState<ReportResolutionAction>(
-    recommended.action
+    effectiveRecommended.action
   );
   const [durationDays, setDurationDays] = useState<number>(
-    recommended.durationDays ?? REPORT_BAN_DURATIONS.THREE_DAYS
+    effectiveRecommended.durationDays ?? REPORT_BAN_DURATIONS.THREE_DAYS
   );
-  const [deleteContent, setDeleteContent] = useState(recommended.deleteContent);
+  const [deleteContent, setDeleteContent] = useState(
+    effectiveRecommended.deleteContent
+  );
   const [isPending, startTransition] = useTransition();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
   const isReadOnly = reportStatus !== "PENDING";
 
   useEffect(() => {
     if (!open) return;
 
     setComment(existingAdminComment ?? "");
-    setAction(recommended.action);
+    setAction(effectiveRecommended.action);
     setDurationDays(
-      recommended.durationDays ?? REPORT_BAN_DURATIONS.THREE_DAYS
+      effectiveRecommended.durationDays ?? REPORT_BAN_DURATIONS.THREE_DAYS
     );
-    setDeleteContent(recommended.deleteContent);
-  }, [existingAdminComment, open, recommended]);
+    setDeleteContent(effectiveRecommended.deleteContent);
+  }, [effectiveRecommended, existingAdminComment, open]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || isMobile) return;
 
     const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -133,7 +172,7 @@ export default function ReportActionDialog({
       window.clearTimeout(timer);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isPending, onClose, open]);
+  }, [isMobile, isPending, onClose, open]);
 
   if (!open) return null;
 
@@ -148,8 +187,8 @@ export default function ReportActionDialog({
               adminComment: comment,
               strike:
                 action === REPORT_RESOLUTION_ACTIONS.PERMA_BAN
-                  ? Math.max(recommended.strike, 2)
-                  : recommended.strike,
+                  ? Math.max(effectiveRecommended.strike, 2)
+                  : effectiveRecommended.strike,
               durationDays:
                 action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN
                   ? durationDays
@@ -161,7 +200,7 @@ export default function ReportActionDialog({
                   ? true
                   : deleteContent,
             }
-          : undefined
+          : { adminComment: comment }
       );
       if (res.success) {
         toast.success(
@@ -175,8 +214,8 @@ export default function ReportActionDialog({
           comment,
           status === "RESOLVED"
             ? action === REPORT_RESOLUTION_ACTIONS.PERMA_BAN
-              ? Math.max(recommended.strike, 2)
-              : recommended.strike
+              ? Math.max(effectiveRecommended.strike, 2)
+              : effectiveRecommended.strike
             : 0
         );
         onClose();
@@ -186,8 +225,288 @@ export default function ReportActionDialog({
     });
   };
 
+  const dialogDescription = isReadOnly
+    ? "이미 처리된 신고의 조치 내역입니다."
+    : "조치 내용이나 기각 사유를 입력하세요.";
+
+  const content = (
+    <>
+      <div className="mb-4 rounded-2xl border border-border-subtle bg-surface-dim/60 p-4 space-y-2">
+        <div className="flex items-center justify-between gap-3 text-xs">
+          <span className="font-bold text-primary">
+            신고 사유: {REPORT_REASON_LABELS[reportReason]}
+          </span>
+          <span
+            className={cn(
+              "rounded-full px-2 py-1 font-bold",
+              currentStrikeTotal > 0
+                ? "bg-danger/10 text-danger"
+                : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+            )}
+          >
+            현재 누적 strike {currentStrikeTotal}회
+          </span>
+        </div>
+        {!isReadOnly && (
+          <>
+            <div className="text-xs text-muted">
+              권장 조치:{" "}
+              <span className="font-bold text-primary">
+                {REPORT_RESOLUTION_ACTION_LABELS[effectiveRecommended.action]}
+              </span>
+              {effectiveRecommended.action ===
+                REPORT_RESOLUTION_ACTIONS.TEMP_BAN &&
+                effectiveRecommended.durationDays && (
+                  <span className="font-bold text-primary">
+                    {" "}
+                    / {effectiveRecommended.durationDays}일 정지
+                  </span>
+                )}
+              <span className="ml-1">
+                / 이번 strike {effectiveRecommended.strike}회
+              </span>
+            </div>
+            <p className="text-xs text-muted leading-relaxed">
+              {
+                REPORT_RESOLUTION_ACTION_DESCRIPTIONS[
+                  effectiveRecommended.action
+                ]
+              }
+            </p>
+          </>
+        )}
+      </div>
+
+      <div className="mb-4 rounded-2xl border border-border-subtle bg-surface p-4 space-y-3">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full bg-surface-dim px-2 py-1 font-bold text-primary">
+            신고 #{reportId}
+          </span>
+          {reporterUsername ? (
+            <span className="rounded-full bg-surface-dim px-2 py-1 font-medium text-muted">
+              신고자 {reporterUsername}
+            </span>
+          ) : null}
+        </div>
+
+        {(targetLabel && targetId) || targetParentLabel ? (
+          <div className="rounded-xl bg-surface-dim/40 px-3 py-3">
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-muted">
+              신고 대상
+            </p>
+            <div className="mt-3 space-y-3">
+              {targetResolvedUserId ? (
+                <div className="rounded-lg border border-border-subtle bg-surface/70 px-3 py-2">
+                  <p className="text-xs font-bold text-muted">
+                    조치 대상 유저
+                  </p>
+                  <p className="mt-1 text-sm font-bold text-primary">
+                    {targetResolvedUsername || "이름 없음"} #
+                    {targetResolvedUserId}
+                  </p>
+                </div>
+              ) : null}
+
+              {targetLabel && targetId ? (
+                <div>
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-xs font-bold text-muted">직접 대상</p>
+                    {targetUrl ? (
+                      <Link
+                        href={targetUrl}
+                        prefetch={false}
+                        target={
+                          targetUrl.startsWith("/admin") ? undefined : "_blank"
+                        }
+                        rel={
+                          targetUrl.startsWith("/admin")
+                            ? undefined
+                            : "noopener noreferrer"
+                        }
+                        className="focus-ring-soft rounded px-1 py-0.5 text-xs font-bold text-brand hover:underline"
+                      >
+                        관련 화면 보기
+                      </Link>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm font-medium text-primary">
+                    {targetLabel} #{targetId}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-muted">
+                    {targetPreview?.trim() || "대상 원문 요약이 없습니다."}
+                  </p>
+                </div>
+              ) : null}
+
+              {targetParentLabel && targetParentId ? (
+                <div className="border-t border-border-subtle pt-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-xs font-bold text-muted">상위 문맥</p>
+                    {targetParentUrl ? (
+                      <Link
+                        href={targetParentUrl}
+                        prefetch={false}
+                        target={
+                          targetParentUrl.startsWith("/admin")
+                            ? undefined
+                            : "_blank"
+                        }
+                        rel={
+                          targetParentUrl.startsWith("/admin")
+                            ? undefined
+                            : "noopener noreferrer"
+                        }
+                        className="focus-ring-soft rounded px-1 py-0.5 text-xs font-bold text-brand hover:underline"
+                      >
+                        원본 열기
+                      </Link>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm font-medium text-primary">
+                    {targetParentLabel} #{targetParentId}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-muted">
+                    {targetParentPreview?.trim() ||
+                      "상위 콘텐츠 요약이 없습니다."}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="rounded-xl bg-surface-dim/40 px-3 py-3">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-muted">
+            신고 내용 원문
+          </p>
+          <p className="mt-2 whitespace-pre-line text-sm leading-6 text-primary">
+            {reportDescription?.trim() || "신고 설명이 입력되지 않았습니다."}
+          </p>
+        </div>
+      </div>
+
+      {!isReadOnly && (
+        <div className="space-y-4 mb-4">
+          <div>
+            <label
+              htmlFor="report-resolution-action"
+              className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
+            >
+              승인 시 조치 유형
+            </label>
+            <Select
+              id="report-resolution-action"
+              value={action}
+              onChange={(e) =>
+                setAction(e.target.value as ReportResolutionAction)
+              }
+              disabled={isPending}
+            >
+              {availableActions.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          {action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN && (
+            <div>
+              <label
+                htmlFor="report-ban-duration"
+                className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
+              >
+                정지 기간
+              </label>
+              <Select
+                id="report-ban-duration"
+                value={durationDays}
+                onChange={(e) => setDurationDays(Number(e.target.value))}
+                disabled={isPending}
+              >
+                <option value={3}>3일</option>
+                <option value={7}>7일</option>
+                <option value={30}>30일</option>
+              </Select>
+            </div>
+          )}
+
+          {supportsContentDeletion &&
+            (action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN ||
+              action === REPORT_RESOLUTION_ACTIONS.PERMA_BAN) && (
+              <label className="flex items-center gap-2 text-sm text-primary">
+                <input
+                  type="checkbox"
+                  checked={deleteContent}
+                  onChange={(e) => setDeleteContent(e.target.checked)}
+                  disabled={isPending}
+                  className="focus-ring-soft size-4 shrink-0 rounded border-border accent-brand dark:accent-brand-light"
+                />
+                관련 콘텐츠도 함께 삭제
+              </label>
+            )}
+        </div>
+      )}
+
+      <textarea
+        aria-label={isReadOnly ? "관리자 기록" : "처리 내용"}
+        className="input-primary w-full h-32 p-4 text-sm resize-none bg-surface-dim border-none"
+        placeholder={isReadOnly ? "관리자 기록" : "처리 내용을 입력하세요..."}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        disabled={isPending || isReadOnly}
+      />
+    </>
+  );
+
+  const footer = (
+    <div className="flex gap-3 justify-end">
+      <button
+        onClick={onClose}
+        disabled={isPending}
+        className="btn-secondary-modal h-10 px-4 text-sm font-medium"
+      >
+        {isReadOnly ? "닫기" : "취소"}
+      </button>
+      {!isReadOnly && (
+        <button
+          onClick={() => handleAction("DISMISSED")}
+          disabled={isPending}
+          className="btn-secondary h-10 text-sm border-border text-primary"
+        >
+          기각
+        </button>
+      )}
+      {!isReadOnly && (
+        <button
+          onClick={() => handleAction("RESOLVED")}
+          disabled={isPending}
+          className="btn-primary h-10 text-sm"
+        >
+          {isPending ? "처리 중..." : "조치 완료"}
+        </button>
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open
+        title="신고 처리"
+        description={dialogDescription}
+        onClose={onClose}
+        footer={footer}
+        contentClassName="pt-4"
+        panelClassName="max-h-[92dvh]"
+      >
+        {content}
+      </BottomSheet>
+    );
+  }
+
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 px-4 pt-6 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-sm sm:items-center sm:p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
       <div
         ref={dialogRef}
         role="dialog"
@@ -195,7 +514,7 @@ export default function ReportActionDialog({
         aria-labelledby="report-action-title"
         aria-describedby="report-action-description"
         tabIndex={-1}
-        className="flex max-h-[calc(100dvh-1rem)] w-full max-w-md flex-col rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl"
+        className="flex max-h-[calc(100dvh-2rem)] w-full max-w-md flex-col overflow-hidden rounded-3xl border border-border-subtle bg-surface shadow-2xl"
       >
         <div className="flex-1 overflow-y-auto p-6">
           <h3
@@ -205,257 +524,13 @@ export default function ReportActionDialog({
             신고 처리
           </h3>
           <p id="report-action-description" className="text-sm text-muted mb-4">
-            {isReadOnly
-              ? "이미 처리된 신고의 조치 내역입니다."
-              : "조치 내용이나 기각 사유를 입력하세요."}
+            {dialogDescription}
           </p>
-
-          <div className="mb-4 rounded-2xl border border-border-subtle bg-surface-dim/60 p-4 space-y-2">
-            <div className="flex items-center justify-between gap-3 text-xs">
-              <span className="font-bold text-primary">
-                신고 사유: {REPORT_REASON_LABELS[reportReason]}
-              </span>
-              <span
-                className={cn(
-                  "rounded-full px-2 py-1 font-bold",
-                  currentStrikeTotal > 0
-                    ? "bg-danger/10 text-danger"
-                    : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                )}
-              >
-                현재 누적 strike {currentStrikeTotal}회
-              </span>
-            </div>
-            {!isReadOnly && (
-              <>
-                <div className="text-xs text-muted">
-                  권장 조치:{" "}
-                  <span className="font-bold text-primary">
-                    {REPORT_RESOLUTION_ACTION_LABELS[recommended.action]}
-                  </span>
-                  {recommended.action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN &&
-                    recommended.durationDays && (
-                      <span className="font-bold text-primary">
-                        {" "}
-                        / {recommended.durationDays}일 정지
-                      </span>
-                    )}
-                  <span className="ml-1">
-                    / 이번 strike {recommended.strike}회
-                  </span>
-                </div>
-                <p className="text-xs text-muted leading-relaxed">
-                  {REPORT_RESOLUTION_ACTION_DESCRIPTIONS[recommended.action]}
-                </p>
-              </>
-            )}
-          </div>
-
-          <div className="mb-4 rounded-2xl border border-border-subtle bg-surface p-4 space-y-3">
-            <div className="flex flex-wrap items-center gap-2 text-xs">
-              <span className="rounded-full bg-surface-dim px-2 py-1 font-bold text-primary">
-                신고 #{reportId}
-              </span>
-              {reporterUsername ? (
-                <span className="rounded-full bg-surface-dim px-2 py-1 font-medium text-muted">
-                  신고자 {reporterUsername}
-                </span>
-              ) : null}
-            </div>
-
-            {(targetLabel && targetId) || targetParentLabel ? (
-              <div className="rounded-xl bg-surface-dim/40 px-3 py-3">
-                <p className="text-xs font-bold uppercase tracking-[0.16em] text-muted">
-                  신고 대상
-                </p>
-                <div className="mt-3 space-y-3">
-                  {targetLabel && targetId ? (
-                    <div>
-                      <div className="flex items-center justify-between gap-3">
-                        <p className="text-xs font-bold text-muted">
-                          직접 대상
-                        </p>
-                        {targetUrl ? (
-                          <Link
-                            href={targetUrl}
-                            prefetch={false}
-                            target={
-                              targetUrl.startsWith("/admin")
-                                ? undefined
-                                : "_blank"
-                            }
-                            rel={
-                              targetUrl.startsWith("/admin")
-                                ? undefined
-                                : "noopener noreferrer"
-                            }
-                            className="focus-ring-soft rounded px-1 py-0.5 text-xs font-bold text-brand hover:underline"
-                          >
-                            관련 화면 보기
-                          </Link>
-                        ) : null}
-                      </div>
-                      <p className="mt-1 text-sm font-medium text-primary">
-                        {targetLabel} #{targetId}
-                      </p>
-                      <p className="mt-1 text-xs leading-5 text-muted">
-                        {targetPreview?.trim() || "대상 원문 요약이 없습니다."}
-                      </p>
-                    </div>
-                  ) : null}
-
-                  {targetParentLabel && targetParentId ? (
-                    <div className="border-t border-border-subtle pt-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <p className="text-xs font-bold text-muted">
-                          상위 문맥
-                        </p>
-                        {targetParentUrl ? (
-                          <Link
-                            href={targetParentUrl}
-                            prefetch={false}
-                            target={
-                              targetParentUrl.startsWith("/admin")
-                                ? undefined
-                                : "_blank"
-                            }
-                            rel={
-                              targetParentUrl.startsWith("/admin")
-                                ? undefined
-                                : "noopener noreferrer"
-                            }
-                            className="focus-ring-soft rounded px-1 py-0.5 text-xs font-bold text-brand hover:underline"
-                          >
-                            원본 열기
-                          </Link>
-                        ) : null}
-                      </div>
-                      <p className="mt-1 text-sm font-medium text-primary">
-                        {targetParentLabel} #{targetParentId}
-                      </p>
-                      <p className="mt-1 text-xs leading-5 text-muted">
-                        {targetParentPreview?.trim() ||
-                          "상위 콘텐츠 요약이 없습니다."}
-                      </p>
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            ) : null}
-
-            <div className="rounded-xl bg-surface-dim/40 px-3 py-3">
-              <p className="text-xs font-bold uppercase tracking-[0.16em] text-muted">
-                신고 내용 원문
-              </p>
-              <p className="mt-2 whitespace-pre-line text-sm leading-6 text-primary">
-                {reportDescription?.trim() ||
-                  "신고 설명이 입력되지 않았습니다."}
-              </p>
-            </div>
-          </div>
-
-          {!isReadOnly && (
-            <div className="space-y-4 mb-4">
-              <div>
-                <label
-                  htmlFor="report-resolution-action"
-                  className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
-                >
-                  승인 시 조치 유형
-                </label>
-                <Select
-                  id="report-resolution-action"
-                  value={action}
-                  onChange={(e) =>
-                    setAction(e.target.value as ReportResolutionAction)
-                  }
-                  disabled={isPending}
-                >
-                  {Object.entries(REPORT_RESOLUTION_ACTION_LABELS).map(
-                    ([value, label]) => (
-                      <option key={value} value={value}>
-                        {label}
-                      </option>
-                    )
-                  )}
-                </Select>
-              </div>
-
-              {action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN && (
-                <div>
-                  <label
-                    htmlFor="report-ban-duration"
-                    className="text-xs font-bold text-muted uppercase tracking-wider mb-1.5 block"
-                  >
-                    정지 기간
-                  </label>
-                  <Select
-                    id="report-ban-duration"
-                    value={durationDays}
-                    onChange={(e) => setDurationDays(Number(e.target.value))}
-                    disabled={isPending}
-                  >
-                    <option value={3}>3일</option>
-                    <option value={7}>7일</option>
-                    <option value={30}>30일</option>
-                  </Select>
-                </div>
-              )}
-
-              {(action === REPORT_RESOLUTION_ACTIONS.TEMP_BAN ||
-                action === REPORT_RESOLUTION_ACTIONS.PERMA_BAN) && (
-                <label className="flex items-center gap-2 text-sm text-primary">
-                  <input
-                    type="checkbox"
-                    checked={deleteContent}
-                    onChange={(e) => setDeleteContent(e.target.checked)}
-                    disabled={isPending}
-                    className="focus-ring-soft size-4 shrink-0 rounded border-border accent-brand dark:accent-brand-light"
-                  />
-                  관련 콘텐츠도 함께 삭제
-                </label>
-              )}
-            </div>
-          )}
-
-          <textarea
-            aria-label={isReadOnly ? "관리자 기록" : "처리 내용"}
-            className="input-primary w-full h-32 p-4 text-sm resize-none mb-6 bg-surface-dim border-none"
-            placeholder={
-              isReadOnly ? "관리자 기록" : "처리 내용을 입력하세요..."
-            }
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            disabled={isPending || isReadOnly}
-          />
+          {content}
         </div>
 
-        <div className="shrink-0 flex gap-3 justify-end border-t border-border-subtle bg-surface px-6 py-4">
-          <button
-            onClick={onClose}
-            disabled={isPending}
-            className="btn-secondary-modal h-10 px-4 text-sm font-medium"
-          >
-            {isReadOnly ? "닫기" : "취소"}
-          </button>
-          {!isReadOnly && (
-            <button
-              onClick={() => handleAction("DISMISSED")}
-              disabled={isPending}
-              className="btn-secondary h-10 text-sm border-border text-primary"
-            >
-              기각
-            </button>
-          )}
-          {!isReadOnly && (
-            <button
-              onClick={() => handleAction("RESOLVED")}
-              disabled={isPending}
-              className="btn-primary h-10 text-sm"
-            >
-              {isPending ? "처리 중..." : "조치 완료"}
-            </button>
-          )}
+        <div className="shrink-0 border-t border-border-subtle bg-surface px-6 py-4">
+          {footer}
         </div>
       </div>
     </div>

--- a/features/report/service/admin.ts
+++ b/features/report/service/admin.ts
@@ -13,6 +13,8 @@
  * 2026.03.09  임도헌   Modified  strike 누적을 AuditLog 기반으로 기록 및 합산
  * 2026.03.30  임도헌   Modified  관리자 신고 목록과 처리 모달이 직접 대상·부모 문맥·최근 strike를 함께 읽을 수 있도록 메타를 보강
  * 2026.04.03  임도헌   Modified  관리자 신고 목록 필터 타입을 report/types 공용 정의로 이동
+ * 2026.04.27  임도헌   Modified  신고 기각 코멘트 payload와 승인 조치 payload를 구분해 서버 검증 흐름 보강
+ * 2026.04.28  임도헌   Modified  신고 처리 모달이 실제 조치 대상 유저명을 표시할 수 있도록 대상 유저 메타 조회 추가
  */
 
 import "server-only";
@@ -30,6 +32,7 @@ import type {
   AdminReportItem,
   ReportFilter,
   ReportResolutionInput,
+  ReportStatusInput,
 } from "@/features/report/types";
 import { Prisma } from "@/generated/prisma/client";
 import {
@@ -304,14 +307,14 @@ export async function getReportsAdmin(
  * @param adminId - 처리 담당 관리자 ID
  * @param reportId - 대상 신고 ID
  * @param status - 변경할 상태
- * @param adminComment - 관리자 코멘트
+ * @param resolution - 승인 조치 payload 또는 기각 코멘트 payload
  * @returns {Promise<ServiceResult>} 처리 결과
  */
 export async function updateReportStatus(
   adminId: number,
   reportId: number,
   status: "RESOLVED" | "DISMISSED",
-  resolution?: ReportResolutionInput
+  resolution?: ReportStatusInput
 ): Promise<ServiceResult> {
   try {
     const report = await db.report.findUnique({
@@ -349,7 +352,10 @@ export async function updateReportStatus(
       };
     }
 
-    if (status === "RESOLVED" && !resolution) {
+    if (
+      status === "RESOLVED" &&
+      (!resolution || !isReportResolutionInput(resolution))
+    ) {
       return {
         success: false,
         error: "승인 시 조치 유형을 선택해주세요.",
@@ -360,7 +366,7 @@ export async function updateReportStatus(
 
     let finalAdminComment = trimmedComment;
 
-    if (status === "RESOLVED" && resolution) {
+    if (status === "RESOLVED" && isReportResolutionInput(resolution)) {
       // strike 가산 이력은 별도 감사 로그로 남겨 최근 누적 계산 기준으로 재사용
       if (targetUserId && resolution.strike > 0) {
         await createAuditLog({
@@ -483,6 +489,12 @@ export async function updateReportStatus(
   }
 }
 
+function isReportResolutionInput(
+  input: ReportStatusInput | undefined
+): input is ReportResolutionInput {
+  return !!input && "action" in input;
+}
+
 /**
  * strike 감사 로그 사유 문자열 조립
  * 후속 strike 집계 파싱에 필요한 moderation 메타를 함께 포함
@@ -545,23 +557,25 @@ async function attachStrikeSummary(reports: AdminReportItem[]) {
     getReviewOwnerMap(reports),
   ]);
 
-  // 다양한 대상 타입을 최종 사용자 기준으로 환산해 최근 strike 누적을 붙임
-  const strikeMap = await getRecentUserStrikeMap(
-    reports
-      .map((report) =>
-        getResolvedTargetUserIdFromMaps(report, {
-          userMetaMap,
-          productMetaMap,
-          postMetaMap,
-          commentMetaMap,
-          streamMetaMap,
-          productMessageMetaMap,
-          streamMessageMetaMap,
-          reviewMetaMap,
-        })
-      )
-      .filter((userId): userId is number => !!userId)
-  );
+  // 다양한 대상 타입을 최종 사용자 기준으로 환산해 최근 strike 누적과 유저명을 붙임
+  const resolvedTargetUserIds = reports
+    .map((report) =>
+      getResolvedTargetUserIdFromMaps(report, {
+        userMetaMap,
+        productMetaMap,
+        postMetaMap,
+        commentMetaMap,
+        streamMetaMap,
+        productMessageMetaMap,
+        streamMessageMetaMap,
+        reviewMetaMap,
+      })
+    )
+    .filter((userId): userId is number => !!userId);
+  const [strikeMap, targetUserNameMap] = await Promise.all([
+    getRecentUserStrikeMap(resolvedTargetUserIds),
+    getUserNameMap(resolvedTargetUserIds),
+  ]);
 
   return reports.map((report) => {
     const targetResolvedUserId = getResolvedTargetUserIdFromMaps(report, {
@@ -588,6 +602,9 @@ async function attachStrikeSummary(reports: AdminReportItem[]) {
     return {
       ...report,
       targetResolvedUserId,
+      targetResolvedUsername: targetResolvedUserId
+        ? (targetUserNameMap.get(targetResolvedUserId) ?? null)
+        : null,
       recentStrikeTotal: targetResolvedUserId
         ? (strikeMap.get(targetResolvedUserId) ?? 0)
         : 0,
@@ -806,6 +823,22 @@ async function getUserMetaMap(reports: { targetUserId: number | null }[]) {
   });
 
   return new Map(rows.map((row) => [row.id, { username: row.username }]));
+}
+
+/**
+ * 조치 대상 유저명 조회
+ * 간접 신고도 모달에서 실제 제재 대상 유저를 확인할 수 있도록 표시 메타만 분리 조회
+ */
+async function getUserNameMap(userIds: number[]) {
+  const uniqueUserIds = [...new Set(userIds)];
+  if (uniqueUserIds.length === 0) return new Map<number, string>();
+
+  const rows = await db.user.findMany({
+    where: { id: { in: uniqueUserIds } },
+    select: { id: true, username: true },
+  });
+
+  return new Map(rows.map((row) => [row.id, row.username]));
 }
 
 async function getProductOwnerMap(reports: { targetProductId: number | null }[]) {

--- a/features/report/service/log.ts
+++ b/features/report/service/log.ts
@@ -7,6 +7,7 @@
  * Date        Author   Status    Description
  * 2026.02.07  임도헌   Created   감사 로그 생성 및 목록 조회 기능 구현
  * 2026.03.29  임도헌   Modified  관리자명·액션·대상·사유·ID 검색과 액션/대상 타입 필터를 지원하도록 확장
+ * 2026.04.28  임도헌   Modified  삭제 감사 로그의 OwnerID에 대응하는 유저명을 표시용 메타로 보강
  */
 
 import "server-only";
@@ -28,7 +29,9 @@ import {
  * - 페이징과 관리자/대상 추적용 메타를 함께 반환
  *
  * @param page - 현재 페이지 (기본값: 1)
+ * @param query - 관리자명, 사유, 액션 라벨, 대상 타입, 대상 ID 자유 검색어
  * @param limit - 페이지당 항목 수 (기본값: 20)
+ * @param filters - 액션/대상 타입 빠른 필터
  * @returns {Promise<ServiceResult<AdminAuditLogListResponse>>} 로그 목록 및 페이징 정보
  */
 export async function getAuditLogsAdmin(
@@ -133,11 +136,23 @@ export async function getAuditLogsAdmin(
         take: limit,
       }),
     ]);
+    const ownerNameMap = await getAuditReasonOwnerNameMap(
+      items.map((item) => item.reason)
+    );
 
     return {
       success: true,
       data: {
-        items,
+        items: items.map((item) => {
+          const reasonOwnerId = extractOwnerIdFromReason(item.reason);
+
+          return {
+            ...item,
+            reasonOwnerUsername: reasonOwnerId
+              ? (ownerNameMap.get(reasonOwnerId) ?? null)
+              : null,
+          };
+        }),
         total,
         totalPages: Math.ceil(total / limit),
         currentPage: page,
@@ -146,4 +161,31 @@ export async function getAuditLogsAdmin(
   } catch {
     return { success: false, error: "로그를 불러오지 못했습니다." };
   }
+}
+
+/**
+ * 삭제 감사 로그 reason 안의 OwnerID 추출
+ * - 기존 감사 로그 저장 포맷을 유지하면서 화면 표시용 유저명만 보강하기 위한 파서
+ */
+function extractOwnerIdFromReason(reason: string | null) {
+  const match = reason?.match(/\bOwnerID:\s*(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * 현재 페이지 감사 로그에 등장하는 OwnerID의 유저명 맵 조회
+ */
+async function getAuditReasonOwnerNameMap(reasons: Array<string | null>) {
+  const ownerIds = reasons
+    .map(extractOwnerIdFromReason)
+    .filter((id): id is number => !!id);
+  const uniqueOwnerIds = [...new Set(ownerIds)];
+  if (uniqueOwnerIds.length === 0) return new Map<number, string>();
+
+  const users = await db.user.findMany({
+    where: { id: { in: uniqueOwnerIds } },
+    select: { id: true, username: true },
+  });
+
+  return new Map(users.map((user) => [user.id, user.username]));
 }

--- a/features/report/types.ts
+++ b/features/report/types.ts
@@ -9,6 +9,9 @@
  * 2026.03.09  임도헌   Modified  신고 처리 정책 설계를 위한 제재 액션/입력 타입 추가
  * 2026.03.30  임도헌   Modified  관리자 신고 리스트가 대상 요약과 부모 콘텐츠 추적 정보를 함께 가질 수 있도록 확장
  * 2026.04.03  임도헌   Modified  신고 대상/처리 액션/관리자 필터 타입을 공용 정의로 통합
+ * 2026.04.27  임도헌   Modified  신고 기각 코멘트 payload와 승인 조치 payload 타입을 분리
+ * 2026.04.28  임도헌   Modified  신고 처리 모달에서 조치 대상 유저명을 표시할 수 있도록 대상 유저 메타 확장
+ * 2026.04.28  임도헌   Modified  삭제 감사 로그 OwnerID의 표시용 유저명 메타 추가
  */
 
 import type { Report } from "@/generated/prisma/client";
@@ -56,6 +59,14 @@ export interface ReportResolutionInput {
   deleteContent?: boolean;
 }
 
+/** 신고 기각 시 관리자가 입력해야 하는 처리 사유 */
+export interface ReportDismissalInput {
+  adminComment: string;
+}
+
+/** 신고 승인/기각 처리에 공통으로 전달되는 입력 payload */
+export type ReportStatusInput = ReportResolutionInput | ReportDismissalInput;
+
 /** 신고 처리 결과 요약 DTO */
 export interface ReportResolutionResult {
   reportId: number;
@@ -88,7 +99,10 @@ export interface AdminReportItem extends Report {
     id: number;
     username: string;
   };
+  /** 댓글/리뷰/메시지처럼 간접 대상일 때도 실제 제재 기준이 되는 유저 ID */
   targetResolvedUserId?: number | null;
+  /** 처리 모달에서 운영자가 확인할 수 있는 실제 조치 대상 유저명 */
+  targetResolvedUsername?: string | null;
   recentStrikeTotal?: number;
   targetPreview?: string | null;
   targetParentPostId?: number | null;
@@ -116,6 +130,8 @@ export interface AdminAuditLogItem {
   targetType: string;
   targetId: number;
   reason: string | null;
+  /** 삭제 로그 reason 안의 OwnerID에 대응하는 표시용 유저명 */
+  reasonOwnerUsername?: string | null;
   created_at: Date;
 }
 

--- a/features/report/utils/adminFormatter.ts
+++ b/features/report/utils/adminFormatter.ts
@@ -8,9 +8,135 @@
  * 2026.02.06  임도헌   Created   관리자 신고/감사 로그 대상의 라벨·ID·추적 링크 포맷팅 유틸 추가
  * 2026.03.18  임도헌   Modified  신고 목록 대상 상세 링크 생성 시 현재 관리자 경로를 returnTo로 함께 전달
  * 2026.03.30  임도헌   Modified  USER 대상 신고와 REPORT 감사 로그를 admin 화면으로 바로 추적하고, 댓글·리뷰·메시지의 직접 대상/부모 문맥 링크를 함께 제공하도록 확장
+ * 2026.04.28  임도헌   Modified  신고 제재 감사 로그 사유를 운영자용 한글 요약으로 변환하는 포맷터 추가
+ * 2026.04.28  임도헌   Modified  삭제 감사 로그의 OwnerID 메타에 유저명을 덧붙이는 표시 포맷 보강
  */
 
-import { AdminAuditLogItem, AdminReportItem } from "@/features/report/types";
+import { REPORT_RESOLUTION_ACTION_LABELS } from "@/features/report/constants";
+import type {
+  AdminAuditLogItem,
+  AdminReportItem,
+  ReportResolutionAction,
+} from "@/features/report/types";
+
+/**
+ * 감사 로그 사유를 관리자 화면 표시용 본문과 보조 메타로 분리
+ * - 저장된 원본 reason은 strike 집계와 운영 추적에 재사용되므로 변경하지 않음
+ * - 화면에서는 내부 action 키, moderation metadata, OwnerID 보조 정보를 운영자용 문구로 치환
+ */
+export function formatAuditReason(
+  action: string,
+  reason: string | null,
+  options?: { reasonOwnerUsername?: string | null }
+) {
+  if (!reason) return { displayReason: "-", metaInfo: "" };
+
+  if (action === "ADD_STRIKE") {
+    const [baseReason, meta] = reason.split("[moderation-meta]");
+    const metaInfo = formatModerationMeta(meta);
+
+    return {
+      displayReason: baseReason.trim() || "-",
+      metaInfo,
+    };
+  }
+
+  if (action === "WARN_USER") {
+    const match = reason.match(
+      /^(.*)\s+\(action:\s*([^,]+),\s*strike:\s*(\d+),\s*total:\s*(\d+)\)$/
+    );
+
+    if (!match) return { displayReason: reason, metaInfo: "" };
+
+    const [, baseReason, rawAction, strike, total] = match;
+    const actionLabel =
+      REPORT_RESOLUTION_ACTION_LABELS[rawAction as ReportResolutionAction] ??
+      rawAction;
+
+    return {
+      displayReason: baseReason.trim() || "-",
+      metaInfo: `조치: ${actionLabel} / strike ${strike}회 / 누적 ${total}회`,
+    };
+  }
+
+  if (action === "RESOLVE_REPORT") {
+    const [baseReason, actionSummary] = reason.split("\n[조치]");
+    return {
+      displayReason: baseReason.trim() || "-",
+      metaInfo: actionSummary
+        ? formatReportResolutionSummary(actionSummary)
+        : "",
+    };
+  }
+
+  if (reason.includes("Title:")) {
+    const parts = reason.split(" / ");
+    return {
+      displayReason: parts[parts.length - 1].replace("Reason: ", ""),
+      metaInfo: parts
+        .slice(0, parts.length - 1)
+        .map((part) =>
+          formatOwnerIdPart(part, options?.reasonOwnerUsername)
+        )
+        .join(" | "),
+    };
+  }
+
+  return { displayReason: reason, metaInfo: "" };
+}
+
+/**
+ * 삭제 로그의 OwnerID 조각에 유저명을 덧붙여 운영자가 ID와 닉네임을 함께 확인하도록 변환
+ */
+function formatOwnerIdPart(part: string, ownerUsername?: string | null) {
+  if (!ownerUsername || !/\bOwnerID:\s*\d+/.test(part)) return part;
+  return `${part} (${ownerUsername})`;
+}
+
+/**
+ * ADD_STRIKE 로그의 moderation metadata를 한글 보조 문구로 변환
+ * - metadata는 `buildStrikeAuditReason`에서 만든 내부 파싱 포맷
+ */
+function formatModerationMeta(meta?: string) {
+  if (!meta?.trim()) return "";
+
+  const action = meta.match(/action=([^;]+)/)?.[1];
+  const strike = meta.match(/strike=(\d+)/)?.[1];
+  const duration = meta.match(/duration=(\d+)/)?.[1];
+  const actionLabel = action
+    ? (REPORT_RESOLUTION_ACTION_LABELS[action as ReportResolutionAction] ??
+      action)
+    : null;
+  const durationText =
+    duration && Number(duration) > 0
+      ? ` / 기간 ${duration}일`
+      : duration === "0"
+        ? " / 기간 없음"
+        : "";
+
+  return [
+    actionLabel ? `조치: ${actionLabel}` : null,
+    strike ? `strike ${strike}회` : null,
+  ]
+    .filter(Boolean)
+    .join(" / ")
+    .concat(durationText);
+}
+
+/**
+ * 신고 승인 로그의 `[조치]` 요약에서 내부 action 키만 화면 라벨로 변환
+ */
+function formatReportResolutionSummary(summary: string) {
+  const trimmedSummary = summary.trim();
+  if (!trimmedSummary) return "";
+
+  const [rawAction, ...rest] = trimmedSummary.split(" / ");
+  const action = rawAction.trim();
+  const actionLabel =
+    REPORT_RESOLUTION_ACTION_LABELS[action as ReportResolutionAction] ?? action;
+
+  return [`조치: ${actionLabel}`, ...rest].join(" / ");
+}
 
 /**
  * 신고 대상의 타입 문자열 추출


### PR DESCRIPTION
## Summary
관리자 신고 처리 정책 문서 기준으로 신고 승인/기각 처리 흐름과 감사 로그 확인 UX를 정리했습니다.

이번 PR은 신고 정책 자체를 변경하는 작업이 아니라, `docs/operations/report-moderation-policy.md`에 정리된 현재 운영 기준에 맞춰 에러가 발생할 수 있는 처리 경로를 보강하고, 운영자가 작은 화면과 감사 로그에서 제재 맥락을 더 명확하게 확인할 수 있도록 개선한 후속 Fix입니다.

## Changes
[📜 Moderation Policy]
- 신고 승인/기각 payload를 분리해 기각 시에도 관리자 코멘트가 누락되지 않도록 정리했습니다.
- 처리 사유 길이, 중복 처리 여부, 승인 payload 유효성을 서버에서 검증하도록 보강했습니다.
- 유저 단독 신고는 삭제 가능한 직접 콘텐츠가 없으므로 `DELETE_CONTENT` 추천/선택지에서 제외했습니다.
- 댓글, 리뷰, 메시지처럼 간접 대상 신고도 실제 제재 기준이 되는 조치 대상 유저를 확인할 수 있도록 메타를 보강했습니다.
- `ADD_STRIKE` 감사 로그 metadata 포맷은 유지해 최근 90일 strike 집계 기준과 충돌하지 않도록 정리했습니다.

[🛡️ Admin Moderation]
- 신고 처리 모달을 모바일에서는 BottomSheet, 데스크톱에서는 중앙 모달로 분기해 작은 화면의 잘림을 완화했습니다.
- 신고 대상 요약에서 직접 대상, 상위 문맥, 조치 대상 유저를 구분해 확인할 수 있도록 정리했습니다.
- 관리자 공용 액션 모달도 모바일 BottomSheet 분기를 적용해 입력창과 하단 액션 접근성을 보강했습니다.

[📋 Audit Log]
- STRIKE 부여, 유저 경고, 신고 승인 로그의 내부 action/meta 문자열을 운영자용 한글 요약으로 표시했습니다.
- 삭제 감사 로그의 OwnerID 옆에 유저명을 함께 표시해 삭제 후에도 대상 소유자를 식별할 수 있도록 개선했습니다.
- 감사 로그 reason 원본 저장 포맷은 유지하고, 화면 표시용 포맷터에서만 변환하도록 정리했습니다.

[📱 Interaction]
- 공용 BottomSheet 드래그 닫기를 pointer event 기반으로 유지하면서 버튼, 링크, 입력 요소 클릭은 드래그 시작에서 제외했습니다.

[📝 Comment]
- 신고 처리, 감사 로그 포맷터, BottomSheet 상호작용 관련 JSDoc 및 인라인 주석을 현재 동작 기준으로 정리했습니다.

## Verification
- 관리자 신고 목록 상태 필터/검색/처리 모달 확인
- 모바일 폭에서 신고 처리 모달과 관리자 액션 모달 BottomSheet 렌더링 확인
- 유저 단독 신고의 콘텐츠 삭제 선택지 제외 확인
- 댓글/리뷰/메시지 신고의 실제 조치 대상 유저 표시 확인
- 기각 처리 시 관리자 코멘트 저장 및 기각 감사 로그 확인
- STRIKE 부여, 유저 경고, 신고 승인 로그 한글 요약 표시 확인
- 삭제 감사 로그에서 OwnerID 옆 유저명 표시 확인

## Notes
- 이번 PR에는 신고 정책, strike 정책, 관리자 권한 정책 변경은 포함하지 않았습니다.
- 기존 감사 로그 reason 저장 포맷은 변경하지 않고, 화면 표시용 변환만 추가했습니다.
- `docs/operations/report-moderation-policy.md` 문서 자체는 이번 커밋 범위에 포함하지 않았습니다.
