### PR TITLE
🚑 Fix : BoardPort v1.2.0 릴리즈 전 QA 후속 안정화

### DIFF
--- a/app/(app)/(tabs)/layout.tsx
+++ b/app/(app)/(tabs)/layout.tsx
@@ -13,12 +13,12 @@
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/layout.tsx 에서 app/(app)/(tabs)/layout.tsx 로 변경 (라우트 그룹 개편)
  * 2026.05.12  임도헌   Modified  TabBar 신호 뱃지용 초기 미읽음 채팅 수 서버 주입
  * 2026.05.17  임도헌   Modified  채팅방 Realtime 구독을 탭 레이아웃 브리지 1개로 통합
+ * 2026.05.18  임도헌   Modified  채팅 Realtime 브리지를 앱 전역 레이아웃으로 이동하고 탭바 초기값 주입만 유지
  */
 
 import TabBar from "@/components/global/TabBar";
 import getSession from "@/lib/session";
 import { getUnreadChatMessageCount } from "@/features/chat/service/room";
-import ChatRoomsRealtimeBridge from "@/features/chat/components/ChatRoomsRealtimeBridge";
 
 export default async function TabLayout({
   children,
@@ -32,7 +32,6 @@ export default async function TabLayout({
 
   return (
     <>
-      {session?.id ? <ChatRoomsRealtimeBridge userId={session.id} /> : null}
       <main className="flex-1 w-full min-h-screen">{children}</main>
       <TabBar
         userId={session?.id}

--- a/app/(app)/(tabs)/profile/[username]/channel/page.tsx
+++ b/app/(app)/(tabs)/profile/[username]/channel/page.tsx
@@ -28,6 +28,7 @@
  * 2026.04.09  임도헌   Modified  타인 방송국에도 프로필 페이지와 같은 상단 액션바(뒤로가기, 차단/신고 메뉴) 추가
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/profile/[username]/channel/page.tsx 에서 app/(app)/(tabs)/profile/[username]/channel/page.tsx 로 변경 (라우트 그룹 개편)
  * 2026.05.15  임도헌   Modified  채널 다시보기 첫 페이지를 TAKE+1로 조회해 클라이언트 무한스크롤 커서 전달
+ * 2026.05.18  임도헌   Modified  채널 다시보기 카드 좋아요 메타를 위해 VOD 조회에 viewerId 전달
  */
 
 import { Metadata } from "next";
@@ -112,7 +113,7 @@ export default async function ChannelPage({
   // 2. 데이터 병렬 조회 (차단 여부 체크 추가)
   const [liveResult, vods, roleResult, isBlocked] = await Promise.all([
     getChannelLive(ownerId),
-    getChannelVods(ownerId, STREAMS_PAGE_TAKE + 1),
+    getChannelVods(ownerId, STREAMS_PAGE_TAKE + 1, null, viewerId),
     getViewerRole(viewerId, ownerId),
     viewerId ? checkBlockRelation(viewerId, ownerId) : Promise.resolve(false),
   ]);

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -8,6 +8,7 @@
  * 2026.04.12  임도헌   Created   앱 전역 provider와 AppWrapper를 로그인 후 영역으로 분리
  * 2026.04.13  임도헌   Modified  NotificationBoot를 동적 로딩으로 분리해 앱 공통 초기 번들 부담 완화
  * 2026.04.17  임도헌   Modified  provider 배치 순서와 지연 부트스트랩 의도가 레이아웃 설명에서 바로 드러나도록 주석 보강
+ * 2026.05.18  임도헌   Modified  채팅 미읽음 Realtime 브리지를 앱 전역으로 이동해 탭 밖 채팅 상세 읽음 처리까지 동기화
  */
 import dynamic from "next/dynamic";
 import ThemeProvider from "@/components/global/providers/ThemeProvider";
@@ -16,6 +17,8 @@ import GlobalToaster from "@/components/global/GlobalToaster";
 import QueryProvider from "@/components/global/providers/QueryProvider";
 import { NotificationStoreProvider } from "@/components/global/providers/NotificationStoreProvider";
 import { ModalStoreProvider } from "@/components/global/providers/ModalStoreProvider";
+import getSession from "@/lib/session";
+import ChatRoomsRealtimeBridge from "@/features/chat/components/ChatRoomsRealtimeBridge";
 
 const NotificationBoot = dynamic(
   () => import("@/features/notification/components/NotificationBoot"),
@@ -27,9 +30,16 @@ const NotificationBoot = dynamic(
  *
  * - 테마, React Query, 알림/모달 스토어처럼 탭 전반에 걸쳐 재사용되는 provider를 한 번만 감싼다
  * - `NotificationBoot`는 동적 로딩으로 분리해 첫 렌더 공통 번들에 실시간 알림 구독 코드를 싣지 않는다
+ * - 채팅 미읽음 브리지는 앱 전역에 두어 탭 밖 채팅 상세의 읽음 처리도 놓치지 않도록 유지한다
  * - `GlobalToaster`를 앱 영역 공통으로 배치해 제품/채팅/스트림/프로필 전환 중에도 일관된 토스트 레이어를 유지
  */
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+
   return (
     <ThemeProvider
       attribute="class"
@@ -44,6 +54,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               {/* 토스트와 알림 부트스트랩의 앱 공통 chrome 내 1회 마운트 */}
               <GlobalToaster />
               <NotificationBoot />
+              {session?.id ? (
+                <ChatRoomsRealtimeBridge userId={session.id} />
+              ) : null}
               {children}
             </ModalStoreProvider>
           </NotificationStoreProvider>

--- a/app/(app)/posts/[id]/og-image/route.tsx
+++ b/app/(app)/posts/[id]/og-image/route.tsx
@@ -13,7 +13,7 @@ import PostOpenGraphImage from "../opengraph-image";
 export const runtime = "nodejs";
 
 /**
- * 외부 공유 크롤러가 해시 없는 안정적인 URL로 게시글 OG 이미지를 가져가도록 위임
+ * 외부 공유 크롤러용 해시 없는 게시글 OG 이미지 응답 위임
  */
 export async function GET(
   _request: Request,

--- a/app/(app)/posts/[id]/opengraph-image.tsx
+++ b/app/(app)/posts/[id]/opengraph-image.tsx
@@ -168,7 +168,7 @@ async function createPngResponse(svg: string, imageBuffer: Buffer | null) {
 }
 
 /**
- * 게시글 상세 공유용 OG 이미지 엔트리
+ * 게시글 상세 공유 미리보기 이미지 생성 엔트리
  */
 export default async function Image({ params }: { params: { id: string } }) {
   const id = Number(params.id);

--- a/app/(app)/products/view/[id]/og-image/route.tsx
+++ b/app/(app)/products/view/[id]/og-image/route.tsx
@@ -13,7 +13,7 @@ import ProductOpenGraphImage from "../opengraph-image";
 export const runtime = "nodejs";
 
 /**
- * 외부 공유 크롤러가 해시 없는 안정적인 URL로 상품 OG 이미지를 가져가도록 위임
+ * 외부 공유 크롤러용 해시 없는 상품 OG 이미지 응답 위임
  */
 export async function GET(
   _request: Request,

--- a/app/(app)/products/view/[id]/opengraph-image.tsx
+++ b/app/(app)/products/view/[id]/opengraph-image.tsx
@@ -186,8 +186,8 @@ async function createPngResponse(svg: string, imageBuffer: Buffer | null) {
 }
 
 /**
- * 제품 상세 공유용 OG 이미지 엔트리
- * next/og의 Windows 로컬 폰트 경로 오류 회피를 위한 sharp 직접 PNG 생성
+ * 제품 상세 공유 미리보기 이미지 생성 엔트리
+ * next/og의 Windows 로컬 폰트 경로 오류 회피를 위한 sharp 직접 PNG 생성 경로
  */
 export default async function Image({ params }: { params: { id: string } }) {
   const id = Number(params.id);

--- a/app/(app)/streams/[id]/og-image/route.tsx
+++ b/app/(app)/streams/[id]/og-image/route.tsx
@@ -13,7 +13,7 @@ import StreamOpenGraphImage from "../opengraph-image";
 export const runtime = "nodejs";
 
 /**
- * 외부 공유 크롤러가 해시 없는 안정적인 URL로 방송 OG 이미지를 가져가도록 위임
+ * 외부 공유 크롤러용 해시 없는 방송 OG 이미지 응답 위임
  */
 export async function GET(
   _request: Request,

--- a/app/(app)/streams/[id]/opengraph-image.tsx
+++ b/app/(app)/streams/[id]/opengraph-image.tsx
@@ -10,6 +10,7 @@
  * 2026.04.12  임도헌   Moved     파일 경로를 app/streams/[id]/opengraph-image.tsx 에서 app/(app)/streams/[id]/opengraph-image.tsx 로 변경 (라우트 그룹 개편)
  * 2026.05.15  임도헌   Modified  Windows 로컬 next/og 폰트 경로 오류 회피를 위한 sharp 기반 PNG 생성
  * 2026.05.15  임도헌   Modified  다시보기 OG 대표 이미지를 방송 카드와 동일하게 최신 ready VOD 썸네일 우선 사용
+ * 2026.05.19  임도헌   Modified  상대 썸네일 URL 보정 기준을 NEXT_PUBLIC_APP_URL로 통일
  */
 
 import sharp from "sharp";
@@ -83,7 +84,7 @@ function normalizeStreamThumbnailUrl(src: string | null | undefined) {
     return trimmed;
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.SITE_URL;
+  const siteUrl = process.env.NEXT_PUBLIC_APP_URL;
   if (siteUrl && trimmed.startsWith("/")) {
     try {
       return new URL(trimmed, siteUrl).toString();
@@ -193,7 +194,7 @@ async function createPngResponse(svg: string, imageBuffer: Buffer | null) {
 }
 
 /**
- * 방송 상세 공유용 OG 이미지 엔트리
+ * 방송 상세 공유 미리보기 이미지 생성 엔트리
  */
 export default async function Image({ params }: { params: { id: string } }) {
   const id = Number(params.id);

--- a/app/api/boardgames/catalog/route.ts
+++ b/app/api/boardgames/catalog/route.ts
@@ -1,0 +1,45 @@
+/**
+ * File Name : app/api/boardgames/catalog/route.ts
+ * Description : 공개 보드게임 도감 목록 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.18  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 도감 목록 조회 API 추가
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { BOARDGAME_CATALOG_PAGE_SIZE } from "@/features/boardgame/constants";
+import { getPublishedBoardGames } from "@/features/boardgame/service/publicQuery/list";
+import { parseBoardGameCatalogFilters } from "@/features/boardgame/utils/catalogFilters";
+
+/**
+ * 공개 보드게임 도감 목록 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - page, limit, q, players, playTime, weight, sort query를 포함한 요청
+ * @returns 공개 도감 목록 응답 또는 에러 응답
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const rawPage = Number(searchParams.get("page"));
+  const rawLimit = Number(searchParams.get("limit"));
+  const page = Number.isFinite(rawPage) ? Math.max(1, Math.floor(rawPage)) : 1;
+  const limit = Number.isFinite(rawLimit)
+    ? Math.max(1, Math.floor(rawLimit))
+    : BOARDGAME_CATALOG_PAGE_SIZE;
+  const filters = parseBoardGameCatalogFilters({
+    q: searchParams.get("q") ?? undefined,
+    players: searchParams.get("players") ?? undefined,
+    playTime: searchParams.get("playTime") ?? undefined,
+    weight: searchParams.get("weight") ?? undefined,
+    sort: searchParams.get("sort") ?? undefined,
+  });
+
+  const result = await getPublishedBoardGames(page, limit, filters);
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/app/api/chats/rooms/route.ts
+++ b/app/api/chats/rooms/route.ts
@@ -1,0 +1,29 @@
+/**
+ * File Name : app/api/chats/rooms/route.ts
+ * Description : 현재 로그인한 유저의 채팅방 목록 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.18  임도헌   Created   Client queryFn에서 채팅 목록 Server Action을 직접 호출하지 않도록 조회 API 추가
+ */
+
+import { NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getChatRooms } from "@/features/chat/service/room";
+
+/**
+ * 현재 로그인 유저의 채팅방 목록 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @returns {Promise<NextResponse>} 차단 필터링과 미읽음 수가 반영된 채팅방 목록 응답
+ */
+export async function GET(): Promise<NextResponse> {
+  const session = await getSession();
+  if (!session?.id) {
+    return NextResponse.json([]);
+  }
+
+  const rooms = await getChatRooms(session.id);
+  return NextResponse.json(rooms);
+}

--- a/app/api/chats/unread-count/route.ts
+++ b/app/api/chats/unread-count/route.ts
@@ -1,0 +1,29 @@
+/**
+ * File Name : app/api/chats/unread-count/route.ts
+ * Description : 현재 로그인한 유저의 채팅 미읽음 수 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.18  임도헌   Created   TabBar 채팅 뱃지 queryFn에서 Server Action을 직접 호출하지 않도록 미읽음 수 조회 API 추가
+ */
+
+import { NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getUnreadChatMessageCount } from "@/features/chat/service/room";
+
+/**
+ * 현재 로그인 유저의 전체 채팅 미읽음 수 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @returns {Promise<NextResponse<{ count: number }>>} 채팅 미읽음 수 응답
+ */
+export async function GET() {
+  const session = await getSession();
+  if (!session?.id) {
+    return NextResponse.json({ count: 0 });
+  }
+
+  const count = await getUnreadChatMessageCount(session.id);
+  return NextResponse.json({ count });
+}

--- a/app/api/cron/check-badges/route.ts
+++ b/app/api/cron/check-badges/route.ts
@@ -9,6 +9,7 @@
  * 2026.01.04  임도헌   Modified  Prisma Route Handler runtime=nodejs 명시
  * 2026.01.08  임도헌   Modified  대량 유저 처리 시 타임아웃 방지를 위해 Rolling Batch(take:50) 전략 적용
  * 2026.01.09  임도헌   Modified  Vercel Hobby 플랜 제한(1일 1회) 대응으로 배지 점검 배치 크기 정책을 재조정
+ * 2026.05.19  임도헌   Modified  Vercel Cron 자동 Authorization 헤더와 맞추기 위해 CRON_SECRET 기준으로 변경
  */
 import "server-only";
 import { NextRequest, NextResponse } from "next/server";
@@ -32,8 +33,8 @@ const RECHECK_INTERVAL_MS = 12 * 60 * 60 * 1000;
  * - 타임아웃 방지를 위해 'Rolling Batch' 전략을 사용하여 일정 수의 유저만 처리
  */
 export async function GET(req: NextRequest) {
-  // 1. 보안 체크: Vercel Cron 인증 헤더 검증
-  const cronSecret = process.env.CRON_SECRET_CHECK_BADGE;
+  // 1. 보안 체크: Vercel Cron은 CRON_SECRET 값을 Authorization: Bearer 헤더로 전달
+  const cronSecret = process.env.CRON_SECRET;
   if (cronSecret) {
     const authHeader = req.headers.get("authorization");
     const querySecret = req.nextUrl.searchParams.get("secret"); // 로컬 테스트용

--- a/app/api/posts/[id]/comments/route.ts
+++ b/app/api/posts/[id]/comments/route.ts
@@ -1,0 +1,58 @@
+/**
+ * File Name : app/api/posts/[id]/comments/route.ts
+ * Description : 게시글 댓글 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 게시글 댓글 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getPostCommentsList } from "@/features/post/service/comment";
+
+interface RouteParams {
+  params: {
+    id: string;
+  };
+}
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 undefined
+ */
+function parseNumberParam(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * 게시글 댓글 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - cursor와 limit을 포함한 요청
+ * @param context - 게시글 ID route params
+ * @returns 게시글 댓글 목록 응답
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const postId = Number(params.id);
+
+  if (!Number.isFinite(postId) || postId <= 0) {
+    return NextResponse.json([], { status: 400 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const session = await getSession();
+  const comments = await getPostCommentsList(
+    postId,
+    parseNumberParam(searchParams.get("cursor")),
+    parseNumberParam(searchParams.get("limit")) ?? 10,
+    session?.id ?? null
+  );
+
+  return NextResponse.json(comments);
+}

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,0 +1,57 @@
+/**
+ * File Name : app/api/posts/route.ts
+ * Description : 게시글 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 게시글 목록 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getPostsList } from "@/features/post/service/post";
+import type { PostSearchParams } from "@/features/post/types";
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 null
+ */
+function parseNullableNumberParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * 게시글 목록 검색 조건 파싱
+ *
+ * @param searchParams - 요청 URL query
+ * @returns 게시글 목록 service에 전달할 검색 조건
+ */
+function parsePostSearchParams(searchParams: URLSearchParams): PostSearchParams {
+  return {
+    keyword: searchParams.get("keyword") ?? undefined,
+    category: searchParams.get("category") ?? undefined,
+  };
+}
+
+/**
+ * 게시글 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - cursor와 검색 조건을 포함한 요청
+ * @returns 게시글 목록, 다음 커서, 전체 개수 응답
+ */
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  const viewerId = session?.id ?? -1;
+  const searchParams = request.nextUrl.searchParams;
+  const cursor = parseNullableNumberParam(searchParams.get("cursor"));
+  const params = parsePostSearchParams(searchParams);
+
+  const page = await getPostsList(params, viewerId, cursor);
+  return NextResponse.json(page);
+}

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,0 +1,63 @@
+/**
+ * File Name : app/api/products/route.ts
+ * Description : 제품 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 제품 목록 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getProductsList } from "@/features/product/service/list";
+import type { ProductSearchParams } from "@/features/product/types";
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 undefined
+ */
+function parseNumberParam(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * 제품 목록 검색 조건 파싱
+ *
+ * @param searchParams - 요청 URL query
+ * @returns 제품 목록 service에 전달할 검색 조건
+ */
+function parseProductSearchParams(
+  searchParams: URLSearchParams
+): ProductSearchParams {
+  return {
+    keyword: searchParams.get("keyword") ?? undefined,
+    category: searchParams.get("category") ?? undefined,
+    minPrice: parseNumberParam(searchParams.get("minPrice")),
+    maxPrice: parseNumberParam(searchParams.get("maxPrice")),
+    game_type: searchParams.get("game_type") ?? undefined,
+    condition: searchParams.get("condition") ?? undefined,
+  };
+}
+
+/**
+ * 제품 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - cursor와 검색 조건을 포함한 요청
+ * @returns 제품 목록, 다음 커서, 전체 개수 응답
+ */
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  const viewerId = session?.id ?? -1;
+  const searchParams = request.nextUrl.searchParams;
+  const cursor = parseNumberParam(searchParams.get("cursor")) ?? null;
+  const params = parseProductSearchParams(searchParams);
+
+  const page = await getProductsList(params, viewerId, cursor);
+  return NextResponse.json(page);
+}

--- a/app/api/products/user-scope/route.ts
+++ b/app/api/products/user-scope/route.ts
@@ -1,0 +1,97 @@
+/**
+ * File Name : app/api/products/user-scope/route.ts
+ * Description : 유저 제품 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 프로필/마이페이지 제품 목록 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getUserProductsList } from "@/features/product/service/userList";
+import type { UserProductsScope } from "@/features/product/types";
+import { USER_ERRORS } from "@/features/user/constants";
+
+const USER_PRODUCT_SCOPE_TYPES = [
+  "SELLING",
+  "RESERVED",
+  "SOLD",
+  "PURCHASED",
+  "LIKED",
+] as const;
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 null
+ */
+function parseNullableNumberParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * 유저 제품 목록 scope 파싱
+ *
+ * @param searchParams - 요청 URL query
+ * @returns 유효한 유저 제품 목록 scope 또는 null
+ */
+function parseUserProductsScope(
+  searchParams: URLSearchParams
+): UserProductsScope | null {
+  const type = searchParams.get("type");
+  const userId = parseNullableNumberParam(searchParams.get("userId"));
+
+  if (
+    !type ||
+    !USER_PRODUCT_SCOPE_TYPES.includes(
+      type as (typeof USER_PRODUCT_SCOPE_TYPES)[number]
+    ) ||
+    !userId
+  ) {
+    return null;
+  }
+
+  return {
+    type: type as UserProductsScope["type"],
+    userId,
+  } as UserProductsScope;
+}
+
+/**
+ * 유저 제품 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - scope, userId, cursor를 포함한 요청
+ * @returns 제품 목록, 다음 커서, 전체 개수 응답
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const scope = parseUserProductsScope(searchParams);
+
+  if (!scope) {
+    return NextResponse.json({ error: "BAD_REQUEST" }, { status: 400 });
+  }
+
+  const session = await getSession();
+  const viewerId = session?.id ?? null;
+  const isPrivateScope =
+    scope.type === "PURCHASED" ||
+    scope.type === "LIKED" ||
+    scope.type === "RESERVED";
+
+  if (isPrivateScope && viewerId !== scope.userId) {
+    return NextResponse.json(
+      { error: USER_ERRORS.UNAUTHORIZED },
+      { status: 403 }
+    );
+  }
+
+  const cursor = parseNullableNumberParam(searchParams.get("cursor"));
+  const page = await getUserProductsList(scope, cursor);
+  return NextResponse.json(page);
+}

--- a/app/api/streams/channel-recordings/route.ts
+++ b/app/api/streams/channel-recordings/route.ts
@@ -1,0 +1,94 @@
+/**
+ * File Name : app/api/streams/channel-recordings/route.ts
+ * Description : 유저 채널 다시보기 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 채널 다시보기 추가 페이지 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { STREAMS_PAGE_TAKE } from "@/lib/constants";
+import getSession from "@/lib/session";
+import { getViewerRole } from "@/features/stream/service/access";
+import { getChannelVods } from "@/features/stream/service/list";
+import { isBroadcastUnlockedFromSession } from "@/features/stream/utils/session";
+import type { ViewerRole, VodForGrid } from "@/features/stream/types";
+
+const TAKE = STREAMS_PAGE_TAKE;
+type Session = Awaited<ReturnType<typeof getSession>>;
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 null
+ */
+function parseNullableNumberParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * 채널 다시보기 접근 플래그 보정
+ *
+ * @param vods - 채널 VOD 목록
+ * @param session - 현재 세션
+ * @param role - 조회자의 채널 역할
+ * @returns 접근 보조 플래그가 반영된 VOD 목록
+ */
+function applyChannelVodAccess(
+  vods: VodForGrid[],
+  session: Session,
+  role: ViewerRole
+): VodForGrid[] {
+  return vods.map((vod) => {
+    const isPrivate = vod.visibility === "PRIVATE";
+    const isFollowers = vod.visibility === "FOLLOWERS";
+    const unlocked = isPrivate
+      ? isBroadcastUnlockedFromSession(session, vod.broadcastId)
+      : false;
+
+    return {
+      ...vod,
+      requiresPassword: isPrivate && role !== "OWNER" && !unlocked,
+      followersOnlyLocked:
+        isFollowers && !(role === "OWNER" || role === "FOLLOWER"),
+    };
+  });
+}
+
+/**
+ * 유저 채널 다시보기 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - ownerId와 cursor를 포함한 요청
+ * @returns 채널 다시보기 목록과 다음 커서 응답
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const ownerId = parseNullableNumberParam(searchParams.get("ownerId"));
+
+  if (!ownerId || ownerId <= 0) {
+    return NextResponse.json({ recordings: [], nextCursor: null });
+  }
+
+  const session = await getSession();
+  const role = (await getViewerRole(session?.id ?? null, ownerId)) as ViewerRole;
+  const list = await getChannelVods(
+    ownerId,
+    TAKE + 1,
+    parseNullableNumberParam(searchParams.get("cursor")),
+    session?.id ?? null
+  );
+  const withAccess = applyChannelVodAccess(list, session, role);
+  const hasMore = withAccess.length > TAKE;
+  const recordings = hasMore ? withAccess.slice(0, TAKE) : withAccess;
+  const nextCursor = hasMore
+    ? recordings[recordings.length - 1].vodId
+    : null;
+
+  return NextResponse.json({ recordings, nextCursor });
+}

--- a/app/api/streams/recordings/[vodId]/comments/route.ts
+++ b/app/api/streams/recordings/[vodId]/comments/route.ts
@@ -1,0 +1,61 @@
+/**
+ * File Name : app/api/streams/recordings/[vodId]/comments/route.ts
+ * Description : 녹화본 댓글 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 녹화본 댓글 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import getSession from "@/lib/session";
+import { getRecordingCommentsList } from "@/features/stream/service/comment";
+
+interface RouteParams {
+  params: {
+    vodId: string;
+  };
+}
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 undefined
+ */
+function parseNumberParam(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * 녹화본 댓글 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - cursor와 limit을 포함한 요청
+ * @param context - VOD ID route params
+ * @returns 녹화본 댓글 목록과 다음 커서 응답
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const vodId = Number(params.vodId);
+
+  if (!Number.isFinite(vodId) || vodId <= 0) {
+    return NextResponse.json(
+      { comments: [], nextCursor: undefined },
+      { status: 400 }
+    );
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const session = await getSession();
+  const page = await getRecordingCommentsList(
+    vodId,
+    parseNumberParam(searchParams.get("cursor")),
+    parseNumberParam(searchParams.get("limit")) ?? 10,
+    session?.id ?? null
+  );
+
+  return NextResponse.json(page);
+}

--- a/app/api/streams/recordings/route.ts
+++ b/app/api/streams/recordings/route.ts
@@ -1,0 +1,78 @@
+/**
+ * File Name : app/api/streams/recordings/route.ts
+ * Description : 다시보기 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 다시보기 목록 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { STREAMS_PAGE_TAKE } from "@/lib/constants";
+import getSession from "@/lib/session";
+import { getRecordingsList } from "@/features/stream/service/list";
+import type { RecordingSort } from "@/features/stream/types";
+
+const TAKE = STREAMS_PAGE_TAKE;
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 null
+ */
+function parseNullableNumberParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * 공백 검색 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns trim 후 값 또는 undefined
+ */
+function normalizeTextParam(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * 다시보기 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - sort, followingOnly, cursor, category, keyword를 포함한 요청
+ * @returns 다시보기 목록과 다음 커서 응답
+ */
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  const searchParams = request.nextUrl.searchParams;
+  const sort: RecordingSort =
+    searchParams.get("sort") === "popular" ? "popular" : "latest";
+  const followingOnly = searchParams.get("followingOnly") === "true";
+  const viewerId =
+    session?.id ?? parseNullableNumberParam(searchParams.get("viewerId"));
+
+  if (!viewerId) {
+    return NextResponse.json({ recordings: [], nextCursor: null });
+  }
+
+  const list = await getRecordingsList({
+    sort,
+    followingOnly,
+    category: normalizeTextParam(searchParams.get("category")),
+    keyword: normalizeTextParam(searchParams.get("keyword")),
+    viewerId,
+    cursor: parseNullableNumberParam(searchParams.get("cursor")),
+    take: TAKE + 1,
+  });
+  const hasMore = list.length > TAKE;
+  const recordings = hasMore ? list.slice(0, TAKE) : list;
+  const nextCursor = hasMore
+    ? recordings[recordings.length - 1].vodId
+    : null;
+
+  return NextResponse.json({ recordings, nextCursor });
+}

--- a/app/api/streams/route.ts
+++ b/app/api/streams/route.ts
@@ -1,0 +1,74 @@
+/**
+ * File Name : app/api/streams/route.ts
+ * Description : 라이브 방송 목록 클라이언트 조회 API
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 라이브 방송 목록 조회 API 분리
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { STREAMS_PAGE_TAKE } from "@/lib/constants";
+import getSession from "@/lib/session";
+import { getStreamsList } from "@/features/stream/service/list";
+import type { StreamScope } from "@/features/stream/types";
+
+const TAKE = STREAMS_PAGE_TAKE;
+
+/**
+ * URL query 숫자 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns 유효한 숫자 또는 null
+ */
+function parseNullableNumberParam(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * 공백 검색 파라미터 정규화
+ *
+ * @param value - URLSearchParams에서 읽은 문자열 값
+ * @returns trim 후 값 또는 undefined
+ */
+function normalizeTextParam(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * 라이브 방송 목록 페이지 반환
+ * Client Component queryFn은 이 Route Handler를 fetch해 Server Action 초기 렌더 호출 오류를 피하도록 구성
+ *
+ * @param request - scope, cursor, category, keyword를 포함한 요청
+ * @returns 방송 목록과 다음 커서 응답
+ */
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  const searchParams = request.nextUrl.searchParams;
+  const scope: StreamScope =
+    searchParams.get("scope") === "following" ? "following" : "all";
+  const viewerId =
+    session?.id ?? parseNullableNumberParam(searchParams.get("viewerId"));
+
+  if (!viewerId) {
+    return NextResponse.json({ streams: [], nextCursor: null });
+  }
+
+  const list = await getStreamsList({
+    scope,
+    category: normalizeTextParam(searchParams.get("category")),
+    keyword: normalizeTextParam(searchParams.get("keyword")),
+    viewerId,
+    cursor: parseNullableNumberParam(searchParams.get("cursor")),
+    take: TAKE + 1,
+  });
+  const hasMore = list.length > TAKE;
+  const streams = hasMore ? list.slice(0, TAKE) : list;
+  const nextCursor = hasMore ? streams[streams.length - 1].id : null;
+
+  return NextResponse.json({ streams, nextCursor });
+}

--- a/components/global/TabBar.tsx
+++ b/components/global/TabBar.tsx
@@ -27,13 +27,15 @@
  * 2026.03.28  임도헌   Modified  AppWrapper 폭 측정 전 초기 렌더에서도 탭바가 왼쪽으로 압축되지 않도록 전체 폭 fallback을 추가
  * 2026.05.12  임도헌   Modified  신호 탭에 미읽음 채팅 뱃지와 rooms_refresh 기반 실시간 갱신 추가
  * 2026.05.17  임도헌   Modified  rooms_refresh 구독을 ChatRoomsRealtimeBridge로 이동해 탭바는 query 표시만 담당
+ * 2026.05.18  임도헌   Modified  서버 초기 미읽음 수를 query cache에 명시 동기화해 탭 전환 후 뱃지 잔상 보정
+ * 2026.05.18  임도헌   Modified  미읽음 수 클라이언트 재검증을 Server Action 대신 전용 API 조회로 전환
  */
 "use client";
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   NewspaperIcon as SolidNewspaperIcon,
   HomeIcon as SolidHomeIcon,
@@ -50,11 +52,28 @@ import {
 } from "@heroicons/react/24/outline";
 import { cn } from "@/lib/utils";
 import { queryKeys } from "@/lib/queryKeys";
-import { getUnreadChatMessageCountAction } from "@/features/chat/actions/room";
 
 interface TabBarProps {
   userId?: number;
   initialUnreadChatCount?: number;
+}
+
+/**
+ * TabBar 채팅 뱃지용 전체 미읽음 수 조회
+ *
+ * Client Component 초기 렌더에서 Server Action을 직접 queryFn으로 호출하면
+ * App Router fetch waterfall 오류가 발생할 수 있어 전용 Route Handler를 사용합니다.
+ */
+async function fetchUnreadChatMessageCount() {
+  const response = await fetch("/api/chats/unread-count", {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  if (!response.ok) return 0;
+
+  const data = (await response.json()) as { count?: number };
+  return typeof data.count === "number" ? data.count : 0;
 }
 
 /**
@@ -64,12 +83,14 @@ interface TabBarProps {
  * - 최상위 탭 경로 및 타 유저 프로필/채널 페이지에서 노출
  * - 현재 경로 기준 active 상태 표시
  * - 모바일 하단 고정 내비게이션 제공
+ * - 신호 탭에 전체 채팅 미읽음 수를 표시하고 query invalidation으로 최신화
  */
 export default function TabBar({
   userId,
   initialUnreadChatCount = 0,
 }: TabBarProps) {
   const pathname = usePathname();
+  const queryClient = useQueryClient();
   const [shellBounds, setShellBounds] = useState<{
     left: number;
     width: number;
@@ -78,11 +99,21 @@ export default function TabBar({
   // 서버에서 받은 초기값으로 첫 렌더 뱃지를 채우고, 이후에는 query invalidation으로 최신화
   const unreadChatCountQuery = useQuery({
     queryKey: queryKeys.chats.unreadCount(userId ?? 0),
-    queryFn: getUnreadChatMessageCountAction,
+    queryFn: fetchUnreadChatMessageCount,
     enabled: Boolean(userId),
     initialData: initialUnreadChatCount,
     staleTime: 60 * 1000,
   });
+
+  useEffect(() => {
+    if (!userId) return;
+
+    // 라우트 전환 시 서버 레이아웃이 계산한 최신 미읽음 수를 기존 클라이언트 캐시에 반영
+    queryClient.setQueryData(
+      queryKeys.chats.unreadCount(userId),
+      initialUnreadChatCount
+    );
+  }, [initialUnreadChatCount, queryClient, userId]);
 
   const tabs = [
     {
@@ -158,7 +189,8 @@ export default function TabBar({
 
   if (!shouldShowTabBar) return null;
 
-  const unreadChatCount = unreadChatCountQuery.data ?? initialUnreadChatCount;
+  const unreadChatCount =
+    unreadChatCountQuery.data ?? initialUnreadChatCount;
   const unreadChatBadgeText =
     unreadChatCount > 99 ? "99+" : String(unreadChatCount);
 

--- a/components/global/providers/QueryProvider.tsx
+++ b/components/global/providers/QueryProvider.tsx
@@ -8,12 +8,14 @@
  * 2026.02.28  임도헌   Created   QueryClient 초기화 및 Provider 적용
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.04.13  임도헌   Modified  React Query Devtools를 동적 로딩으로 분리해 프로덕션 공통 번들 부담을 완화
+ * 2026.05.19  임도헌   Modified  서버 prefetch용 QueryClient와 같은 공용 팩토리를 사용해 기본 옵션 중복 선언 제거
  */
 "use client";
 
 import dynamic from "next/dynamic";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { getQueryClient } from "@/lib/getQueryClient";
 
 const ReactQueryDevtools = dynamic(
   () =>
@@ -29,6 +31,7 @@ const ReactQueryDevtools = dynamic(
  * [상태 주입 및 제어 로직]
  * - Next.js App Router 호환 및 SSR 환경에서의 상태 오염 방지 적용
  * - `useState`를 사용한 1회성 QueryClient 인스턴스 생성
+ * - 서버 prefetch와 클라이언트 Provider가 같은 `getQueryClient` 기본 옵션을 공유
  * - 불필요한 자동 갱신(refetchOnWindowFocus) 비활성화 및 기본 staleTime(1분) 적용
  */
 export default function QueryProvider({
@@ -38,21 +41,8 @@ export default function QueryProvider({
 }) {
   const isDev = process.env.NODE_ENV === "development";
   // useState를 사용하여 컴포넌트 마운트 시 단 한 번만 QueryClient를 생성
-  // 이를 통해 다른 유저의 요청 간에 캐시가 공유되는 상태 오염을 방지
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            // SSR 환경을 고려하여 기본 staleTime을 1분으로 설정
-            // 즉시 refetch되는 것을 방지하여 서버 부하를 줄임
-            staleTime: 60 * 1000,
-            refetchOnWindowFocus: false, // 탭 전환 시 불필요한 자동 갱신 방지
-            retry: 1, // 실패 시 재시도 횟수
-          },
-        },
-      })
-  );
+  // 공용 팩토리를 사용해 서버 prefetch와 클라이언트 Provider의 기본 옵션 drift를 방지
+  const [queryClient] = useState(() => getQueryClient());
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/features/auth/components/SocialLogin.tsx
+++ b/features/auth/components/SocialLogin.tsx
@@ -1,6 +1,6 @@
 /**
  * File Name : features/auth/components/SocialLogin.tsx
- * Description : 소셜 로그인 버튼 모음 (Kakao, GitHub, SMS 등)
+ * Description : 소셜 로그인 버튼 모음 (Kakao, SMS 등)
  * Author : 임도헌
  *
  * History
@@ -21,6 +21,7 @@
  * 2026.04.13  임도헌   Modified  SMS 로그인 CTA의 명도 대비를 높여 접근성 기준을 보강
  * 2026.05.12  임도헌   Modified  포인터 이동 시 blur 검증으로 CTA가 한 번 막히지 않도록 focus 이동 방지 처리
  * 2026.05.16  임도헌   Modified  포인터 이벤트 핸들러를 가진 클라이언트 컴포넌트임을 명시
+ * 2026.05.18  임도헌   Modified  타깃 사용자 맥락에 맞춰 GitHub 로그인 버튼을 화면에서 제거
  */
 "use client";
 
@@ -34,7 +35,7 @@ import { preventPointerDownFocus } from "@/lib/preventPointerDownFocus";
  *
  * [기능]
  * - callbackUrl을 각 OAuth 시작 라우트에 전달
- * - 카카오, GitHub, SMS 로그인 진입 버튼 제공
+ * - 카카오, SMS 로그인 진입 버튼 제공
  */
 export default function SocialLogin({
   callbackUrl,
@@ -51,9 +52,6 @@ export default function SocialLogin({
   const kakaoHref = callbackUrl
     ? `/kakao/start?callbackUrl=${encodeURIComponent(callbackUrl)}`
     : "/kakao/start";
-  const githubHref = callbackUrl
-    ? `/github/start?callbackUrl=${encodeURIComponent(callbackUrl)}`
-    : "/github/start";
   const smsHref = callbackUrl
     ? `/sms?callbackUrl=${encodeURIComponent(callbackUrl)}`
     : "/sms";
@@ -81,22 +79,6 @@ export default function SocialLogin({
           <path d="M12 3C6.477 3 2 6.538 2 10.905c0 2.846 1.834 5.337 4.672 6.828l-1.002 3.738c-.068.254.218.432.428.283l4.38-2.932c.5.068 1.01.103 1.522.103 5.523 0 10-3.538 10-7.905C22 6.538 17.523 3 12 3z" />
         </svg>
         <span>카카오로 계속하기</span>
-      </a>
-      {/* GitHub 로그인 */}
-      <a
-        aria-label="GitHub로 계속하기"
-        className={cn(baseButtonClass)}
-        href={githubHref}
-        onPointerDown={preventPointerDownFocus}
-      >
-        <svg className="size-5" viewBox="0 0 15 15" fill="currentColor">
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M7.49933 0.25C3.49635 0.25 0.25 3.49593 0.25 7.50024C0.25 10.703 2.32715 13.4206 5.2081 14.3797C5.57084 14.446 5.70302 14.2222 5.70302 14.0299C5.70302 13.8576 5.69679 13.4019 5.69323 12.797C3.67661 13.235 3.25112 11.825 3.25112 11.825C2.92132 10.9874 2.44599 10.7644 2.44599 10.7644C1.78773 10.3149 2.49584 10.3238 2.49584 10.3238C3.22353 10.375 3.60629 11.0711 3.60629 11.0711C4.25298 12.1788 5.30335 11.8588 5.71638 11.6732C5.78225 11.205 5.96962 10.8854 6.17658 10.7043C4.56675 10.5209 2.87415 9.89918 2.87415 7.12104C2.87415 6.32925 3.15677 5.68257 3.62053 5.17563C3.54576 4.99226 3.29697 4.25521 3.69174 3.25691C3.69174 3.25691 4.30015 3.06196 5.68522 3.99973C6.26337 3.83906 6.8838 3.75895 7.50022 3.75583C8.1162 3.75895 8.73619 3.83906 9.31523 3.99973C10.6994 3.06196 11.3069 3.25691 11.3069 3.25691C11.7026 4.25521 11.4538 4.99226 11.3795 5.17563C11.8441 5.68257 12.1245 6.32925 12.1245 7.12104C12.1245 9.9063 10.4292 10.5192 8.81452 10.6985C9.07444 10.9224 9.30633 11.3648 9.30633 12.0413C9.30633 13.0102 9.29742 13.7922 9.29742 14.0299C9.29742 14.2239 9.42828 14.4496 9.79591 14.3788C12.6746 13.4179 14.75 10.7025 14.75 7.50024C14.75 3.49593 11.5036 0.25 7.49933 0.25Z"
-          />
-        </svg>
-        <span>GitHub로 계속하기</span>
       </a>
 
       {/* SMS 로그인 */}

--- a/features/auth/components/form/ForgotPasswordForm.tsx
+++ b/features/auth/components/form/ForgotPasswordForm.tsx
@@ -10,6 +10,7 @@
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 안내 문구와 복귀 링크 타이포 계층을 정리
  * 2026.04.20  임도헌   Modified  계정 노출 방지 정책을 유지하면서도 비밀번호 재설정 요청 성공 문구를 더 자연스럽게 정리
  * 2026.05.12  임도헌   Modified  로그인 복귀 링크 클릭 시 blur 검증으로 이동이 지연되지 않도록 처리
+ * 2026.05.19  임도헌   Modified  서버 액션 예외 시 pending 해제 후 토스트로 안내되도록 에러 처리 보강
  */
 "use client";
 
@@ -58,31 +59,35 @@ export default function ForgotPasswordForm({
 
   const onSubmit = (data: PasswordResetRequestSchema) => {
     startTransition(async () => {
-      const formData = new FormData();
-      formData.append("email", data.email);
-      // 재설정 완료 후 다시 로그인할 때 원래 목적지 복귀 문맥 유지
-      formData.append("callbackUrl", callbackUrl);
+      try {
+        const formData = new FormData();
+        formData.append("email", data.email);
+        // 재설정 완료 후 다시 로그인할 때 원래 목적지 복귀 문맥 유지
+        formData.append("callbackUrl", callbackUrl);
 
-      const result = await requestPasswordResetAction(undefined, formData);
+        const result = await requestPasswordResetAction(undefined, formData);
 
-      if (!result.success) {
-        if (result.fieldErrors) {
-          applyFieldErrors<PasswordResetRequestSchema>(
-            setError,
-            result.fieldErrors,
-            { setFocus }
-          );
+        if (!result.success) {
+          if (result.fieldErrors) {
+            applyFieldErrors<PasswordResetRequestSchema>(
+              setError,
+              result.fieldErrors,
+              { setFocus }
+            );
+          }
+          if (result.error) {
+            toast.error(result.error);
+          }
+          return;
         }
-        if (result.error) {
-          toast.error(result.error);
-        }
-        return;
+
+        setSubmitted(true);
+        toast.success(
+          "입력하신 이메일을 확인해 주세요. 재설정 안내가 가능한 계정이면 메일을 보냈습니다."
+        );
+      } catch {
+        toast.error("재설정 메일 요청 중 일시적인 오류가 발생했습니다.");
       }
-
-      setSubmitted(true);
-      toast.success(
-        "입력하신 이메일을 확인해 주세요. 재설정 안내가 가능한 계정이면 메일을 보냈습니다."
-      );
     });
   };
 

--- a/features/auth/components/form/OnboardingForm.tsx
+++ b/features/auth/components/form/OnboardingForm.tsx
@@ -14,6 +14,7 @@
  * 2026.04.02  임도헌   Modified  온보딩 폼 JSDoc 보강
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 온보딩 도움 문구와 지역 액션 타이포를 정리
  * 2026.05.12  임도헌   Modified  지역 선택 버튼이 blur 검증으로 한 번 막히지 않도록 포인터 focus 이동 방지
+ * 2026.05.19  임도헌   Modified  서버 액션 예외 시 pending 해제 후 토스트로 안내되도록 에러 처리 보강
  */
 "use client";
 
@@ -146,44 +147,48 @@ export default function OnboardingForm({
 
   const onSubmit = (data: FormValues) => {
     startTransition(async () => {
-      const formData = new FormData();
+      try {
+        const formData = new FormData();
 
-      if (forceUsernameSetup) {
-        // 소셜 자동 생성 닉네임 보완 여부를 action에서 다시 판단할 수 있도록 전달
-        formData.append("forceUsernameSetup", "1");
-      }
-
-      if (onboarding.needsUsernameSetup && data.username) {
-        formData.append("username", data.username);
-      }
-      if (onboarding.needsEmailSetup && data.email) {
-        formData.append("email", data.email);
-      }
-      if (onboarding.needsLocationSetup) {
-        formData.append("locationName", data.locationName ?? "");
-        formData.append("region1", data.region1 ?? "");
-        formData.append("region2", data.region2 ?? "");
-        formData.append("region3", data.region3 ?? "");
-        formData.append("latitude", String(data.latitude ?? ""));
-        formData.append("longitude", String(data.longitude ?? ""));
-      }
-
-      const result = await completeOnboardingAction(formData);
-
-      if (!result.success) {
-        if (result.fieldErrors) {
-          applyFieldErrors<FormValues>(setError, result.fieldErrors, {
-            setFocus,
-          });
+        if (forceUsernameSetup) {
+          // 소셜 자동 생성 닉네임 보완 여부를 action에서 다시 판단할 수 있도록 전달
+          formData.append("forceUsernameSetup", "1");
         }
-        if (result.error) {
-          toast.error(result.error);
-        }
-        return;
-      }
 
-      toast.success("항해 준비가 완료되었습니다. 바로 서비스를 이용해보세요.");
-      router.replace(next);
+        if (onboarding.needsUsernameSetup && data.username) {
+          formData.append("username", data.username);
+        }
+        if (onboarding.needsEmailSetup && data.email) {
+          formData.append("email", data.email);
+        }
+        if (onboarding.needsLocationSetup) {
+          formData.append("locationName", data.locationName ?? "");
+          formData.append("region1", data.region1 ?? "");
+          formData.append("region2", data.region2 ?? "");
+          formData.append("region3", data.region3 ?? "");
+          formData.append("latitude", String(data.latitude ?? ""));
+          formData.append("longitude", String(data.longitude ?? ""));
+        }
+
+        const result = await completeOnboardingAction(formData);
+
+        if (!result.success) {
+          if (result.fieldErrors) {
+            applyFieldErrors<FormValues>(setError, result.fieldErrors, {
+              setFocus,
+            });
+          }
+          if (result.error) {
+            toast.error(result.error);
+          }
+          return;
+        }
+
+        toast.success("항해 준비가 완료되었습니다. 바로 서비스를 이용해보세요.");
+        router.replace(next);
+      } catch {
+        toast.error("온보딩 저장 중 일시적인 오류가 발생했습니다.");
+      }
     });
   };
 

--- a/features/auth/components/form/ResetPasswordForm.tsx
+++ b/features/auth/components/form/ResetPasswordForm.tsx
@@ -7,6 +7,7 @@
  * Date        Author   Status    Description
  * 2026.03.14  임도헌   Created   재설정 토큰 기반 새 비밀번호 설정 폼 추가
  * 2026.03.18  임도헌   Modified  비밀번호 재설정 후 로그인 화면으로 복귀할 때 callbackUrl을 유지
+ * 2026.05.19  임도헌   Modified  서버 액션 예외 시 pending 해제 후 토스트로 안내되도록 에러 처리 보강
  */
 "use client";
 
@@ -56,31 +57,33 @@ export default function ResetPasswordForm({
 
   const onSubmit = (data: PasswordResetFormSchema) => {
     startTransition(async () => {
-      const formData = new FormData();
-      formData.append("token", token);
-      formData.append("password", data.password);
-      formData.append("confirmPassword", data.confirmPassword);
+      try {
+        const formData = new FormData();
+        formData.append("token", token);
+        formData.append("password", data.password);
+        formData.append("confirmPassword", data.confirmPassword);
 
-      const result = await resetPasswordAction(undefined, formData);
+        const result = await resetPasswordAction(undefined, formData);
 
-      if (!result.success) {
-        if (result.fieldErrors) {
-          applyFieldErrors<PasswordResetFormSchema>(
-            setError,
-            result.fieldErrors,
-            { setFocus }
-          );
+        if (!result.success) {
+          if (result.fieldErrors) {
+            applyFieldErrors<PasswordResetFormSchema>(
+              setError,
+              result.fieldErrors,
+              { setFocus }
+            );
+          }
+          if (result.error) {
+            toast.error(result.error);
+          }
+          return;
         }
-        if (result.error) {
-          toast.error(result.error);
-        }
-        return;
+
+        toast.success("비밀번호가 재설정되었습니다. 새 비밀번호로 로그인해주세요.");
+        router.replace(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+      } catch {
+        toast.error("비밀번호 재설정 중 일시적인 오류가 발생했습니다.");
       }
-
-      toast.success("비밀번호가 재설정되었습니다. 새 비밀번호로 로그인해주세요.");
-      router.replace(
-        `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`
-      );
     });
   };
 

--- a/features/auth/components/form/SmsForm.tsx
+++ b/features/auth/components/form/SmsForm.tsx
@@ -21,6 +21,7 @@
  * 2026.03.14  임도헌   Modified  인증 성공 시 온보딩 필요 여부를 서버 redirectTo 규칙으로 통일
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 SMS 인증 안내와 액션 링크 타이포를 정리
  * 2026.05.12  임도헌   Modified  토큰 단계 보조 액션이 blur 검증으로 한 번 막히지 않도록 처리
+ * 2026.05.19  임도헌   Modified  서버 액션 예외 처리와 SMS 자동완성 힌트 보강
  */
 
 // react-hook-form에 사용되는 schema가 z.object가 아닌 단일 필드라서 전체 폼 검증이 무효화됨.
@@ -85,36 +86,40 @@ export default function SmsForm({
   const onSubmit = (data: FormValues) => {
     setFormError(null);
     startTransition(async () => {
-      // 1. 전화번호 전송 단계
-      if (phase === "phone" && data.phone) {
-        const formData = new FormData();
-        formData.append("phone", data.phone);
-        const res = await sendPhoneToken(formData);
+      try {
+        // 1. 전화번호 전송 단계
+        if (phase === "phone" && data.phone) {
+          const formData = new FormData();
+          formData.append("phone", data.phone);
+          const res = await sendPhoneToken(formData);
 
-        if (!res.success) {
-          setFormError(res.error || "알 수 없는 오류가 발생했습니다.");
-        } else {
-          setPhone(data.phone);
-          setPhase("token"); // 다음 단계로 전환
-          toast.success("인증번호가 발송되었습니다. 📨");
-          reset(); // 입력 필드 초기화 (토큰 입력 준비)
+          if (!res.success) {
+            setFormError(res.error || "알 수 없는 오류가 발생했습니다.");
+          } else {
+            setPhone(data.phone);
+            setPhase("token"); // 다음 단계로 전환
+            toast.success("인증번호가 발송되었습니다. 📨");
+            reset(); // 입력 필드 초기화 (토큰 입력 준비)
+          }
         }
-      }
 
-      // 2. 토큰 검증 단계
-      if (phase === "token" && data.token && phone) {
-        const formData = new FormData();
-        formData.append("token", data.token);
-        formData.append("phone", phone);
-        formData.append("callbackUrl", callbackUrl);
-        const res = await verifyPhoneToken(formData);
+        // 2. 토큰 검증 단계
+        if (phase === "token" && data.token && phone) {
+          const formData = new FormData();
+          formData.append("token", data.token);
+          formData.append("phone", phone);
+          formData.append("callbackUrl", callbackUrl);
+          const res = await verifyPhoneToken(formData);
 
-        if (!res.success) {
-          setFormError(res.error || "알 수 없는 오류가 발생했습니다.");
-        } else {
-          toast.success("인증 성공! 항해를 시작합니다. ⚓");
-          router.replace(res.redirectTo ?? callbackUrl);
+          if (!res.success) {
+            setFormError(res.error || "알 수 없는 오류가 발생했습니다.");
+          } else {
+            toast.success("인증 성공! 항해를 시작합니다. ⚓");
+            router.replace(res.redirectTo ?? callbackUrl);
+          }
         }
+      } catch {
+        setFormError("SMS 인증 처리 중 일시적인 오류가 발생했습니다.");
       }
     });
   };
@@ -124,18 +129,22 @@ export default function SmsForm({
 
     setFormError(null);
     startTransition(async () => {
-      const formData = new FormData();
-      formData.append("phone", phone);
-      const res = await sendPhoneToken(formData);
+      try {
+        const formData = new FormData();
+        formData.append("phone", phone);
+        const res = await sendPhoneToken(formData);
 
-      if (!res.success) {
-        setFormError(res.error || "인증번호 재전송에 실패했습니다.");
-        return;
+        if (!res.success) {
+          setFormError(res.error || "인증번호 재전송에 실패했습니다.");
+          return;
+        }
+
+        toast.success("인증번호를 다시 발송했습니다. 📨");
+        reset({ token: "" });
+        setFocus("token");
+      } catch {
+        setFormError("인증번호 재전송 중 일시적인 오류가 발생했습니다.");
       }
-
-      toast.success("인증번호를 다시 발송했습니다. 📨");
-      reset({ token: "" });
-      setFocus("token");
     });
   };
 
@@ -166,6 +175,7 @@ export default function SmsForm({
             {...register("phone")}
             type="tel"
             placeholder="휴대폰 번호 (- 없이 입력)"
+            autoComplete="tel"
             errors={phoneError}
             required
             icon={<DevicePhoneMobileIcon className="size-5" />}
@@ -185,6 +195,7 @@ export default function SmsForm({
             {...register("token")}
             type="number"
             placeholder="인증번호 6자리"
+            autoComplete="one-time-code"
             min={100000}
             max={999999}
             errors={tokenError}

--- a/features/boardgame/components/catalog/BoardGameCatalogListContainer.tsx
+++ b/features/boardgame/components/catalog/BoardGameCatalogListContainer.tsx
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.08  임도헌   Created   HydrationBoundary 아래에서 도감 목록 Query 캐시 사용
+ * 2026.05.18  임도헌   Modified  긴 도감 목록 탐색을 위해 목록 상단에도 페이지네이션 배치
  */
 
 "use client";
@@ -64,11 +65,19 @@ export default function BoardGameCatalogListContainer({
             </p>
           </div>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {items.map((item) => (
-              <BoardGameCatalogCard key={item.id} item={item} />
-            ))}
-          </div>
+          <>
+            <BoardGamePagination
+              page={page}
+              totalPages={totalPages}
+              filters={filters}
+              placement="top"
+            />
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {items.map((item) => (
+                <BoardGameCatalogCard key={item.id} item={item} />
+              ))}
+            </div>
+          </>
         )}
       </section>
 

--- a/features/boardgame/components/catalog/BoardGamePagination.tsx
+++ b/features/boardgame/components/catalog/BoardGamePagination.tsx
@@ -9,6 +9,8 @@
  * 2026.05.06  임도헌   Modified  관리자 페이지네이션과 같은 숫자형/ellipsis 탐색 패턴으로 정리
  * 2026.05.06  임도헌   Modified  숫자형 페이지네이션 JSDoc 명사형 기준 정리
  * 2026.05.12  임도헌   Modified  페이지 번호 직접 입력 이동 폼 추가
+ * 2026.05.18  임도헌   Modified  직접 이동 버튼 아이콘을 다음 페이지와 구분되는 Enter 계열 아이콘으로 변경
+ * 2026.05.18  임도헌   Modified  상단/하단 동시 배치와 숫자 버튼 중앙 정렬 보정
  */
 "use client";
 
@@ -16,7 +18,7 @@ import Link from "next/link";
 import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import {
-  ArrowRightIcon,
+  ArrowTurnDownLeftIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
 } from "@heroicons/react/24/outline";
@@ -27,6 +29,7 @@ interface BoardGamePaginationProps {
   page: number;
   totalPages: number;
   filters: BoardGameCatalogFilters;
+  placement?: "top" | "bottom";
 }
 
 type VisiblePage = number | "ellipsis";
@@ -80,6 +83,7 @@ export default function BoardGamePagination({
   page,
   totalPages,
   filters,
+  placement = "bottom",
 }: BoardGamePaginationProps) {
   const router = useRouter();
   const [targetPage, setTargetPage] = useState(String(page));
@@ -92,6 +96,8 @@ export default function BoardGamePagination({
   if (totalPages <= 1) return null;
 
   const visiblePages = buildVisiblePages(page, totalPages);
+  const jumpInputId = `boardgame-page-jump-${placement}`;
+  const jumpTotalId = `boardgame-page-jump-total-${placement}`;
 
   const handleJumpSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -112,7 +118,11 @@ export default function BoardGamePagination({
 
   return (
     <nav
-      className="mt-8 flex flex-wrap items-center justify-center gap-2 sm:gap-3"
+      className={
+        placement === "top"
+          ? "mb-4 flex flex-wrap items-center justify-center gap-2 sm:gap-3"
+          : "mt-8 flex flex-wrap items-center justify-center gap-2 sm:gap-3"
+      }
       aria-label="보드게임 도감 페이지네이션"
     >
       <PageLink
@@ -158,11 +168,11 @@ export default function BoardGamePagination({
         className="flex min-h-[44px] items-center gap-1.5 rounded-xl border border-border-subtle bg-surface px-2 py-1 shadow-sm"
         aria-label="페이지 번호로 바로 이동"
       >
-        <label htmlFor="boardgame-page-jump" className="sr-only">
+        <label htmlFor={jumpInputId} className="sr-only">
           이동할 페이지 번호
         </label>
         <input
-          id="boardgame-page-jump"
+          id={jumpInputId}
           type="number"
           min={1}
           max={totalPages}
@@ -172,11 +182,11 @@ export default function BoardGamePagination({
           onBlur={() => {
             if (!targetPage.trim()) setTargetPage(String(page));
           }}
-          className="h-9 w-16 rounded-lg border border-border bg-background px-2 text-center text-sm font-medium text-primary outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/20"
-          aria-describedby="boardgame-page-jump-total"
+          className="h-9 w-16 rounded-lg border border-border bg-background px-2 text-center text-sm font-medium leading-none text-primary outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/20"
+          aria-describedby={jumpTotalId}
         />
         <span
-          id="boardgame-page-jump-total"
+          id={jumpTotalId}
           className="whitespace-nowrap text-xs font-medium text-muted"
         >
           / {totalPages}
@@ -186,7 +196,7 @@ export default function BoardGamePagination({
           className="focus-ring-soft inline-flex min-h-9 min-w-9 items-center justify-center rounded-lg bg-surface-dim text-muted transition-colors hover:bg-brand hover:text-white"
           aria-label="입력한 페이지로 이동"
         >
-          <ArrowRightIcon className="size-4" aria-hidden="true" />
+          <ArrowTurnDownLeftIcon className="size-4" aria-hidden="true" />
         </button>
       </form>
 
@@ -227,9 +237,9 @@ function PageLink({
   variant?: "page" | "icon";
 }): ReactNode {
   const iconClass =
-    "focus-ring-soft rounded-lg p-2 text-muted transition-colors hover:bg-surface-dim disabled:opacity-30 disabled:hover:bg-transparent";
+    "focus-ring-soft inline-flex size-10 items-center justify-center rounded-lg text-muted transition-colors hover:bg-surface-dim disabled:opacity-30 disabled:hover:bg-transparent";
   const pageClass =
-    "focus-ring-soft min-w-10 rounded-xl border px-3 py-2 text-sm font-medium transition-colors";
+    "focus-ring-soft inline-flex h-10 min-w-10 items-center justify-center rounded-xl border px-3 text-sm font-medium leading-none transition-colors";
   const activePageClass = "border-border-strong bg-brand text-white";
   const inactivePageClass =
     "border-border bg-surface text-primary hover:bg-surface-dim";
@@ -237,7 +247,11 @@ function PageLink({
   if (disabled) {
     return (
       <span
-        className={variant === "icon" ? `${iconClass} opacity-30` : `${pageClass} ${inactivePageClass} opacity-40`}
+        className={
+          variant === "icon"
+            ? `${iconClass} opacity-30`
+            : `${pageClass} ${inactivePageClass} opacity-40`
+        }
         aria-disabled="true"
         aria-label={ariaLabel}
       >

--- a/features/boardgame/hooks/useBoardGameCatalogQuery.ts
+++ b/features/boardgame/hooks/useBoardGameCatalogQuery.ts
@@ -6,12 +6,12 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.08  임도헌   Created   page/filter 기반 공개 도감 목록 Suspense Query 추가
+ * 2026.05.18  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출을 피하도록 Route Handler fetch로 변경
  */
 
 "use client";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { getBoardGamesCatalogAction } from "@/features/boardgame/actions/list";
 import { queryKeys } from "@/lib/queryKeys";
 import type { BoardGameCatalogFilters } from "@/features/boardgame/types/catalog";
 import type { BoardGamePublicListResponse } from "@/features/boardgame/types/public";
@@ -23,7 +23,55 @@ interface UseBoardGameCatalogQueryParams {
 }
 
 /**
+ * 보드게임 도감 목록 API URL 생성
+ *
+ * @param params - 페이지, 페이지 크기, 필터 조건
+ * @returns 도감 목록 API URL
+ */
+function buildBoardGameCatalogApiUrl({
+  page,
+  limit,
+  filters,
+}: UseBoardGameCatalogQueryParams) {
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+
+  if (filters.query) params.set("q", filters.query);
+  if (filters.players) params.set("players", filters.players);
+  if (filters.playTime) params.set("playTime", filters.playTime);
+  if (filters.weight) params.set("weight", filters.weight);
+  if (filters.sort) params.set("sort", filters.sort);
+
+  return `/api/boardgames/catalog?${params.toString()}`;
+}
+
+/**
+ * 공개 보드게임 도감 목록 API 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param params - 페이지, 페이지 크기, 필터 조건
+ * @returns 공개 도감 목록 응답
+ */
+async function fetchBoardGameCatalog(
+  params: UseBoardGameCatalogQueryParams
+): Promise<BoardGamePublicListResponse> {
+  const response = await fetch(buildBoardGameCatalogApiUrl(params), {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    throw new Error("보드게임 도감 목록을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
+/**
  * 공개 보드게임 도감 목록 캐시 조회
+ * Route Handler fetch를 통해 Client queryFn의 Server Action 직접 호출을 피하는 조회 훅
  *
  * @param params - 페이지, 페이지 크기, URL 기반 필터
  * @returns 공개 도감 목록 응답
@@ -35,7 +83,7 @@ export function useBoardGameCatalogQuery({
 }: UseBoardGameCatalogQueryParams): BoardGamePublicListResponse {
   const { data } = useSuspenseQuery({
     queryKey: queryKeys.boardgames.list({ page, limit, ...filters }),
-    queryFn: () => getBoardGamesCatalogAction(page, limit, filters),
+    queryFn: () => fetchBoardGameCatalog({ page, limit, filters }),
   });
 
   return data;

--- a/features/chat/components/ChatMessagesList.tsx
+++ b/features/chat/components/ChatMessagesList.tsx
@@ -56,10 +56,11 @@
  * 2026.04.10  임도헌   Modified  채팅 타이포 정책에 맞춰 검색 상태 문구 강조 weight를 500 기준으로 정리
  * 2026.04.21  임도헌   Modified  검색/뷰포트 상태를 전용 훅으로 분리하고 함수 설명 주석을 정리
  * 2026.04.22  임도헌   Modified  메시지 삭제 확인을 브라우저 confirm 대신 공용 ConfirmDialog로 통일
+ * 2026.05.18  임도헌   Modified  채팅방 진입 직후 목록/TabBar 미읽음 캐시를 읽음 상태와 즉시 동기화
  */
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -203,6 +204,24 @@ export default function ChatMessagesList({
     isMobile,
     isKeyboardOpen,
   });
+
+  useEffect(() => {
+    // 서버 컴포넌트에서 이미 읽음 처리한 결과를 클라이언트 Query Cache에도 즉시 반영
+    queryClient.setQueryData(
+      queryKeys.chats.list(user.id),
+      (oldRooms: ChatRoom[] | undefined) => {
+        if (!oldRooms) return oldRooms;
+
+        return oldRooms.map((room) =>
+          room.id === productChatRoomId ? { ...room, unreadCount: 0 } : room
+        );
+      }
+    );
+    void queryClient.refetchQueries({
+      queryKey: queryKeys.chats.unreadCount(user.id),
+      type: "all",
+    });
+  }, [productChatRoomId, queryClient, user.id]);
 
   /**
    * 채팅방 목록 마지막 메시지 미리보기 동기화

--- a/features/chat/components/ChatRoomsRealtimeBridge.tsx
+++ b/features/chat/components/ChatRoomsRealtimeBridge.tsx
@@ -6,6 +6,9 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.17  임도헌   Created   TabBar와 채팅 목록의 user chat-room 채널 중복 구독 제거
+ * 2026.05.18  임도헌   Modified  탭 밖 채팅 상세까지 포함하도록 앱 전역 브리지 역할로 설명 보강
+ * 2026.05.18  임도헌   Modified  초기 렌더 중 Server Action 재호출을 피하도록 마운트 직후 목록 invalidate 제거
+ * 2026.05.18  임도헌   Modified  rooms_refresh 수신 시 미읽음 수 query를 비활성 상태까지 재검증하도록 보강
  */
 "use client";
 
@@ -22,8 +25,8 @@ interface ChatRoomsRealtimeBridgeProps {
 /**
  * 채팅방 요약 Realtime 브리지
  *
- * - 앱 탭 영역에서 사용자 단위 `rooms_refresh` 채널을 한 번만 구독
- * - 이벤트 수신 시 채팅 목록과 하단 탭바 미읽음 수 query를 함께 무효화
+ * - 로그인 후 앱 영역에서 사용자 단위 `rooms_refresh` 채널을 한 번만 구독
+ * - 이벤트 수신 시 채팅 목록과 TabBar 미읽음 수 query를 함께 재검증
  * - `pagehide`/hidden 상태에서는 채널을 정리하고, 복귀 시 서버 상태를 재검증
  *
  * @param {ChatRoomsRealtimeBridgeProps} props
@@ -40,8 +43,15 @@ export default function ChatRoomsRealtimeBridge({
     const unreadQueryKey = queryKeys.chats.unreadCount(userId);
 
     const refreshChatSummaries = () => {
-      void queryClient.invalidateQueries({ queryKey: listQueryKey });
-      void queryClient.invalidateQueries({ queryKey: unreadQueryKey });
+      // 목록은 화면에 보일 때만 재조회하고, TabBar 뱃지는 어느 화면에서도 최신화되도록 all refetch
+      void queryClient.invalidateQueries({
+        queryKey: listQueryKey,
+        refetchType: "active",
+      });
+      void queryClient.refetchQueries({
+        queryKey: unreadQueryKey,
+        type: "all",
+      });
     };
 
     const subscribe = () => {

--- a/features/chat/hooks/useChatRoomSubscription.ts
+++ b/features/chat/hooks/useChatRoomSubscription.ts
@@ -1,6 +1,6 @@
 /**
  * File Name : features/chat/hooks/useChatRoomSubscription.ts
- * Description : Supabase 채팅방 실시간 구독 훅
+ * Description : 채팅방 목록 TanStack Query 조회 훅
  * Author : 임도헌
  *
  * History
@@ -14,7 +14,7 @@
  * 2026.01.22  임도헌   Modified  Utils 경로 수정
  * 2026.01.28  임도헌   Modified  주석 보강
  * 2026.03.03  임도헌   Modified  useState 기반 상태 제거 및 useSuspenseQuery / setQueryData 연동으로 구조 전면 개편
- * 2026.03.03  임도헌   Modified  getChatRoomsAction 서버 액션 호출로 변경 (Service 직접 호출 차단)
+ * 2026.03.03  임도헌   Modified  getChatRoomsAction 서버 액션 호출로 변경
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.03.07  임도헌   Modified  message_read readerId 기준으로 unreadCount 초기화 조건 보강
  * 2026.03.13  임도헌   Modified  SYSTEM 메시지 수신 시 채팅방 목록 unreadCount를 증가시키지 않도록 보정
@@ -23,21 +23,41 @@
  * 2026.04.04  임도헌   Modified  사용자 채널 rooms_refresh로 새 채팅방 등장 시 목록 재조회 지원
  * 2026.04.14  임도헌   Modified  채팅 목록 성능 점검 대응으로 방별 구독을 제거하고 사용자 단위 refresh 채널만 유지
  * 2026.05.17  임도헌   Modified  사용자 단위 refresh 채널을 ChatRoomsRealtimeBridge로 이동해 목록 훅은 query 조회만 담당
+ * 2026.05.18  임도헌   Modified  Client queryFn 초기 렌더의 채팅 목록 Server Action 호출을 피하도록 Route Handler fetch로 변경
  */
 
 "use client";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
-import { getChatRoomsAction } from "@/features/chat/actions/room";
+import type { ChatRoom } from "@/features/chat/types";
 
 /**
- * 채팅방 목록 페이지용 실시간 구독 훅
+ * 채팅방 목록 API 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @returns {Promise<ChatRoom[]>} 현재 로그인 유저의 채팅방 목록
+ */
+async function fetchChatRooms(): Promise<ChatRoom[]> {
+  const response = await fetch("/api/chats/rooms", {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    throw new Error("채팅방 목록을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
+/**
+ * 채팅방 목록 페이지용 조회 훅
  *
  * [기능 및 동작 원리]
  * 1. `useSuspenseQuery`를 활용하여 하이드레이션된 채팅방 목록을 선언적으로 가져옴
  * 2. Realtime 이벤트 처리는 탭 레이아웃의 `ChatRoomsRealtimeBridge`가 담당
- * 3. 목록 훅은 query data를 읽는 역할만 맡아 탭바와 같은 채널을 중복으로 열지 않음
+ * 3. 목록 훅은 Route Handler fetch만 담당해 Client queryFn의 Server Action 직접 호출을 피함
  *
  * @param {number} userId - 현재 접속 중인 사용자 ID
  * @returns {{ rooms: ChatRoom[] }} 최신화된 채팅방 목록 query 결과
@@ -48,7 +68,7 @@ export default function useChatRoomSubscription(userId: number) {
   // 1. 서버 캐시 연동 (Suspense 지원)
   const { data: rooms } = useSuspenseQuery({
     queryKey,
-    queryFn: () => getChatRoomsAction(),
+    queryFn: fetchChatRooms,
     staleTime: 60 * 1000,
   });
 

--- a/features/chat/hooks/useChatSubscription.ts
+++ b/features/chat/hooks/useChatSubscription.ts
@@ -27,9 +27,11 @@
  * 2026.04.01  임도헌   Modified  message_deleted 이벤트 수신 및 로컬 메시지 교체 콜백 추가
  * 2026.04.02  임도헌   Modified  구독 훅 JSDoc 반환 설명 보강
  * 2026.04.10  임도헌   Modified  상위 검색 모달 클라이언트 경계 아래에서만 사용되도록 use client 중복 선언을 제거
+ * 2026.05.18  임도헌   Modified  채팅방 내부 읽음 처리 후 TabBar 미읽음 query를 즉시 동기화
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import {
   ChatMessage,
@@ -40,6 +42,7 @@ import { readMessageUpdateAction } from "@/features/chat/actions/messages";
 import type { AppointmentStatus } from "@/generated/prisma/enums";
 import { useNotificationStore } from "@/components/global/providers/NotificationStoreProvider";
 import { CHAT_EVENT } from "@/features/chat/constants";
+import { queryKeys } from "@/lib/queryKeys";
 
 interface UseChatSubscriptionOptions {
   chatRoomId: string; // Supabase 채널 식별용 채팅방 ID
@@ -81,6 +84,8 @@ export default function useChatSubscription({
   onAppointmentUpdate,
   throttleReadUpdate = true,
 }: UseChatSubscriptionOptions) {
+  const queryClient = useQueryClient();
+
   // 상위 컴포넌트의 리렌더링으로 인해 콜백 참조값이 변경되더라도
   // 불필요한 재구독이 발생하지 않도록 useRef를 사용하여 최신 콜백을 유지
   const onNewMessageRef = useRef(onNewMessage);
@@ -91,6 +96,28 @@ export default function useChatSubscription({
 
   // Zustand 액션 가져오기 (이전의 window.dispatchEvent 대체)
   const decrement = useNotificationStore((state) => state.decrement);
+
+  const syncUnreadChatQueries = useCallback(
+    (readCount: number) => {
+      if (readCount > 0) {
+        queryClient.setQueryData<number>(
+          queryKeys.chats.unreadCount(currentUserId),
+          (current) => Math.max((current ?? 0) - readCount, 0)
+        );
+      }
+
+      // Realtime 이벤트 도착 전에도 상세 화면의 읽음 결과를 관련 query에 즉시 반영
+      void queryClient.refetchQueries({
+        queryKey: queryKeys.chats.unreadCount(currentUserId),
+        type: "all",
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.chats.list(currentUserId),
+        refetchType: "active",
+      });
+    },
+    [currentUserId, queryClient]
+  );
 
   useEffect(() => {
     onNewMessageRef.current = onNewMessage;
@@ -160,6 +187,9 @@ export default function useChatSubscription({
               if (res.success && res.readIds.length > 0) {
                 decrement(res.readIds.length);
               }
+              if (res.success) {
+                syncUnreadChatQueries(res.readIds.length);
+              }
               return;
             }
 
@@ -174,6 +204,9 @@ export default function useChatSubscription({
             // 쓰로틀링 모드에서도 동일하게 스토어 상태를 차감함
             if (res.success && res.readIds.length > 0) {
               decrement(res.readIds.length);
+            }
+            if (res.success) {
+              syncUnreadChatQueries(res.readIds.length);
             }
           } finally {
             // 다음 메시지 수신 시 다시 호출 가능하도록 락 해제
@@ -253,5 +286,11 @@ export default function useChatSubscription({
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [chatRoomId, currentUserId, throttleReadUpdate, decrement]);
+  }, [
+    chatRoomId,
+    currentUserId,
+    throttleReadUpdate,
+    decrement,
+    syncUnreadChatQueries,
+  ]);
 }

--- a/features/common/service/view.ts
+++ b/features/common/service/view.ts
@@ -15,10 +15,12 @@
  * 2026.03.28  임도헌   Modified   공략(MAP) 조회수 누적 뱃지가 상세 진입 증가에도 반응하도록 후처리 추가
  * 2026.05.08  임도헌   Modified   외부 사용이 없는 조회 대상 내부 타입 export 제거
  * 2026.05.16  임도헌   Modified   캐시 재검증 제거 이후 흐름에 맞게 주석 정리 및 공용 타입/상수 분리
+ * 2026.05.19  임도헌   Modified   조회수 DB write service가 클라이언트 번들에 포함되지 않도록 server-only 가드 추가
  */
 
 "use server";
 
+import "server-only";
 import db from "@/lib/db";
 import { checkRuleSageBadge } from "@/features/user/service/badge";
 import { isUniqueConstraintError } from "@/lib/errors";

--- a/features/notification/components/NotificationListener.tsx
+++ b/features/notification/components/NotificationListener.tsx
@@ -25,14 +25,17 @@
  * 2026.04.13  임도헌   Modified  next/navigation 및 정적 toast/image 의존을 줄여 알림 후속 번들 평가 비용을 완화
  * 2026.04.22  임도헌   Modified  개인 sys_event를 전역 브리지 이벤트로 발행해 스트림 상세 운영 액션(강제 퇴장/채팅 금지/유저 차단)의 실시간 반영 경로를 단일화
  * 2026.05.17  임도헌   Modified  pagehide/hidden 상태에서 알림 채널을 정리하고 복귀 시 unread count를 서버 기준으로 재동기화
+ * 2026.05.18  임도헌   Modified  채팅 알림 수신 시 TabBar 미읽음 query도 함께 재검증
  */
 "use client";
 
 import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { useNotificationStore } from "@/components/global/providers/NotificationStoreProvider";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import { getUnreadNotificationCount } from "@/features/notification/actions/count";
+import { queryKeys } from "@/lib/queryKeys";
 
 type NotiPayload = {
   id?: number;
@@ -77,6 +80,7 @@ function getCurrentPath() {
  * @param {number} userId - 로그인한 사용자 ID
  */
 export default function NotificationListener({ userId }: { userId: number }) {
+  const queryClient = useQueryClient();
   // Zustand 스토어에서 알림 카운트 증가 액션 가져오기
   const increment = useNotificationStore((state) => state.increment);
   const setUnreadCount = useNotificationStore((state) => state.setUnreadCount);
@@ -126,6 +130,18 @@ export default function NotificationListener({ userId }: { userId: number }) {
       setUnreadCount(nextCount);
     };
 
+    const syncChatUnreadCount = () => {
+      // CHAT 알림은 알림 벨과 별개로 채팅 뱃지도 바꿀 수 있어 보조 재검증 경로를 둠
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.chats.list(userId),
+        refetchType: "active",
+      });
+      void queryClient.refetchQueries({
+        queryKey: queryKeys.chats.unreadCount(userId),
+        type: "all",
+      });
+    };
+
     const subscribe = () => {
       if (activeChannel) return;
 
@@ -135,6 +151,11 @@ export default function NotificationListener({ userId }: { userId: number }) {
         const p = payload as Partial<NotiPayload>;
 
         if (typeof p.userId === "number" && p.userId !== userId) return;
+
+        if (p.type === "CHAT") {
+          // 알림 채널은 배포 환경에서 이미 살아 있는 사용자 채널이므로 채팅 뱃지 재검증 보조 경로로 활용
+          syncChatUnreadCount();
+        }
 
         // 사용자가 현재 보고 있는 페이지(예: 지금 대화 중인 채팅방)와 관련된 알림일 경우,
         // 토스트 팝업 표시 및 상단 뱃지 카운트 증가를 생략하여 번쩍거리는 UX 결함을 방지
@@ -252,7 +273,7 @@ export default function NotificationListener({ userId }: { userId: number }) {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       unsubscribe();
     };
-  }, [userId, increment, setUnreadCount]);
+  }, [userId, increment, queryClient, setUnreadCount]);
 
   return null;
 }

--- a/features/notification/service/sender.ts
+++ b/features/notification/service/sender.ts
@@ -16,8 +16,11 @@
  * 2026.03.07  임도헌   Modified  SYSTEM 기본 tag가 KEYWORD로 폴스루되지 않도록 분기 수정
  * 2026.04.02  임도헌   Modified  푸시 결과 타입과 알림 타입을 notification/types 공용 정의로 분리
  * 2026.05.16  임도헌   Modified  푸시 payload 타입을 명시해 any 제거
+ * 2026.05.18  임도헌   Modified  만료/해지된 Push 구독 정리는 expected cleanup으로 로깅 레벨 조정
+ * 2026.05.19  임도헌   Modified  Web Push/DB 접근 service가 클라이언트 번들에 포함되지 않도록 server-only 가드 추가
  */
 
+import "server-only";
 import webPush from "web-push";
 import db from "@/lib/db";
 import type { NotificationType, SendPushResult } from "@/features/notification/types";
@@ -327,19 +330,23 @@ export async function sendPushNotification({
             // 410 Gone, 404 Not Found -> 구독 만료
             if (err.statusCode === 410 || err.statusCode === 404) {
               results.removed += 1;
-              await db.pushSubscription.delete({ where: { id: sub.id } });
+              await db.pushSubscription.deleteMany({ where: { id: sub.id } });
+              console.info("WebPush subscription expired and removed:", {
+                status: err.statusCode,
+                endpoint: sub.endpoint,
+              });
             } else {
               // 그 외 에러 (403, 429, 500 등) -> 일시 비활성
               results.disabled += 1;
               await db.pushSubscription
                 .update({ where: { id: sub.id }, data: { isActive: false } })
                 .catch(() => {});
+              console.error("WebPush error:", {
+                status: err.statusCode,
+                body: err.body,
+                endpoint: sub.endpoint,
+              });
             }
-            console.error("WebPush error:", {
-              status: err.statusCode,
-              body: err.body,
-              endpoint: sub.endpoint,
-            });
           } else {
             // 알 수 없는 에러
             console.error("Unknown Push error:", err);

--- a/features/post/components/PostLikeButton.tsx
+++ b/features/post/components/PostLikeButton.tsx
@@ -23,16 +23,23 @@
  * 2026.04.14  임도헌   Modified  게시글 상세 기준으로 좋아요 시각 텍스트를 명시해 Lighthouse 레이블 불일치 가능성을 낮춤
  * 2026.04.14  임도헌   Modified  별도 aria-labelledby 없이 버튼 본문 텍스트를 그대로 이름으로 사용하도록 단순화
  * 2026.05.12  임도헌   Modified  다른 상세 화면과 맞춰 시각 레이블은 하트와 숫자만 남기고 접근성 이름은 aria-label로 분리
+ * 2026.05.18  임도헌   Modified  상세 좋아요 변경 시 게시글 목록 캐시의 isLiked와 좋아요 수를 함께 낙관 업데이트
  */
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import { dislikePost, likePost } from "@/features/post/actions/likes";
 import { queryKeys } from "@/lib/queryKeys";
 import { HeartIcon } from "@heroicons/react/24/solid";
 import { HeartIcon as OutlineHeartIcon } from "@heroicons/react/24/outline";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import type { PostsPage } from "@/features/post/types";
 
 interface PostLikeButtonProps {
   postId: number;
@@ -46,6 +53,7 @@ interface PostLikeButtonProps {
  * [상태 주입 및 캐시 제어 로직]
  * - `initialData`를 통한 초기 렌더링 깜빡임 방지 및 상태 하이드레이션 적용
  * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 피드백 제공
+ * - 상세 좋아요 변경 시 목록 카드의 좋아요 수와 isLiked도 함께 갱신해 뒤로가기 후 하트 색상 정합성 유지
  * - `onError` 발생 시 `previous` 스냅샷을 활용한 이전 상태 복구(Rollback) 로직 포함
  * - `onSettled` 단계에서 `invalidateQueries` 호출로 서버/클라이언트 데이터 최종 동기화 처리
  */
@@ -73,28 +81,66 @@ export default function PostLikeButton({
     // Mutate 발생 직후 실행 (낙관적 업데이트)
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: queryKeys.posts.lists() });
       // 롤백을 위한 이전 상태 스냅샷 저장
       const previous = queryClient.getQueryData(queryKey);
+      const previousLists =
+        queryClient.getQueriesData<InfiniteData<PostsPage>>({
+          queryKey: queryKeys.posts.lists(),
+        });
+
+      const nextIsLiked = !data.isLiked;
+      const nextLikeCount = data.isLiked
+        ? Math.max(0, data.likeCount - 1)
+        : data.likeCount + 1;
 
       // 캐시 강제 업데이트
       queryClient.setQueryData(queryKey, {
-        isLiked: !data.isLiked,
-        likeCount: data.isLiked
-          ? Math.max(0, data.likeCount - 1)
-          : data.likeCount + 1,
+        isLiked: nextIsLiked,
+        likeCount: nextLikeCount,
       });
 
-      return { previous };
+      // 목록 카드는 별도 좋아요 버튼이 없지만 하트 색상은 isLiked 기준이므로 상세 변경을 즉시 반영
+      queryClient.setQueriesData<InfiniteData<PostsPage>>(
+        { queryKey: queryKeys.posts.lists() },
+        (old) =>
+          old
+            ? {
+                ...old,
+                pages: old.pages.map((page) => ({
+                  ...page,
+                  posts: page.posts.map((post) =>
+                    post.id === postId
+                      ? {
+                          ...post,
+                          isLiked: nextIsLiked,
+                          _count: {
+                            ...post._count,
+                            post_likes: nextLikeCount,
+                          },
+                        }
+                      : post
+                  ),
+                })),
+              }
+            : old
+      );
+
+      return { previous, previousLists };
     },
     // 에러 발생 시 이전 상태로 복구
     onError: (err, _variables, context) => {
       console.error("Like mutation failed:", err);
       toast.error("게시글 좋아요 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
       queryClient.setQueryData(queryKey, context?.previous);
+      context?.previousLists.forEach(([listQueryKey, listData]) => {
+        queryClient.setQueryData(listQueryKey, listData);
+      });
     },
     // 성공/실패 무관하게 백그라운드 데이터 최신화
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: queryKeys.posts.lists() });
     },
   });
   const likeButtonLabel = data.isLiked

--- a/features/post/components/postCard/PostCardMeta.tsx
+++ b/features/post/components/postCard/PostCardMeta.tsx
@@ -16,6 +16,7 @@
  * 2026.03.06  임도헌   Modified  모바일 그리드 메타를 하단 정렬로 재배치하고 통계/시간을 한 줄로 정리
  * 2026.03.26  임도헌   Modified  리스트 카드 모바일에서는 위치 정보를 분리 노출해 시간 표시와의 충돌을 완화
  * 2026.04.10  임도헌   Modified  post 타이포 정책에 맞춰 카드 메타 숫자/위치/시간 라벨을 text-xs 기준으로 통일
+ * 2026.05.18  임도헌   Modified  좋아요 하트 강조 색상을 총 좋아요 수가 아닌 현재 사용자 좋아요 여부 기준으로 보정
  */
 "use client";
 
@@ -32,6 +33,7 @@ import type { ViewMode } from "@/features/product/types";
 interface PostCardMetaProps {
   views: number;
   likes: number;
+  isLiked?: boolean;
   comments: number;
   createdAt: string;
   region2?: string | null;
@@ -50,6 +52,7 @@ interface PostCardMetaProps {
 export default function PostCardMeta({
   views,
   likes,
+  isLiked = false,
   comments,
   createdAt,
   region2,
@@ -67,7 +70,7 @@ export default function PostCardMeta({
         <HeartIcon
           className={cn(
             "size-3 sm:size-3.5",
-            likes > 0 ? "text-rose-500" : "text-muted/70"
+            isLiked ? "text-rose-500" : "text-muted/70"
           )}
         />
         <span className="text-xs">{likes}</span>

--- a/features/post/components/postCard/index.tsx
+++ b/features/post/components/postCard/index.tsx
@@ -24,6 +24,7 @@
  * 2026.04.14  임도헌   Modified  현재 목록 경로(returnTo)와 대표 카드 우선 로드 여부를 상위에서 주입받도록 정리
  * 2026.04.20  임도헌   Modified  게시글 카드 포커스가 브라우저 기본 outline 대신 keyboard-only inset 링으로 보이도록 조정
  * 2026.05.03  임도헌   Modified  게시글 목록 카드에 연결 보드게임 요약 배지 표시
+ * 2026.05.18  임도헌   Modified  게시글 카드 좋아요 하트 색상을 현재 사용자 좋아요 여부 기준으로 전달
  * ===============================================================================================
  * PostCard (게시글 카드) 컴포넌트를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * 각 컴포넌트는 게시글 정보를 보여주는 카드에서 특정 부분의 렌더링을 담당:
@@ -128,6 +129,7 @@ export default function PostCard({
           <PostCardMeta
             views={post.views}
             likes={post._count.post_likes}
+            isLiked={Boolean(post.isLiked)}
             comments={post._count.comments}
             createdAt={post.created_at.toString()}
             region2={post.region2}

--- a/features/post/components/postsDetail/PostDetailMeta.tsx
+++ b/features/post/components/postsDetail/PostDetailMeta.tsx
@@ -1,6 +1,6 @@
 /**
  * File Name : features/post/components/postDetail/PostDetailMeta.tsx
- * Description : 게시글 상세 메타 정보 (좋아요 버튼, 조회수, 작성일)
+ * Description : 게시글 상세 메타 정보 (좋아요 버튼, 조회수, 댓글 수, 작성일)
  * Author : 임도헌
  *
  * History
@@ -8,33 +8,47 @@
  * 2025.07.11  임도헌   Created   PostDetail Meta 분리
  * 2026.01.13  임도헌   Modified  [Rule 5.1] 아이콘/텍스트 색상 통일
  * 2026.01.17  임도헌   Moved     components/post -> features/post/components
+ * 2026.05.18  임도헌   Modified  상세 메타에 댓글 수 표시 및 post stats 캐시 연동
+ * 2026.05.18  임도헌   Modified  상세 통계 아이콘을 목록 카드와 같은 solid 문법으로 통일
  */
 "use client";
 
 import PostLikeButton from "@/features/post/components/PostLikeButton";
-import { EyeIcon } from "@heroicons/react/24/outline";
+import { ChatBubbleLeftIcon, EyeIcon } from "@heroicons/react/24/solid";
 import TimeAgo from "@/components/ui/TimeAgo";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 
 interface PostDetailMetaProps {
   postId: number;
   isLiked: boolean;
   likeCount: number;
   views: number;
+  commentCount: number;
   createdAt: string;
 }
 
 /**
  * 게시글 하단의 메타 정보 영역
  * - 좌측: 좋아요 버튼 (PostLikeButton)
- * - 우측: 조회수 및 작성 시간 (TimeAgo)
+ * - 우측: 조회수, 댓글 수, 작성 시간 (TimeAgo)
+ * - 댓글 수는 댓글 작성/삭제 mutation이 갱신하는 post stats 캐시 기준으로 표시
  */
 export default function PostDetailMeta({
   postId,
   isLiked,
   likeCount,
   views,
+  commentCount,
   createdAt,
 }: PostDetailMetaProps) {
+  const { data: stats } = useQuery({
+    queryKey: queryKeys.posts.stats(postId),
+    initialData: { commentCount },
+    staleTime: Infinity,
+    enabled: false,
+  });
+
   return (
     <div className="flex items-center justify-between">
       <PostLikeButton isLiked={isLiked} likeCount={likeCount} postId={postId} />
@@ -43,6 +57,10 @@ export default function PostDetailMeta({
         <div className="flex items-center gap-1">
           <EyeIcon className="size-4" />
           <span>{views.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <ChatBubbleLeftIcon className="size-4" />
+          <span>{stats.commentCount.toLocaleString()}</span>
         </div>
         <span className="text-border">|</span>
         <TimeAgo date={createdAt} />

--- a/features/post/components/postsDetail/index.tsx
+++ b/features/post/components/postsDetail/index.tsx
@@ -33,6 +33,7 @@
  * 2026.04.24  임도헌   Modified  detail-edit 링크에도 항상 내부 returnTo를 실어 저장 back 안전 조건과 정합성을 맞춤
  * 2026.05.03  임도헌   Modified  게시글 상세에 연결된 보드게임 카탈로그 칩 노출
  * 2026.05.04  임도헌   Modified  게시글 상세의 연결 보드게임을 도감 이동 카드로 강조
+ * 2026.05.18  임도헌   Modified  상세 메타에 댓글 수를 표시하도록 PostDetailMeta에 commentCount 전달
  * ===============================================================================================
  * PostDetail (게시글 상세) 페이지를 구성하는 UI 요소 모음
  *
@@ -162,6 +163,7 @@ export default function PostDetail({
             isLiked={isLiked}
             likeCount={likeCount}
             views={views}
+            commentCount={post._count.comments}
             createdAt={post.created_at?.toString() ?? ""}
           />
         </div>

--- a/features/post/hooks/useCreatePostCommentMutation.ts
+++ b/features/post/hooks/useCreatePostCommentMutation.ts
@@ -9,13 +9,19 @@
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.04.03  임도헌   Modified  댓글 작성 성공 토스트를 녹화 댓글과 같은 문법으로 통일
  * 2026.04.09  임도헌   Modified  성공 결과가 화면에 바로 드러나는 댓글 작성은 실패 토스트만 남기도록 정리
+ * 2026.05.18  임도헌   Modified  댓글 작성 시 상세 메타와 목록 카드 댓글 수 캐시 동기화 추가
  */
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import { createCommentAction } from "@/features/post/actions/comments";
 import { queryKeys } from "@/lib/queryKeys";
+import type { PostsPage } from "@/features/post/types";
 
 /**
  * 게시글 댓글 생성 전용 Mutation 훅
@@ -23,6 +29,7 @@ import { queryKeys } from "@/lib/queryKeys";
  * [기능]
  * - `createCommentAction` 서버 액션을 호출해 댓글 생성을 처리
  * - 성공 시 댓글 목록 쿼리를 무효화해 최신 목록을 다시 읽음
+ * - 상세 메타와 목록 카드 댓글 수를 낙관적으로 갱신해 상세/뒤로가기 흐름의 체감 지연을 줄임
  * - 실패 시 토스트 알림으로 사용자 피드백을 제공
  *
  * @param {number} postId - 댓글을 작성할 게시글 ID
@@ -30,6 +37,7 @@ import { queryKeys } from "@/lib/queryKeys";
 export function useCreatePostCommentMutation(postId: number) {
   const queryClient = useQueryClient();
   const queryKey = queryKeys.posts.comments(postId);
+  const statsQueryKey = queryKeys.posts.stats(postId);
 
   return useMutation({
     mutationFn: async (formData: FormData) => {
@@ -37,13 +45,60 @@ export function useCreatePostCommentMutation(postId: number) {
       if (!res.success) throw new Error(res.error);
       return res;
     },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.posts.lists() });
+
+      const previousStats = queryClient.getQueryData(statsQueryKey);
+      const previousLists = queryClient.getQueriesData<InfiniteData<PostsPage>>({
+        queryKey: queryKeys.posts.lists(),
+      });
+
+      queryClient.setQueryData(
+        statsQueryKey,
+        (oldData: { commentCount: number } | undefined) => ({
+          commentCount: (oldData?.commentCount ?? 0) + 1,
+        })
+      );
+      queryClient.setQueriesData<InfiniteData<PostsPage>>(
+        { queryKey: queryKeys.posts.lists() },
+        (oldData) =>
+          oldData
+            ? {
+                ...oldData,
+                pages: oldData.pages.map((page) => ({
+                  ...page,
+                  posts: page.posts.map((post) =>
+                    post.id === postId
+                      ? {
+                          ...post,
+                          _count: {
+                            ...post._count,
+                            comments: post._count.comments + 1,
+                          },
+                        }
+                      : post
+                  ),
+                })),
+              }
+            : oldData
+      );
+
+      return { previousStats, previousLists };
+    },
     onSuccess: () => {
       // 등록 직후 최신 댓글 목록 재조회
       queryClient.invalidateQueries({ queryKey });
     },
-    onError: (err) => {
+    onError: (err, _variables, context) => {
       console.error(err);
+      queryClient.setQueryData(statsQueryKey, context?.previousStats);
+      context?.previousLists.forEach(([listQueryKey, listData]) => {
+        queryClient.setQueryData(listQueryKey, listData);
+      });
       toast.error("댓글 작성에 실패했습니다.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.posts.lists() });
     },
   });
 }

--- a/features/post/hooks/useDeletePostCommentMutation.ts
+++ b/features/post/hooks/useDeletePostCommentMutation.ts
@@ -9,13 +9,19 @@
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.04.03  임도헌   Modified  댓글 삭제 성공 토스트를 녹화 댓글과 같은 문법으로 통일
  * 2026.04.09  임도헌   Modified  성공 결과가 화면에 바로 드러나는 댓글 삭제는 실패 토스트만 남기도록 정리
+ * 2026.05.18  임도헌   Modified  댓글 삭제 시 상세 메타와 목록 카드 댓글 수 캐시 동기화 추가
  */
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import { deleteCommentAction } from "@/features/post/actions/comments";
 import { queryKeys } from "@/lib/queryKeys";
+import type { PostsPage } from "@/features/post/types";
 
 /**
  * 게시글 댓글 삭제 전용 Mutation 훅
@@ -23,6 +29,7 @@ import { queryKeys } from "@/lib/queryKeys";
  * [기능]
  * - `deleteCommentAction` 서버 액션을 호출해 댓글 삭제를 처리
  * - 성공 시 댓글 목록 쿼리를 무효화해 최신 목록을 다시 읽음
+ * - 상세 메타와 목록 카드 댓글 수를 낙관적으로 갱신해 상세/뒤로가기 흐름의 체감 지연을 줄임
  * - 실패 시 토스트 알림으로 사용자 피드백을 제공
  *
  * @param {number} postId - 삭제할 댓글이 속한 게시글 ID
@@ -30,6 +37,7 @@ import { queryKeys } from "@/lib/queryKeys";
 export function useDeletePostCommentMutation(postId: number) {
   const queryClient = useQueryClient();
   const queryKey = queryKeys.posts.comments(postId);
+  const statsQueryKey = queryKeys.posts.stats(postId);
 
   return useMutation({
     mutationFn: async (commentId: number) => {
@@ -37,13 +45,60 @@ export function useDeletePostCommentMutation(postId: number) {
       if (!res.success) throw new Error(res.error);
       return res;
     },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.posts.lists() });
+
+      const previousStats = queryClient.getQueryData(statsQueryKey);
+      const previousLists = queryClient.getQueriesData<InfiniteData<PostsPage>>({
+        queryKey: queryKeys.posts.lists(),
+      });
+
+      queryClient.setQueryData(
+        statsQueryKey,
+        (oldData: { commentCount: number } | undefined) => ({
+          commentCount: Math.max(0, (oldData?.commentCount ?? 0) - 1),
+        })
+      );
+      queryClient.setQueriesData<InfiniteData<PostsPage>>(
+        { queryKey: queryKeys.posts.lists() },
+        (oldData) =>
+          oldData
+            ? {
+                ...oldData,
+                pages: oldData.pages.map((page) => ({
+                  ...page,
+                  posts: page.posts.map((post) =>
+                    post.id === postId
+                      ? {
+                          ...post,
+                          _count: {
+                            ...post._count,
+                            comments: Math.max(0, post._count.comments - 1),
+                          },
+                        }
+                      : post
+                  ),
+                })),
+              }
+            : oldData
+      );
+
+      return { previousStats, previousLists };
+    },
     onSuccess: () => {
       // 삭제 직후 최신 댓글 목록 재조회
       queryClient.invalidateQueries({ queryKey });
     },
-    onError: (err) => {
+    onError: (err, _variables, context) => {
       console.error(err);
+      queryClient.setQueryData(statsQueryKey, context?.previousStats);
+      context?.previousLists.forEach(([listQueryKey, listData]) => {
+        queryClient.setQueryData(listQueryKey, listData);
+      });
       toast.error("댓글 삭제에 실패했습니다.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.posts.lists() });
     },
   });
 }

--- a/features/post/hooks/usePostCommentsQuery.ts
+++ b/features/post/hooks/usePostCommentsQuery.ts
@@ -16,19 +16,62 @@
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.03.31  임도헌   Modified  커서 조회와 평탄화 반환 역할이 보이도록 설명 톤 통일
  * 2026.04.17  임도헌   Modified  댓글 무한스크롤 훅의 다음 커서 규칙과 반환 책임 설명 보강
+ * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
  */
 "use client";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getPostCommentsListAction } from "@/features/post/actions/comments";
 import { queryKeys } from "@/lib/queryKeys";
+import type { PostComment } from "@/features/post/types";
+
+/**
+ * 게시글 댓글 Route Handler 요청 URL 생성
+ *
+ * @param postId - 댓글을 조회할 게시글 ID
+ * @param cursor - 다음 페이지 커서
+ * @param limit - 페이지당 로드할 댓글 수
+ * @returns 게시글 댓글 API URL
+ */
+function buildPostCommentsApiUrl(
+  postId: number,
+  cursor: number | undefined,
+  limit: number
+) {
+  const params = new URLSearchParams({ limit: String(limit) });
+
+  if (cursor !== undefined) {
+    params.set("cursor", String(cursor));
+  }
+
+  return `/api/posts/${postId}/comments?${params.toString()}`;
+}
+
+/**
+ * 게시글 댓글 Route Handler 응답 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param url - 요청 URL
+ * @returns 게시글 댓글 목록
+ */
+async function fetchPostCommentsPage(url: string): Promise<PostComment[]> {
+  const response = await fetch(url, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    throw new Error("게시글 댓글을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
 
 /**
  * 게시글 댓글 목록 조회 전용 Suspense Query 훅
  *
  * [기능]
  * - `useSuspenseInfiniteQuery`로 댓글 목록을 커서 기반으로 조회
- * - 서버 액션(`getPostCommentsListAction`)을 호출해 다음 페이지를 이어서 읽음
+ * - Route Handler fetch로 Server Action 직접 호출을 피하고 다음 페이지를 이어서 읽음
  * - 마지막 페이지가 `pageSize`만큼 찼을 때만 끝 댓글 ID를 다음 커서로 이어 붙임
  * - 평탄화된 comments 배열과 페이지네이션 상태를 함께 반환
  *
@@ -41,10 +84,13 @@ export function usePostCommentsQuery(postId: number, pageSize = 10) {
     useSuspenseInfiniteQuery({
       queryKey: queryKeys.posts.comments(postId),
       queryFn: async ({ pageParam }) => {
-        return await getPostCommentsListAction(
-          postId,
-          pageParam as number | undefined,
-          pageSize
+        // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+        return fetchPostCommentsPage(
+          buildPostCommentsApiUrl(
+            postId,
+            pageParam as number | undefined,
+            pageSize
+          )
         );
       },
       initialPageParam: undefined as number | undefined,

--- a/features/post/hooks/usePostPagination.ts
+++ b/features/post/hooks/usePostPagination.ts
@@ -20,13 +20,17 @@
  * 2026.03.12  임도헌   Modified  currentRange 전환 시 stale 방지를 위한 queryKeyExtra 분기 설명 추가
  * 2026.03.14  임도헌   Modified  첫 페이지 totalCount를 노출해 무한스크롤 중에도 총 게시글 수를 고정 표시
  * 2026.04.17  임도헌   Modified  Suspense 무한스크롤 훅의 캐시 분리/반환 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
  */
 "use client";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getPostsListAction } from "@/features/post/actions/list";
 import { queryKeys } from "@/lib/queryKeys";
-import type { PostDetail, PostSearchParams } from "@/features/post/types";
+import type {
+  PostDetail,
+  PostSearchParams,
+  PostsPage,
+} from "@/features/post/types";
 
 // =============================================================================
 // 1. Hook Configuration Types
@@ -46,6 +50,46 @@ export interface UsePostPaginationResult {
   loadMore: () => Promise<unknown>;
 }
 
+/**
+ * 게시글 목록 API URL 생성
+ *
+ * @param searchParams - 게시글 검색 조건
+ * @param cursor - 다음 페이지 커서
+ * @returns 게시글 목록 API URL
+ */
+function buildPostsApiUrl(
+  searchParams: PostSearchParams,
+  cursor: number | null
+) {
+  const params = new URLSearchParams();
+  if (cursor) params.set("cursor", String(cursor));
+  if (searchParams.keyword) params.set("keyword", searchParams.keyword);
+  if (searchParams.category) params.set("category", searchParams.category);
+
+  const queryString = params.toString();
+  return queryString ? `/api/posts?${queryString}` : "/api/posts";
+}
+
+/**
+ * 게시글 목록 API 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param url - 호출할 Route Handler URL
+ * @returns 게시글 목록 페이지 응답
+ */
+async function fetchPostsPage(url: string): Promise<PostsPage> {
+  const response = await fetch(url, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    throw new Error("게시글 목록을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
 // =============================================================================
 // 2. Hook Implementation
 // =============================================================================
@@ -56,7 +100,7 @@ export interface UsePostPaginationResult {
  * [기능]
  * - `searchParams`를 queryKey에 반영해 게시판/카테고리/검색어 조합별 캐시를 분리
  * - `queryKeyExtra`로 같은 검색 조건 안에서도 currentRange 같은 보조 범위를 추가 분리
- * - `useSuspenseInfiniteQuery`와 서버 액션(`getPostsListAction`)을 연결해 다음 페이지를 커서 기반으로 조회
+ * - `useSuspenseInfiniteQuery`와 게시글 목록 Route Handler를 연결해 Client queryFn의 Server Action 직접 호출을 피하고 다음 페이지를 커서 기반으로 조회
  * - 평탄화된 posts 배열과 첫 페이지 totalCount를 함께 반환해 목록/헤더가 같은 데이터를 공유하도록 구성
  *
  * @param {UsePostPaginationParams} params - 검색 조건과 추가 캐시 분리 스코프
@@ -73,10 +117,9 @@ export function usePostPagination({
         __scope: queryKeyExtra,
       }),
       queryFn: async ({ pageParam }) => {
-        // 서버 액션 호출
-        return await getPostsListAction(
-          pageParam as number | null,
-          searchParams
+        // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+        return fetchPostsPage(
+          buildPostsApiUrl(searchParams, pageParam as number | null)
         );
       },
       initialPageParam: null as number | null,

--- a/features/post/service/post.ts
+++ b/features/post/service/post.ts
@@ -40,6 +40,7 @@
  * 2026.05.12  임도헌   Modified  동영상 READY/FAILED 웹훅 선도착 상태를 게시글 연결 시 덮어쓰지 않도록 보강
  * 2026.05.13  임도헌   Modified  게시글 목록 검색을 제목/본문/태그 대소문자 무시 조건으로 통일
  * 2026.05.16  임도헌   Modified  수정 액션의 기존 첨부 동영상 확인 쿼리를 service 헬퍼로 분리
+ * 2026.05.18  임도헌   Modified  게시글 목록 카드 하트 색상을 현재 사용자 좋아요 여부 기준으로 표시하도록 isLiked 매핑 추가
  */
 import "server-only";
 
@@ -98,11 +99,16 @@ export async function hasOwnedAttachedPostVideo(
  * 게시글 목록 DTO에 맞게 공개 보드게임 locale만 평탄화
  *
  * @param row - POST_SELECT로 조회한 게시글 row
+ * @param likedPostIds - 현재 조회자가 좋아요한 게시글 ID 집합
  * @returns PostCard가 바로 사용할 수 있는 게시글 목록 DTO
  */
-function mapPostListRow(row: PostListRow): PostDetail {
+function mapPostListRow(
+  row: PostListRow,
+  likedPostIds: ReadonlySet<number> = new Set()
+): PostDetail {
   return {
     ...row,
+    isLiked: likedPostIds.has(row.id),
     board_games: row.board_games.flatMap(({ boardGame }) => {
       const { locales, ...linkedBoardGame } = boardGame;
       const locale = locales[0];
@@ -532,7 +538,23 @@ export async function getPostsList(
 
   const hasNextPage = rows.length > TAKE;
   const pageRows = hasNextPage ? rows.slice(0, TAKE) : rows;
-  const posts = pageRows.map(mapPostListRow);
+
+  const likedPostIds =
+    viewerId > 0 && pageRows.length > 0
+      ? new Set(
+          (
+            await db.postLike.findMany({
+              where: {
+                userId: viewerId,
+                postId: { in: pageRows.map((row) => row.id) },
+              },
+              select: { postId: true },
+            })
+          ).map((like) => like.postId)
+        )
+      : new Set<number>();
+
+  const posts = pageRows.map((row) => mapPostListRow(row, likedPostIds));
   const nextCursor = hasNextPage ? posts[posts.length - 1].id : null;
 
   return { posts, nextCursor, totalCount };

--- a/features/post/types.ts
+++ b/features/post/types.ts
@@ -21,6 +21,7 @@
  * 2026.04.02  임도헌   Modified  PostActionResponse를 success/failure union으로 정리
  * 2026.05.03  임도헌   Modified  보드게임 카탈로그 연결 DTO 및 상세 타입 추가
  * 2026.05.03  임도헌   Modified  게시글 목록 카드에서 연결 보드게임 요약을 표시할 수 있도록 타입 설명 보강
+ * 2026.05.18  임도헌   Modified  게시글 목록 카드 하트 색상 기준 분리를 위한 isLiked 필드 추가
  */
 
 import { LocationData } from "@/features/map/types";
@@ -184,6 +185,7 @@ export interface PostDetail extends BasePost {
   board_games?: Array<{
     boardGame: BoardGameRelationOption;
   }>;
+  isLiked?: boolean;
   _count: {
     post_likes: number;
     comments: number;

--- a/features/product/components/MySalesProductItem.tsx
+++ b/features/product/components/MySalesProductItem.tsx
@@ -50,6 +50,7 @@
  * 2026.04.20  임도헌   Modified  썸네일/제목 링크가 기본 outline 대신 공용 포커스 톤을 따르도록 정리
  * 2026.05.03  임도헌   Modified  프로필 판매 카드에 연결 보드게임 배지 표시 추가
  * 2026.05.05  임도헌   Modified  판매 내역 카드 helper와 상태/리뷰 핸들러 JSDoc 보강
+ * 2026.05.18  임도헌   Modified  판매 완료 탭의 시간 표기를 등록일이 아닌 판매 완료 시점 기준으로 보정
  */
 
 "use client";
@@ -260,6 +261,10 @@ export default function MySalesProductItem({
   const buyerReviews = reviews.filter(
     (r) => r.userId === (product.purchase_userId ?? -1)
   );
+  const displayDate =
+    type === "sold"
+      ? product.purchased_at ?? product.created_at
+      : product.created_at;
 
   // 리뷰 작성 훅
   const { isLoading: reviewLoading, submitReview } = useReview({
@@ -641,7 +646,7 @@ export default function MySalesProductItem({
                   {product.views ?? 0}
                 </Metric>
               </div>
-              <TimeAgo date={product.created_at?.toString() ?? ""} />
+              <TimeAgo date={displayDate?.toString() ?? ""} />
             </div>
           </div>
         </div>

--- a/features/product/components/ProductLikeButton.tsx
+++ b/features/product/components/ProductLikeButton.tsx
@@ -23,6 +23,7 @@
  * 2026.03.26  임도헌   Modified  quick-remove 버튼의 모바일 라벨/톤을 줄여 제목 공간과 액션 위계를 보정
  * 2026.04.10  임도헌   Modified  products 타이포 정책에 맞춰 quick-remove 초소형 라벨을 text-xs/font-medium 기준으로 통일
  * 2026.05.16  임도헌   Modified  제품 목록/찜 목록 캐시 갱신 shape 타입 정리
+ * 2026.05.18  임도헌   Modified  목록 카드 하트 색상 보정을 위해 낙관 업데이트에 isLiked 상태 반영
  */
 "use client";
 
@@ -52,6 +53,8 @@ interface ProductLikeButtonProps {
 
 type ProductLikeCacheItem = {
   id: number;
+  isLiked?: boolean;
+  liked_at?: string;
   _count: {
     product_likes: number;
   };
@@ -63,6 +66,7 @@ type ProductLikeCacheItem = {
  * [상태 주입 및 캐시 제어 로직]
  * - 부모로부터 주입된 초기값(`initialIsLiked`, `initialLikeCount`)을 `useQuery`의 `initialData`로 설정하여 서버 상태 동기화(Hydration) 구성
  * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 상태 반전 및 피드백 제공
+ * - 목록 카드 하트 색상이 현재 사용자 좋아요 여부를 의미하도록 list cache의 `isLiked`를 함께 갱신
  * - 좋아요 취소 시 찜한 목록(`LIKED` scope) 쿼리 캐시에 접근하여 해당 아이템을 목록에서 즉각 제거 처리
  * - API 요청 에러 발생 시 `onError`에서 캡처된 이전 상태 스냅샷(`previous`)으로 안전한 롤백(Rollback) 처리
  * - `onSettled` 시점 관련 쿼리 무효화(invalidateQueries)를 통한 서버 데이터와의 최종 정합성 보장
@@ -111,7 +115,7 @@ export default function ProductLikeButton({
         likeCount: nextLikeCount,
       });
 
-      // 2) /products 목록 캐시 즉시 반영 (_count.product_likes)
+      // 2) /products 목록 캐시 즉시 반영: 좋아요 수와 하트 강조 기준(isLiked)을 같이 갱신
       queryClient.setQueriesData(
         { queryKey: queryKeys.products.lists() },
         (oldData: ProductInfiniteCache<ProductLikeCacheItem> | undefined) => {
@@ -124,6 +128,7 @@ export default function ProductLikeButton({
                 product.id === productId
                   ? {
                       ...product,
+                      isLiked: !data.isLiked,
                       _count: {
                         ...product._count,
                         product_likes: nextLikeCount,
@@ -178,7 +183,14 @@ export default function ProductLikeButton({
                 pages: [
                   {
                     ...firstPage,
-                    products: [snapshot, ...firstPage.products],
+                    products: [
+                      {
+                        ...snapshot,
+                        isLiked: true,
+                        liked_at: new Date().toISOString(),
+                      },
+                      ...firstPage.products,
+                    ],
                   },
                   ...oldData.pages.slice(1),
                 ],

--- a/features/product/components/productCard/ProductCardMeta.tsx
+++ b/features/product/components/productCard/ProductCardMeta.tsx
@@ -1,6 +1,6 @@
 /**
  * File Name : features/product/components/productCard/ProductCardMeta.tsx
- * Description : 조회수, 좋아요, 생성일 등 제품 메타 정보 표시 컴포넌트
+ * Description : 조회수, 좋아요, 위치, 기준 시점 등 제품 메타 정보 표시 컴포넌트
  * Author : 임도헌
  *
  * History
@@ -22,6 +22,8 @@
  * 2026.04.17  임도헌   Modified  찜한 내역에서도 활동 시점(activityLabel + TimeAgo)이 장소 유무와 무관하게 우측 끝에 고정되도록 정렬 규칙 정리
  * 2026.05.04  임도헌   Modified  그리드 카드의 위치/시간/반응 메타를 한 줄로 압축
  * 2026.05.04  임도헌   Modified  그리드 카드 작성 시간을 우측 끝에 고정해 장소 유무와 무관한 정렬 유지
+ * 2026.05.18  임도헌   Modified  좋아요 수가 아닌 현재 유저 좋아요 여부 기준으로 하트 색상 표시
+ * 2026.05.20  임도헌   Modified  작성 시간 외 찜/끌어올림 기준 활동 시점 표시 의미를 주석에 반영
  */
 
 "use client";
@@ -39,6 +41,7 @@ import type { ISODate, ViewMode } from "@/features/product/types";
 interface ProductCardMetaProps {
   views: number;
   likes: number;
+  isLiked?: boolean;
   createdAt: ISODate;
   activityAt?: ISODate;
   activityLabel?: string;
@@ -49,17 +52,18 @@ interface ProductCardMetaProps {
 }
 
 /**
- * 하단 메타 정보(좋아요 수, 조회수, 작성 시간, 위치)를 표시하는 컴포넌트
+ * 하단 메타 정보(좋아요 수, 조회수, 위치, 기준 시점)를 표시하는 컴포넌트
  *
  * [레이아웃 최적화]
- * 1. 통계(좋아요/조회수)와 시간 정보는 형태를 유지하도록 고정(shrink-0)
+ * 1. 통계(좋아요/조회수)와 기준 시점은 형태를 유지하도록 고정(shrink-0)
  * 2. 위치 정보는 공간이 부족할 경우 말줄임(...) 처리하여 줄바꿈 방지(flex-1 min-w-0)
  * 3. 다크모드 가시성을 위해 구분선 및 아이콘 색상 보정
- * 4. 리스트 카드에서는 위치 유무와 관계없이 작성 시간을 우측 끝에 정렬
+ * 4. 리스트 카드에서는 위치 유무와 관계없이 기준 시점을 우측 끝에 정렬
  */
 export default function ProductCardMeta({
   views,
   likes,
+  isLiked = false,
   createdAt,
   activityAt,
   activityLabel,
@@ -115,7 +119,7 @@ export default function ProductCardMeta({
               <HeartIcon
                 className={cn(
                   "size-3",
-                  likes > 0 ? "text-rose-500" : "text-muted/70"
+                  isLiked ? "text-rose-500" : "text-muted/70"
                 )}
               />
               <span>{likes}</span>
@@ -157,7 +161,7 @@ export default function ProductCardMeta({
             <HeartIcon
               className={cn(
                 "size-3",
-                likes > 0 ? "text-rose-500" : "text-muted/70"
+                isLiked ? "text-rose-500" : "text-muted/70"
               )}
             />
             <span>{likes}</span>
@@ -190,7 +194,7 @@ export default function ProductCardMeta({
                 <span className="shrink-0 text-border-subtle dark:text-neutral-700/80">
                   |
                 </span>
-                {/* 4. 작성/활동 시간 */}
+                {/* 작성일, 찜한 시점, 끌어올림 시점처럼 카드 맥락에 맞는 기준 시점 */}
                 {timeMeta}
               </div>
             )}

--- a/features/product/components/productCard/index.tsx
+++ b/features/product/components/productCard/index.tsx
@@ -51,13 +51,15 @@
  * 2026.05.04  임도헌   Modified  모바일 카드에서는 연결 보드게임명 pill을 생략해 하단 거래 메타 영역 확보
  * 2026.05.15  임도헌   Modified  찜한 내역 리스트 카드의 빠른 해제 버튼/보드게임 배지/활동 시점 정렬 충돌 해소
  * 2026.05.15  임도헌   Modified  리스트 카드 하단 메타 여백을 확보하도록 카드 높이와 세로 패딩 미세 조정
+ * 2026.05.18  임도헌   Modified  카드 메타 하트 색상을 현재 유저 좋아요 여부 기준으로 전달
+ * 2026.05.20  임도헌   Modified  끌어올린 상품은 등록일 대신 refreshed_at 기준 노출 시점을 표시
  * ===============================================================================================
  * ProductCard (구 ListProduct) 컴포넌트를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * 각 컴포넌트는 제품 정보를 보여주는 카드에서 특정 부분의 렌더링을 담당
  * - ProductCardHeader.tsx    : 게임 타입 및 카테고리 경로 표시
  * - ProductCardTitle.tsx     : 제품 제목 표시
  * - ProductCardPrice.tsx     : 가격 및 판매/예약 상태 뱃지
- * - ProductCardMeta.tsx      : 조회수, 좋아요 수, 작성 시간
+ * - ProductCardMeta.tsx      : 조회수, 좋아요 수, 위치, 기준 시점
  * - ProductCardTags.tsx      : 제품 관련 태그 목록
  * - ProductCardThumbnail.tsx : 대표 이미지 및 오버레이 렌더링
  * - index.tsx                : 위 컴포넌트들을 조합한 최종 ProductCard
@@ -97,6 +99,7 @@ export default function ProductCard({
     title,
     price,
     created_at,
+    refreshed_at,
     images,
     id,
     reservation_userId,
@@ -109,10 +112,12 @@ export default function ProductCard({
     bump_count,
     region2,
     region3,
+    isLiked,
     board_games,
   } = product;
 
   const href = `/products/view/${id}?returnTo=${encodeURIComponent(returnTo)}`;
+  const exposureAt = bump_count > 0 ? refreshed_at : undefined;
 
   const isGrid = viewMode === "grid";
   const showInlineQuickUnlike = showQuickUnlike && !isGrid;
@@ -217,8 +222,9 @@ export default function ProductCard({
       <ProductCardMeta
         views={views}
         likes={_count.product_likes}
+        isLiked={Boolean(isLiked || likedAt)}
         createdAt={created_at}
-        activityAt={likedAt}
+        activityAt={likedAt ?? exposureAt}
         activityLabel={likedAt ? "찜" : undefined}
         bumpCount={bump_count}
         region2={region2}

--- a/features/product/hooks/useProductPagination.ts
+++ b/features/product/hooks/useProductPagination.ts
@@ -22,6 +22,7 @@
  * 2026.04.17  임도헌   Modified  Suspense 무한 쿼리 기준 현재 동작과 맞지 않던 initialData 설명을 제거하고 훅 책임 주석을 최신화
  * 2026.05.08  임도헌   Modified  프로필 제품 목록 조회 범위 타입 import 경로를 product types로 정리
  * 2026.05.16  임도헌   Modified  제품 무한스크롤 캐시 shape 타입을 공용 유틸 타입으로 정리
+ * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
  */
 
 "use client";
@@ -31,8 +32,6 @@ import {
   useSuspenseInfiniteQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { getUserProductsAction } from "@/features/user/actions/product";
-import { getProductsAction } from "@/features/product/actions/list";
 import { queryKeys } from "@/lib/queryKeys";
 import type { ProductInfiniteCache } from "@/features/product/utils/productQueryCache";
 import type {
@@ -86,6 +85,102 @@ export interface UseProductPaginationResult<T extends { id: number }> {
   updateOne: (id: number, patch: Partial<T>) => void; // 캐시 내 특정 아이템 부분 업데이트 함수
 }
 
+/**
+ * URLSearchParams에 문자열 값이 있을 때만 추가
+ *
+ * @param params - 조립 중인 URLSearchParams
+ * @param key - query key
+ * @param value - query value
+ */
+function appendStringParam(
+  params: URLSearchParams,
+  key: string,
+  value: string | undefined
+) {
+  if (value) params.set(key, value);
+}
+
+/**
+ * URLSearchParams에 숫자 값이 있을 때만 추가
+ *
+ * @param params - 조립 중인 URLSearchParams
+ * @param key - query key
+ * @param value - query value
+ */
+function appendNumberParam(
+  params: URLSearchParams,
+  key: string,
+  value: number | undefined | null
+) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    params.set(key, String(value));
+  }
+}
+
+/**
+ * 기본 상품 목록 API URL 생성
+ *
+ * @param searchParams - 상품 검색 조건
+ * @param cursor - 다음 페이지 커서
+ * @returns 상품 목록 API URL
+ */
+function buildProductsApiUrl(
+  searchParams: ProductSearchParams | undefined,
+  cursor: number | null
+) {
+  const params = new URLSearchParams();
+  appendNumberParam(params, "cursor", cursor);
+  appendStringParam(params, "keyword", searchParams?.keyword);
+  appendStringParam(params, "category", searchParams?.category);
+  appendNumberParam(params, "minPrice", searchParams?.minPrice);
+  appendNumberParam(params, "maxPrice", searchParams?.maxPrice);
+  appendStringParam(params, "game_type", searchParams?.game_type);
+  appendStringParam(params, "condition", searchParams?.condition);
+
+  const queryString = params.toString();
+  return queryString ? `/api/products?${queryString}` : "/api/products";
+}
+
+/**
+ * 유저 제품 목록 API URL 생성
+ *
+ * @param scope - 유저 제품 목록 조회 범위
+ * @param cursor - 다음 페이지 커서
+ * @returns 유저 제품 목록 API URL
+ */
+function buildUserProductsApiUrl(
+  scope: UserProductsScope,
+  cursor: number | null
+) {
+  const params = new URLSearchParams({
+    type: scope.type,
+    userId: String(scope.userId),
+  });
+  appendNumberParam(params, "cursor", cursor);
+
+  return `/api/products/user-scope?${params.toString()}`;
+}
+
+/**
+ * 제품 목록 API 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param url - 호출할 Route Handler URL
+ * @returns 제품 목록 페이지 응답
+ */
+async function fetchProductsPage<T>(url: string): Promise<ProductsEnvelope<T>> {
+  const response = await fetch(url, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    throw new Error("제품 목록을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
 // =============================================================================
 // 2. Hook Implementation
 // =============================================================================
@@ -95,9 +190,10 @@ export interface UseProductPaginationResult<T extends { id: number }> {
  *
  * [기능 및 동작 원리]
  * 1. TanStack Query의 `useSuspenseInfiniteQuery`로 커서 기반 무한 스크롤 상태를 조립
- * 2. `mode` 값에 따라 Query Key와 서버 액션(fetcher)을 동적으로 분기해 메인 목록/프로필 목록/커스텀 목록을 공통 처리
- * 3. Suspense 경계 아래에서 평탄화된 제품 배열과 첫 페이지 totalCount를 반환해 상위 리스트가 즉시 렌더링할 수 있게 함
- * 4. `updateOne`으로 단일 아이템만 로컬 캐시에 반영해 좋아요/후기 같은 부분 갱신을 쿼리 무효화 없이 처리
+ * 2. `mode` 값에 따라 Query Key와 조회 URL(fetcher)을 동적으로 분기해 메인 목록/프로필 목록/커스텀 목록을 공통 처리
+ * 3. Client queryFn의 Server Action 직접 호출을 피하도록 기본/프로필 목록은 Route Handler fetch로 조회
+ * 4. Suspense 경계 아래에서 평탄화된 제품 배열과 첫 페이지 totalCount를 반환해 상위 리스트가 즉시 렌더링할 수 있게 함
+ * 5. `updateOne`으로 단일 아이템만 로컬 캐시에 반영해 좋아요/후기 같은 부분 갱신을 쿼리 무효화 없이 처리
  */
 export function useProductPagination<T extends { id: number }>(
   params: UseProductPaginationParams<T>
@@ -148,16 +244,16 @@ export function useProductPagination<T extends { id: number }>(
         }
         // 2. 프로필 탭 모드 (내 판매/구매 내역)
         if (mode === "profile" && profileScope) {
-          return getUserProductsAction<T>(
-            profileScope,
-            pageParam as number | null
+          // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+          return fetchProductsPage<T>(
+            buildUserProductsApiUrl(profileScope, pageParam as number | null)
           );
         }
         // 3. 기본 카탈로그 모드 (항구 메인)
         // 제네릭 T와의 충돌 방지를 위해 unknown으로 캐스팅 후 반환
-        return (await getProductsAction(
-          pageParam as number | null,
-          searchParams || {}
+        // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+        return (await fetchProductsPage(
+          buildProductsApiUrl(searchParams, pageParam as number | null)
         )) as unknown as ProductsEnvelope<T>;
       },
       initialPageParam: null as number | null,

--- a/features/product/service/list.ts
+++ b/features/product/service/list.ts
@@ -19,6 +19,8 @@
  * 2026.04.09  임도헌   Modified  판매완료 숨김 상품(hidden_at)은 공개 제품 목록과 검색 결과에서 제외
  * 2026.05.03  임도헌   Modified  상품 카드 표시용 연결 보드게임 locale 매핑 추가
  * 2026.05.12  임도헌   Modified  제품 검색의 제목/본문/태그 조건을 대소문자 무시 기준으로 통일
+ * 2026.05.18  임도헌   Modified  목록 카드 하트 색상용 현재 유저 좋아요 여부를 DTO에 포함
+ * 2026.05.20  임도헌   Modified  refreshed_at 정렬 주석의 2차 기준을 실제 id 기준으로 정정
  */
 import "server-only";
 import db from "@/lib/db";
@@ -45,9 +47,13 @@ type ProductListRow = Prisma.ProductGetPayload<{
  * @param row - PRODUCT_SELECT로 조회한 제품 row
  * @returns ProductCard가 바로 사용할 수 있는 제품 목록 DTO
  */
-function mapProductListRow(row: ProductListRow): ProductType {
+function mapProductListRow(
+  row: ProductListRow,
+  likedProductIds: Set<number>
+): ProductType {
   return {
     ...row,
+    isLiked: likedProductIds.has(row.id),
     board_games: row.board_games.flatMap(({ boardGame }) => {
       const { locales, ...linkedBoardGame } = boardGame;
       const locale = locales[0];
@@ -165,7 +171,7 @@ async function buildSearchWhere(
  * [데이터 페칭 및 가공 전략]
  * - 검색 쿼리 빌더(`buildSearchWhere`) 적용 및 커서 기반 데이터 추출
  * - 조회자(`viewerId`) 기준 차단된 유저의 상품 은닉 처리
- * - 끌어올리기(`refreshed_at`)를 반영한 내림차순 1차 정렬 및 생성일 기준 2차 정렬 적용
+ * - 끌어올리기(`refreshed_at`)를 반영한 내림차순 1차 정렬 및 id 기준 2차 정렬 적용
  * - 다음 페이지 존재 유무 판별을 위한 LIMIT + 1 레코드 조회 로직 포함
  *
  * @param {ProductSearchParams} params - 검색 조건
@@ -207,7 +213,18 @@ export async function getProductsList(
   // LIMIT + 1 기준의 다음 페이지 존재 판별
   const hasNext = rows.length > (params.take ?? TAKE);
   const pageRows = hasNext ? rows.slice(0, params.take ?? TAKE) : rows;
-  const products = pageRows.map(mapProductListRow);
+  const likedRows =
+    viewerId > 0 && pageRows.length > 0
+      ? await db.productLike.findMany({
+          where: {
+            userId: viewerId,
+            productId: { in: pageRows.map((row) => row.id) },
+          },
+          select: { productId: true },
+        })
+      : [];
+  const likedProductIds = new Set(likedRows.map((row) => row.productId));
+  const products = pageRows.map((row) => mapProductListRow(row, likedProductIds));
   const nextCursor = hasNext ? products[products.length - 1].id : null;
 
   return { products, nextCursor, totalCount };

--- a/features/product/service/userList.ts
+++ b/features/product/service/userList.ts
@@ -27,6 +27,7 @@
  * 2026.05.03  임도헌   Modified  프로필 판매/구매/찜 목록의 보드게임 relation을 카드 DTO에 맞게 평탄화
  * 2026.05.08  임도헌   Modified  UserProductsScope를 features/product/types.ts 공용 타입으로 이동
  * 2026.05.16  임도헌   Modified  커서 옵션 타입을 Prisma findMany 인자 기준으로 정리
+ * 2026.05.18  임도헌   Modified  예약/판매 완료/구매 내역 목록 정렬을 등록일이 아닌 상태 전환 시각 기준으로 보정
  */
 
 import "server-only";
@@ -183,6 +184,7 @@ export async function getUserProductsList<
     const pageRows = hasNext ? likedRows.slice(0, TAKE) : likedRows;
     const products = pageRows.map((r) => ({
       ...mapProfileProductRow(r.product),
+      isLiked: true,
       liked_at: r.created_at,
     })) as unknown as T[];
     const nextCursor = hasNext
@@ -206,10 +208,19 @@ export async function getUserProductsList<
     if (exists) cursorOpt = { skip: 1, cursor: { id: cursor } };
   }
 
+  const orderBy: Prisma.ProductFindManyArgs["orderBy"] =
+    scope.type === "RESERVED"
+      ? // 예약 중 탭은 최근 예약된 상품이 먼저 보이도록 예약 시각을 정렬 기준으로 사용
+        [{ reservation_at: "desc" }, { id: "desc" }]
+      : scope.type === "SOLD" || scope.type === "PURCHASED"
+      ? // 거래 내역 성격의 탭은 등록 순서가 아니라 실제 거래 완료 시각을 최신순 기준으로 사용
+        [{ purchased_at: "desc" }, { id: "desc" }]
+      : { id: "desc" };
+
   const rows = await db.product.findMany({
     where: whereFor(scope),
     select: PROFILE_SALES_UNIFIED_SELECT,
-    orderBy: { id: "desc" },
+    orderBy,
     take: TAKE + 1,
     ...cursorOpt,
   });

--- a/features/product/types.ts
+++ b/features/product/types.ts
@@ -25,6 +25,7 @@
  * 2026.04.13  임도헌   Modified  ProductCard returnTo를 상위 리스트에서 주입할 수 있도록 prop 확장
  * 2026.05.03  임도헌   Modified  보드게임 카탈로그 연결 DTO 및 상세 타입 추가
  * 2026.05.03  임도헌   Modified  상품 목록 카드에서 연결 보드게임 요약을 표시할 수 있도록 목록 타입 확장
+ * 2026.05.18  임도헌   Modified  상품 목록 카드 하트 색상 기준 분리를 위한 isLiked 필드 추가
  * 2026.05.08  임도헌   Modified  프로필/마이페이지 제품 목록 조회 범위 타입을 product types로 이동
  */
 
@@ -294,6 +295,7 @@ export interface ProductType extends BaseProduct {
   _count: {
     product_likes: number;
   };
+  isLiked?: boolean;
   board_games?: Array<{
     boardGame: BoardGameRelationOption;
   }>;

--- a/features/stream/actions/list.ts
+++ b/features/stream/actions/list.ts
@@ -20,6 +20,7 @@
  * 2026.03.31  임도헌   Modified  방송/다시보기 목록 액션 역할이 보이도록 설명 톤 통일
  * 2026.05.08  임도헌   Modified  목록 응답 타입과 조회 범위 타입을 features/stream/types.ts로 이동
  * 2026.05.15  임도헌   Modified  유저 채널 다시보기 무한스크롤 액션 추가
+ * 2026.05.18  임도헌   Modified  채널 다시보기 추가 페이지에서도 현재 사용자 좋아요 여부를 유지하도록 viewerId 전달
  */
 
 "use server";
@@ -175,7 +176,12 @@ export async function getChannelVodsAction(
 
   const session = await getSession();
   const role = (await getViewerRole(session?.id ?? null, ownerId)) as ViewerRole;
-  const list = await getChannelVods(ownerId, TAKE + 1, cursor);
+  const list = await getChannelVods(
+    ownerId,
+    TAKE + 1,
+    cursor,
+    session?.id ?? null
+  );
   const withAccess = applyChannelVodAccess(list, session, role);
 
   const hasMore = withAccess.length > TAKE;

--- a/features/stream/components/PrivateAccessModal.tsx
+++ b/features/stream/components/PrivateAccessModal.tsx
@@ -23,6 +23,7 @@
  * 2026.03.28  임도헌   Modified  프로필/카드 hover transform 내부에서도 모달이 뷰포트 기준으로 고정되도록 body portal 렌더링 적용
  * 2026.04.07  임도헌   Modified  모바일에서는 BottomSheet를 사용해 비밀번호 입력과 키보드 겹침을 완화
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.05.19  임도헌   Modified  비공개 방송 입장 비밀번호 입력에 current-password autocomplete를 명시해 브라우저 폼 경고 완화
  */
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
@@ -205,6 +206,7 @@ export default function PrivateAccessModal({
             setError("");
           }}
           placeholder="비밀번호 입력"
+          autoComplete="current-password"
           className={cn(
             "input-primary h-12 rounded-2xl bg-surface-dim px-4",
             error && "ring-2 ring-danger/50"

--- a/features/stream/components/RecordingList.tsx
+++ b/features/stream/components/RecordingList.tsx
@@ -9,6 +9,7 @@
  * 2026.04.16  임도헌   Modified  첫 다시보기 카드 썸네일을 우선 로드해 LCP 후보를 더 빠르게 노출
  * 2026.04.17  임도헌   Modified  다시보기 무한 스크롤과 첫 카드 우선 로드 책임이 주석에서 바로 드러나도록 설명 보강
  * 2026.05.03  임도헌   Modified  다시보기 카드에 연결 보드게임 요약 배지 표시
+ * 2026.05.18  임도헌   Modified  다시보기 카드에 좋아요/댓글 메타 전달
  */
 "use client";
 
@@ -97,6 +98,9 @@ export default function RecordingList({
             boardGames={rec.board_games}
             duration={rec.duration}
             viewCount={rec.viewCount}
+            likeCount={rec.likeCount}
+            commentCount={rec.commentCount}
+            isLiked={rec.isLiked}
             href={rec.href}
             requiresPassword={rec.requiresPassword}
             isFollowersOnly={rec.visibility === "FOLLOWERS"}

--- a/features/stream/components/StreamCard.tsx
+++ b/features/stream/components/StreamCard.tsx
@@ -51,6 +51,7 @@
  * 2026.05.05  임도헌   Modified  방송 카드 preview/잠금 처리 핸들러 JSDoc 보강
  * 2026.05.15  임도헌   Modified  레일 카드 카테고리 배지가 남는 가로폭을 우선 사용하고 부족할 때만 말줄임되도록 조정
  * 2026.05.15  임도헌   Modified  모바일 터치 환경에서 썸네일 미리보기 버튼으로 라이브 프리뷰를 켤 수 있도록 보강
+ * 2026.05.18  임도헌   Modified  다시보기 카드 메타를 좋아요/댓글/조회수 Heroicons 통계 문법으로 통일
  */
 
 "use client";
@@ -68,6 +69,11 @@ import {
   PlayIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import {
+  ChatBubbleLeftIcon,
+  EyeIcon,
+  HeartIcon,
+} from "@heroicons/react/24/solid";
 import { StreamCategory, StreamVisibility } from "@/features/stream/types";
 import type { BoardGameRelationOption } from "@/features/boardgame/types/public";
 import { STREAM_VISIBILITY } from "@/features/stream/constants";
@@ -98,6 +104,9 @@ interface StreamCardProps {
   boardGames?: Array<{ boardGame: BoardGameRelationOption }>;
   duration?: number; // 초 단위
   viewCount?: number; // 조회수
+  likeCount?: number; // 다시보기 좋아요 수
+  commentCount?: number; // 다시보기 댓글 수
+  isLiked?: boolean; // 현재 사용자의 다시보기 좋아요 여부
   shortDescription?: boolean;
   href?: string /** 직접 지정하면 우선 사용, 없으면 isLive 기준으로 기본 경로 계산 */;
   // 서버 플래그
@@ -121,11 +130,11 @@ interface StreamCardProps {
  *
  * [기능]
  * 1. 라이브 및 녹화본(VOD) 정보를 카드 형태로 표시
- * 2. 썸네일, 제목, 스트리머 정보, 카테고리, 태그, 메타 정보(시간, 조회수 등)를 렌더링
+ * 2. 썸네일, 제목, 스트리머 정보, 카테고리, 태그, 메타 정보(시간, 좋아요, 댓글, 조회수 등)를 렌더링
  * 3. 접근 권한(Private, Followers Only)에 따른 잠금 UI 및 오버레이를 제공
  * 4. 데스크톱 hover/focus 또는 모바일 미리보기 버튼으로 라이브 미리보기(iframe)를 로드
  * 5. 클릭 시 권한에 따라 상세 페이지 이동, 비밀번호 모달 열기, 팔로우 요청 등을 수행
- * 6. 작은 화면에서는 태그/시간/조회수 메타를 2단으로 분리해 카드 밀도 완화
+ * 6. 작은 화면에서는 태그/시간/좋아요/댓글/조회수 메타를 2단으로 분리해 카드 밀도 완화
  *
  * [권한]
  * - `PRIVATE` 방송: `requiresPassword` prop을 SSOT로 사용 (서버에서 세션의 언락 여부까지 확인하여 주입됨)
@@ -149,6 +158,9 @@ export default function StreamCard(props: StreamCardProps) {
     boardGames,
     duration,
     viewCount,
+    likeCount,
+    commentCount,
+    isLiked = false,
     shortDescription = false,
     href,
     requiresPassword = false,
@@ -572,7 +584,9 @@ export default function StreamCard(props: StreamCardProps) {
             (formattedTags ||
               startedAtIso ||
               duration ||
-              viewCount != null) && (
+              viewCount != null ||
+              likeCount != null ||
+              commentCount != null) && (
               <div
                 className={cn(
                   "mt-auto min-w-0 border-t border-border-subtle text-xs text-muted",
@@ -603,12 +617,52 @@ export default function StreamCard(props: StreamCardProps) {
                       {!isLive &&
                         duration &&
                         duration > 0 &&
+                        (typeof viewCount === "number" ||
+                          typeof likeCount === "number" ||
+                          typeof commentCount === "number") && (
+                          <span className="text-border shrink-0">|</span>
+                        )}
+                      {!isLive &&
+                        typeof likeCount === "number" && (
+                        <span className="inline-flex shrink-0 items-center gap-1">
+                          {/* 다시보기 카드의 빨간 하트는 전체 좋아요 수가 아니라 현재 사용자 좋아요 여부를 의미 */}
+                          <HeartIcon
+                            className={cn(
+                              "size-3",
+                              isLiked ? "text-rose-500" : "text-muted/70"
+                            )}
+                            aria-hidden="true"
+                          />
+                          {likeCount.toLocaleString()}
+                        </span>
+                      )}
+                      {!isLive &&
+                        typeof likeCount === "number" &&
+                        typeof commentCount === "number" && (
+                          <span className="text-border shrink-0">|</span>
+                        )}
+                      {!isLive && typeof commentCount === "number" && (
+                        <span className="inline-flex shrink-0 items-center gap-1">
+                          <ChatBubbleLeftIcon
+                            className="size-3 text-muted/70"
+                            aria-hidden="true"
+                          />
+                          {commentCount.toLocaleString()}
+                        </span>
+                      )}
+                      {!isLive &&
+                        (typeof likeCount === "number" ||
+                          typeof commentCount === "number") &&
                         typeof viewCount === "number" && (
                           <span className="text-border shrink-0">|</span>
                         )}
                       {!isLive && typeof viewCount === "number" && (
-                        <span className="shrink-0">
-                          조회 {viewCount.toLocaleString()}
+                        <span className="inline-flex shrink-0 items-center gap-1">
+                          <EyeIcon
+                            className="size-3 text-muted/70"
+                            aria-hidden="true"
+                          />
+                          {viewCount.toLocaleString()}
                         </span>
                       )}
                     </div>

--- a/features/stream/components/StreamDetail/StreamSecretInfo.tsx
+++ b/features/stream/components/StreamDetail/StreamSecretInfo.tsx
@@ -15,6 +15,7 @@
  * 2026.03.20  임도헌   Modified  송출 정보 라벨과 버튼 문구를 제작자 문맥에 맞게 더 직관적으로 정리
  * 2026.03.24  임도헌   Modified  owner 관리 패널 무게를 줄이기 위해 송출 정보 버튼과 내부 패널 간격/톤을 조금 더 절제
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 송출 정보 버튼·코드·경고 문구 타이포를 정리
+ * 2026.05.19  임도헌   Modified  RTMP URL 표시 기본값을 Cloudflare 기본 ingest URL로 통일
  */
 "use client";
 
@@ -89,11 +90,9 @@ export default function StreamSecretInfo({
   const [isPending, startTransition] = useTransition();
   const panelId = useId();
 
-  // ENV 폴백은 서버 액션에서 처리하지만, 초기 렌더에서 표시용 폴백 유지
+  // 서버 액션 응답 전에도 송출 URL 형식을 안내하기 위한 표시용 기본값
   const fallbackRtmp = useMemo(
-    () =>
-      process.env.NEXT_PUBLIC_CLOUDFLARE_RTMP_URL?.trim() ||
-      "rtmps://live.cloudflare.com:443/live/",
+    () => "rtmps://live.cloudflare.com:443/live/",
     []
   );
 

--- a/features/stream/components/channel/RecordingGrid.tsx
+++ b/features/stream/components/channel/RecordingGrid.tsx
@@ -30,6 +30,7 @@
  * 2026.04.17  임도헌   Modified  Lighthouse 대응: 첫 다시보기 카드 썸네일만 우선 로드해 유저 채널 LCP 후보를 앞당김
  * 2026.05.03  임도헌   Modified  채널 다시보기 카드에 연결 보드게임 요약 배지 표시
  * 2026.05.15  임도헌   Modified  채널 다시보기에 커스텀 훅 기반 무한스크롤 적용
+ * 2026.05.18  임도헌   Modified  채널 다시보기 카드에 좋아요/댓글 메타 전달
  */
 
 "use client";
@@ -179,6 +180,9 @@ export default function RecordingGrid({
                 boardGames={rec.board_games}
                 duration={hasDuration ? rec.duration : undefined}
                 viewCount={hasViews ? rec.viewCount : undefined}
+                likeCount={rec.likeCount}
+                commentCount={rec.commentCount}
+                isLiked={rec.isLiked}
                 href={href}
                 requiresPassword={requiresPassword}
                 isFollowersOnly={isFollowersOnly}

--- a/features/stream/components/recording/recordingDetail/RecordingLikeButton.tsx
+++ b/features/stream/components/recording/recordingDetail/RecordingLikeButton.tsx
@@ -13,11 +13,16 @@
  * 2026.03.01  임도헌   Modified  React useOptimistic 제거 및 TanStack Query useMutation 도입
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.04.17  임도헌   Modified  녹화본 상세 좋아요 버튼의 낙관 업데이트와 접근성 이름 책임 설명 보강
+ * 2026.05.18  임도헌   Modified  녹화본 상세 좋아요 변경 시 메인/채널 다시보기 목록 캐시 동기화 추가
  */
 
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   likeRecording,
   dislikeRecording,
@@ -27,6 +32,13 @@ import { HeartIcon } from "@heroicons/react/24/solid";
 import { HeartIcon as OutlineHeartIcon } from "@heroicons/react/24/outline";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import {
+  cancelRecordingListQueries,
+  getRecordingListSnapshots,
+  invalidateRecordingListCaches,
+  restoreRecordingListSnapshots,
+  updateRecordingListCaches,
+} from "@/features/stream/utils/recordingListCache";
 
 interface RecordingLikeButtonProps {
   isLiked: boolean;
@@ -40,6 +52,7 @@ interface RecordingLikeButtonProps {
  * [기능]
  * - 부모로부터 주입된 초기값(`initialIsLiked`, `initialLikeCount`)을 `useQuery`의 `initialData`로 설정하여 서버 상태 동기화(Hydration) 구성
  * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 상태 반전 및 피드백 제공
+ * - 상세에서 좋아요를 바꾼 뒤 뒤로가도 목록 카드의 좋아요 수와 하트 상태가 유지되도록 다시보기 목록 캐시도 함께 갱신
  * - API 요청 에러 발생 시 `onError`에서 캡처된 이전 상태 스냅샷(`previous`)으로 안전한 롤백(Rollback) 처리
  * - `onSettled` 시점 관련 쿼리 무효화(invalidateQueries)를 통한 서버 데이터와의 최종 정합성 보장
  * - 버튼 본문은 숫자만 노출하고, 스크린리더 이름은 `aria-label`로 분리해 상세 페이지 액션 의미를 명확히 전달
@@ -69,25 +82,36 @@ export default function RecordingLikeButton({
       if (res && !res.success) throw new Error(res.error);
     },
     onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey }),
+        cancelRecordingListQueries(queryClient),
+      ]);
       const previous = queryClient.getQueryData(queryKey);
+      const previousRecordingLists = getRecordingListSnapshots(queryClient);
 
-      queryClient.setQueryData(queryKey, {
+      const nextState = {
         isLiked: !data.isLiked,
         likeCount: data.isLiked
           ? Math.max(0, data.likeCount - 1)
           : data.likeCount + 1,
-      });
+      };
 
-      return { previous };
+      queryClient.setQueryData(queryKey, nextState);
+
+      // 상세에서 좋아요를 바꾼 뒤 뒤로갈 때 이전 목록 캐시도 같은 상태를 보여주도록 동기화
+      updateRecordingListCaches(queryClient, vodId, () => nextState);
+
+      return { previous, previousRecordingLists };
     },
     onError: (err, _variables, context) => {
       console.error("Like mutation failed:", err);
       toast.error("좋아요 처리에 실패했습니다.");
       queryClient.setQueryData(queryKey, context?.previous);
+      restoreRecordingListSnapshots(queryClient, context?.previousRecordingLists);
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
+      invalidateRecordingListCaches(queryClient);
     },
   });
 

--- a/features/stream/components/recording/recordingDetail/RecordingMeta.tsx
+++ b/features/stream/components/recording/recordingDetail/RecordingMeta.tsx
@@ -11,19 +11,24 @@
  * 2026.01.17  임도헌   Moved     components/stream -> features/stream/components
  * 2026.02.13  임도헌   Modified  handleCopyLink 제거 및 handleShare 통합
  * 2026.03.21  임도헌   Modified  녹화 메타 하단 구분선을 제거해 통계 행과 댓글 섹션 사이 시각적 중복을 정리
+ * 2026.05.18  임도헌   Modified  댓글 작성/삭제 후 상세 메타 댓글 수가 즉시 반영되도록 recordingStats 캐시 연동
+ * 2026.05.18  임도헌   Modified  상세 통계 아이콘을 다시보기 카드와 같은 solid 문법으로 통일
  */
 
 "use client";
 
 import TimeAgo from "@/components/ui/TimeAgo";
+import { ShareIcon } from "@heroicons/react/24/outline";
 import {
   ChatBubbleBottomCenterTextIcon,
   EyeIcon,
-  ShareIcon,
-} from "@heroicons/react/24/outline";
+} from "@heroicons/react/24/solid";
 import { formatDuration, handleShare } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
 
 interface RecordingMetaProps {
+  vodId: number;
   title: string;
   created: Date;
   duration: number;
@@ -36,8 +41,10 @@ interface RecordingMetaProps {
  * 녹화본 메타 정보 영역
  * - 상단: 작성일, 영상 길이, 공유 버튼
  * - 하단: 좋아요 버튼(주입됨), 조회수, 댓글 수
+ * - 댓글 수는 상세 댓글 mutation에서 갱신하는 recordingStats 캐시를 기준으로 표시
  */
 export default function RecordingMeta({
+  vodId,
   title,
   created,
   duration,
@@ -45,6 +52,13 @@ export default function RecordingMeta({
   commentCount = 0,
   LikeButtonComponent,
 }: RecordingMetaProps) {
+  const { data: stats } = useQuery({
+    queryKey: queryKeys.streams.recordingStats(vodId),
+    initialData: { commentCount },
+    staleTime: Infinity,
+    enabled: false,
+  });
+
   return (
     <div className="flex flex-col gap-4">
       {/* 1. 시간 및 공유 */}
@@ -76,7 +90,7 @@ export default function RecordingMeta({
           </div>
           <div className="flex items-center gap-1">
             <ChatBubbleBottomCenterTextIcon className="size-4" />
-            <span>{commentCount.toLocaleString()}</span>
+            <span>{stats.commentCount.toLocaleString()}</span>
           </div>
         </div>
       </div>

--- a/features/stream/components/recording/recordingDetail/index.tsx
+++ b/features/stream/components/recording/recordingDetail/index.tsx
@@ -17,6 +17,7 @@
  * 2026.05.03  임도헌   Modified  녹화 상세에 부모 방송과 연결된 보드게임 카탈로그 칩 노출
  * 2026.05.05  임도헌   Modified  방송 상세과 같은 보드게임 카드형 표시로 통일
  * 2026.05.12  임도헌   Modified  녹화 상세 본문에 방송 카테고리/태그 노출 추가
+ * 2026.05.18  임도헌   Modified  RecordingMeta가 VodAsset 기준 댓글 수 캐시를 갱신할 수 있도록 vodId 전달
  * ===============================================================================================
  * RecordingDetail (녹화본 상세) 정보를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * - RecordingTitle.tsx      : 녹화본 제목
@@ -96,6 +97,7 @@ export default function RecordingDetail({
       </div>
       <div className="rounded-2xl border border-border-subtle bg-surface px-4 py-4 shadow-sm sm:px-5">
         <RecordingMeta
+          vodId={vodId}
           title={broadcast.title}
           created={created}
           duration={duration}

--- a/features/stream/hooks/useChannelRecordingsPagination.ts
+++ b/features/stream/hooks/useChannelRecordingsPagination.ts
@@ -6,11 +6,11 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.15  임도헌   Created   채널 다시보기 SSR 첫 페이지와 추가 페이지를 TanStack Query로 연결
+ * 2026.05.19  임도헌   Modified  Client queryFn 추가 페이지 조회의 Server Action 직접 호출을 피하도록 Route Handler fetch로 전환
  */
 "use client";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { getChannelVodsAction } from "@/features/stream/actions/list";
 import { queryKeys } from "@/lib/queryKeys";
 import type { RecordingsPage, VodForGrid } from "@/features/stream/types";
 
@@ -28,11 +28,51 @@ interface UseChannelRecordingsPaginationResult {
 }
 
 /**
+ * 채널 다시보기 Route Handler 요청 URL 생성
+ *
+ * @param {number} ownerId - 채널 소유자 ID
+ * @param {number | null} cursor - 다음 페이지 커서
+ * @returns {string} 채널 다시보기 API URL
+ */
+function buildChannelRecordingsApiUrl(
+  ownerId: number,
+  cursor: number | null
+): string {
+  const params = new URLSearchParams({ ownerId: String(ownerId) });
+
+  if (cursor !== null) {
+    params.set("cursor", String(cursor));
+  }
+
+  return `/api/streams/channel-recordings?${params.toString()}`;
+}
+
+/**
+ * 채널 다시보기 Route Handler 응답 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param {string} url - 요청 URL
+ * @returns {Promise<RecordingsPage>} 채널 다시보기 페이지
+ */
+async function fetchChannelRecordingsPage(
+  url: string
+): Promise<RecordingsPage> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error("채널 다시보기를 불러오지 못했습니다.");
+  }
+
+  return (await response.json()) as RecordingsPage;
+}
+
+/**
  * 유저 채널 다시보기 무한 스크롤 훅
  *
  * [데이터 전략]
  * - 서버 컴포넌트에서 받은 첫 페이지를 initialData로 사용해 초기 중복 요청을 피함
- * - 이후 페이지는 채널 전용 Server Action으로 조회해 PRIVATE/FOLLOWERS 접근 플래그를 최신 세션 기준으로 보정
+ * - 이후 페이지는 채널 전용 Route Handler로 조회해 Client queryFn의 Server Action 직접 호출을 피함
+ * - PRIVATE/FOLLOWERS 접근 플래그는 추가 페이지 요청 시 최신 세션 기준으로 보정
  */
 export function useChannelRecordingsPagination({
   ownerId,
@@ -42,8 +82,12 @@ export function useChannelRecordingsPagination({
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery({
       queryKey: queryKeys.streams.channelRecordings(ownerId),
-      queryFn: ({ pageParam }) =>
-        getChannelVodsAction(ownerId, pageParam as number | null),
+      queryFn: ({ pageParam }) => {
+        // 추가 페이지만 Route Handler로 조회해 SSR 첫 페이지와 Client queryFn 재조회 책임을 분리
+        return fetchChannelRecordingsPage(
+          buildChannelRecordingsApiUrl(ownerId, pageParam as number | null)
+        );
+      },
       initialPageParam: null as number | null,
       initialData: {
         pages: [

--- a/features/stream/hooks/useCreateRecordingCommentMutation.ts
+++ b/features/stream/hooks/useCreateRecordingCommentMutation.ts
@@ -10,6 +10,7 @@
  * 2026.04.03  임도헌   Modified  댓글 작성 성공 토스트를 게시글 댓글과 같은 문법으로 통일
  * 2026.04.09  임도헌   Modified  성공 결과가 화면에 바로 드러나는 댓글 작성은 실패 토스트만 남기도록 정리
  * 2026.05.16  임도헌   Modified  Mutation 에러 메시지 추출을 unknown-safe 방식으로 정리
+ * 2026.05.18  임도헌   Modified  댓글 작성 시 다시보기 목록 카드 commentCount 캐시 동기화 추가
  */
 "use client";
 
@@ -17,6 +18,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { createRecordingComment } from "@/features/stream/actions/comments";
 import { queryKeys } from "@/lib/queryKeys";
+import {
+  cancelRecordingListQueries,
+  getRecordingListSnapshots,
+  invalidateRecordingListCaches,
+  restoreRecordingListSnapshots,
+  updateRecordingListCaches,
+} from "@/features/stream/utils/recordingListCache";
 
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : "";
@@ -27,6 +35,7 @@ const getErrorMessage = (error: unknown) =>
  * [기능]
  * - `createRecordingComment` 서버 액션을 호출해 댓글 생성을 처리
  * - 성공 시 녹화본 댓글 목록 쿼리를 무효화해 최신 목록을 다시 읽음
+ * - 상세에서 댓글을 작성한 뒤 뒤로갈 때 다시보기 카드 댓글 수가 즉시 맞도록 목록 캐시를 함께 갱신
  * - 실패 시 상태 코드별 토스트 알림으로 사용자 피드백을 제공
  *
  * @param {number} vodId - 대상 녹화본(VOD) ID
@@ -34,6 +43,7 @@ const getErrorMessage = (error: unknown) =>
 export function useCreateRecordingCommentMutation(vodId: number) {
   const queryClient = useQueryClient();
   const queryKey = queryKeys.streams.vodComments(vodId);
+  const statsQueryKey = queryKeys.streams.recordingStats(vodId);
 
   return useMutation({
     mutationFn: async (formData: FormData) => {
@@ -41,17 +51,40 @@ export function useCreateRecordingCommentMutation(vodId: number) {
       if (!res.success) throw new Error(res.error);
       return res;
     },
+    onMutate: async () => {
+      await cancelRecordingListQueries(queryClient);
+      const previousRecordingLists = getRecordingListSnapshots(queryClient);
+      const previousStats = queryClient.getQueryData(statsQueryKey);
+
+      // 카드의 댓글 수는 녹화본 상세 댓글 생성 성공을 기대해 먼저 1 증가
+      updateRecordingListCaches(queryClient, vodId, (recording) => ({
+        commentCount: (recording.commentCount ?? 0) + 1,
+      }));
+      queryClient.setQueryData(
+        statsQueryKey,
+        (oldData: { commentCount: number } | undefined) => ({
+          commentCount: (oldData?.commentCount ?? 0) + 1,
+        })
+      );
+
+      return { previousRecordingLists, previousStats };
+    },
     onSuccess: () => {
       // 등록 직후 최신 댓글 목록 재조회
       queryClient.invalidateQueries({ queryKey });
     },
-    onError: (err: unknown) => {
+    onError: (err: unknown, _variables, context) => {
       console.error(err);
+      restoreRecordingListSnapshots(queryClient, context?.previousRecordingLists);
+      queryClient.setQueryData(statsQueryKey, context?.previousStats);
       const msg = getErrorMessage(err);
       if (msg === "NOT_LOGGED_IN") toast.error("로그인이 필요합니다.");
       else if (msg === "VALIDATION_FAILED")
         toast.error("입력값을 확인해 주세요.");
       else toast.error("댓글 작성에 실패했습니다.");
+    },
+    onSettled: () => {
+      invalidateRecordingListCaches(queryClient);
     },
   });
 }

--- a/features/stream/hooks/useDeleteRecordingCommentMutation.ts
+++ b/features/stream/hooks/useDeleteRecordingCommentMutation.ts
@@ -10,6 +10,7 @@
  * 2026.04.03  임도헌   Modified  댓글 삭제 성공 토스트를 게시글 댓글과 같은 문법으로 통일
  * 2026.04.09  임도헌   Modified  성공 결과가 화면에 바로 드러나는 댓글 삭제는 실패 토스트만 남기도록 정리
  * 2026.05.16  임도헌   Modified  Mutation 에러 메시지 추출을 unknown-safe 방식으로 정리
+ * 2026.05.18  임도헌   Modified  댓글 삭제 시 다시보기 목록 카드 commentCount 캐시 동기화 추가
  */
 "use client";
 
@@ -17,6 +18,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { deleteRecordingComment } from "@/features/stream/actions/comments";
 import { queryKeys } from "@/lib/queryKeys";
+import {
+  cancelRecordingListQueries,
+  getRecordingListSnapshots,
+  invalidateRecordingListCaches,
+  restoreRecordingListSnapshots,
+  updateRecordingListCaches,
+} from "@/features/stream/utils/recordingListCache";
 
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : "";
@@ -27,6 +35,7 @@ const getErrorMessage = (error: unknown) =>
  * [기능]
  * - `deleteRecordingComment` 서버 액션을 호출해 댓글 삭제를 처리
  * - 성공 시 녹화본 댓글 목록 쿼리를 무효화해 최신 목록을 다시 읽음
+ * - 상세에서 댓글을 삭제한 뒤 뒤로갈 때 다시보기 카드 댓글 수가 즉시 맞도록 목록 캐시를 함께 갱신
  * - 실패 시 상태 코드별 토스트 알림으로 사용자 피드백을 제공
  *
  * @param {number} vodId - 대상 녹화본(VOD) ID
@@ -34,6 +43,7 @@ const getErrorMessage = (error: unknown) =>
 export function useDeleteRecordingCommentMutation(vodId: number) {
   const queryClient = useQueryClient();
   const queryKey = queryKeys.streams.vodComments(vodId);
+  const statsQueryKey = queryKeys.streams.recordingStats(vodId);
 
   return useMutation({
     mutationFn: async (commentId: number) => {
@@ -41,18 +51,41 @@ export function useDeleteRecordingCommentMutation(vodId: number) {
       if (!res.success) throw new Error(res.error);
       return res;
     },
+    onMutate: async () => {
+      await cancelRecordingListQueries(queryClient);
+      const previousRecordingLists = getRecordingListSnapshots(queryClient);
+      const previousStats = queryClient.getQueryData(statsQueryKey);
+
+      // 삭제 낙관 업데이트는 0 아래로 내려가지 않도록 보정
+      updateRecordingListCaches(queryClient, vodId, (recording) => ({
+        commentCount: Math.max(0, (recording.commentCount ?? 0) - 1),
+      }));
+      queryClient.setQueryData(
+        statsQueryKey,
+        (oldData: { commentCount: number } | undefined) => ({
+          commentCount: Math.max(0, (oldData?.commentCount ?? 0) - 1),
+        })
+      );
+
+      return { previousRecordingLists, previousStats };
+    },
     onSuccess: () => {
       // 삭제 직후 최신 댓글 목록 재조회
       queryClient.invalidateQueries({ queryKey });
     },
-    onError: (err: unknown) => {
+    onError: (err: unknown, _variables, context) => {
       console.error(err);
+      restoreRecordingListSnapshots(queryClient, context?.previousRecordingLists);
+      queryClient.setQueryData(statsQueryKey, context?.previousStats);
       const msg = getErrorMessage(err);
       if (msg === "NOT_LOGGED_IN") toast.error("로그인이 필요합니다.");
       else if (msg === "FORBIDDEN")
         toast.error("본인 댓글만 삭제할 수 있습니다.");
       else if (msg === "NOT_FOUND") toast.error("이미 삭제된 댓글입니다.");
       else toast.error("댓글 삭제에 실패했습니다.");
+    },
+    onSettled: () => {
+      invalidateRecordingListCaches(queryClient);
     },
   });
 }

--- a/features/stream/hooks/useRecordingCommentsQuery.ts
+++ b/features/stream/hooks/useRecordingCommentsQuery.ts
@@ -16,19 +16,69 @@
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.03.31  임도헌   Modified  커서 조회와 평탄화 반환 역할이 보이도록 설명 톤 통일
  * 2026.05.13  임도헌   Modified  댓글 페이징 응답의 nextCursor를 사용해 불필요한 빈 추가 요청을 방지
+ * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
  */
 "use client";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getRecordingCommentsListAction } from "@/features/stream/actions/comments";
 import { queryKeys } from "@/lib/queryKeys";
+import type { StreamComment } from "@/features/stream/types";
+
+interface RecordingCommentsPage {
+  comments: StreamComment[];
+  nextCursor?: number;
+}
+
+/**
+ * 녹화본 댓글 Route Handler 요청 URL 생성
+ *
+ * @param vodId - 대상 녹화본 ID
+ * @param cursor - 다음 페이지 커서
+ * @param limit - 페이지당 로드할 댓글 수
+ * @returns 녹화본 댓글 API URL
+ */
+function buildRecordingCommentsApiUrl(
+  vodId: number,
+  cursor: number | undefined,
+  limit: number
+) {
+  const params = new URLSearchParams({ limit: String(limit) });
+
+  if (cursor !== undefined) {
+    params.set("cursor", String(cursor));
+  }
+
+  return `/api/streams/recordings/${vodId}/comments?${params.toString()}`;
+}
+
+/**
+ * 녹화본 댓글 Route Handler 응답 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param url - 요청 URL
+ * @returns 녹화본 댓글 목록 페이지
+ */
+async function fetchRecordingCommentsPage(
+  url: string
+): Promise<RecordingCommentsPage> {
+  const response = await fetch(url, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+
+  if (!response.ok) {
+    throw new Error("녹화본 댓글을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
 
 /**
  * 녹화본 댓글 조회 전용 Suspense Query 훅
  *
  * [기능]
  * - `useSuspenseInfiniteQuery`로 녹화본 댓글 목록을 커서 기반으로 조회
- * - 서버 액션(`getRecordingCommentsListAction`)을 호출해 다음 페이지를 이어서 읽음
+ * - Route Handler fetch로 Server Action 직접 호출을 피하고 다음 페이지를 이어서 읽음
  * - 평탄화된 comments 배열과 페이지네이션 상태를 함께 반환
  *
  * @param {number} vodId - 대상 녹화본(VOD) ID
@@ -39,10 +89,13 @@ export function useRecordingCommentsQuery(vodId: number, pageSize = 10) {
     useSuspenseInfiniteQuery({
       queryKey: queryKeys.streams.vodComments(vodId),
       queryFn: async ({ pageParam }) => {
-        return await getRecordingCommentsListAction(
-          vodId,
-          pageParam as number | undefined,
-          pageSize
+        // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+        return fetchRecordingCommentsPage(
+          buildRecordingCommentsApiUrl(
+            vodId,
+            pageParam as number | undefined,
+            pageSize
+          )
         );
       },
       initialPageParam: undefined as number | undefined,

--- a/features/stream/hooks/useRecordingPagination.ts
+++ b/features/stream/hooks/useRecordingPagination.ts
@@ -9,13 +9,13 @@
  * 2026.03.29  임도헌   Modified  최신/인기 정렬과 팔로잉만 보조 필터를 같은 쿼리 키 기준으로 정렬
  * 2026.03.31  임도헌   Modified  export 훅 역할과 반환값이 바로 보이도록 JSDoc 보강
  * 2026.04.02  임도헌   Modified  다시보기 페이징 훅 파라미터/반환 타입 설명 보강
+ * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
  */
 "use client";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getRecordingsListAction } from "@/features/stream/actions/list";
 import { queryKeys } from "@/lib/queryKeys";
-import type { VodForGrid } from "@/features/stream/types";
+import type { RecordingsPage, VodForGrid } from "@/features/stream/types";
 
 interface UseRecordingPaginationParams {
   sort: "latest" | "popular";
@@ -33,11 +33,69 @@ export interface UseRecordingPaginationResult {
 }
 
 /**
+ * 다시보기 목록 Route Handler 요청 URL 생성
+ *
+ * @param {UseRecordingPaginationParams & { cursor: number | null }} params - 정렬, 필터, 조회자, 커서 정보
+ * @returns {string} 다시보기 목록 API URL
+ */
+function buildRecordingsApiUrl({
+  sort,
+  followingOnly,
+  searchParams,
+  viewerId,
+  cursor,
+}: UseRecordingPaginationParams & { cursor: number | null }): string {
+  const params = new URLSearchParams({ sort });
+
+  if (followingOnly) {
+    params.set("followingOnly", "true");
+  }
+
+  if (cursor !== null) {
+    params.set("cursor", String(cursor));
+  }
+
+  if (viewerId !== undefined && viewerId !== null) {
+    params.set("viewerId", String(viewerId));
+  }
+
+  const category = searchParams.category;
+  const keyword = searchParams.keyword;
+
+  if (category) {
+    params.set("category", category);
+  }
+
+  if (keyword) {
+    params.set("keyword", keyword);
+  }
+
+  return `/api/streams/recordings?${params.toString()}`;
+}
+
+/**
+ * 다시보기 목록 Route Handler 응답 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param {string} url - 요청 URL
+ * @returns {Promise<RecordingsPage>} 다시보기 목록 페이지
+ */
+async function fetchRecordingsPage(url: string): Promise<RecordingsPage> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error("다시보기 목록을 불러오지 못했습니다.");
+  }
+
+  return (await response.json()) as RecordingsPage;
+}
+
+/**
  * 다시보기 목록 Suspense 무한 스크롤 훅
  *
  * [기능]
  * - 정렬 기준과 보조 필터를 queryKey에 반영해 캐시를 분리
- * - 서버 액션 기반으로 다음 페이지를 커서 방식으로 조회
+ * - Route Handler fetch로 Server Action 직접 호출을 피하고 다음 페이지를 커서 방식으로 조회
  * - 평탄화된 recordings 배열과 페이징 상태를 함께 반환
  *
  * @param {UseRecordingPaginationParams} params - 정렬/필터/조회자 정보
@@ -55,14 +113,18 @@ export function useRecordingPagination({
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
       queryKey,
-      queryFn: async ({ pageParam }) =>
-        getRecordingsListAction(
-          sort,
-          followingOnly,
-          pageParam as number | null,
-          searchParams,
-          viewerId ?? null
-        ),
+      queryFn: async ({ pageParam }) => {
+        // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+        return fetchRecordingsPage(
+          buildRecordingsApiUrl({
+            sort,
+            followingOnly,
+            searchParams,
+            viewerId,
+            cursor: pageParam as number | null,
+          })
+        );
+      },
       initialPageParam: null as number | null,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       staleTime: 60 * 1000,

--- a/features/stream/hooks/useStreamPagination.ts
+++ b/features/stream/hooks/useStreamPagination.ts
@@ -12,14 +12,18 @@
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.04.17  임도헌   Modified  현재 훅이 담당하는 범위가 무한 스크롤 페이징 중심으로 읽히도록 설명을 최신화
  * 2026.05.08  임도헌   Modified  스트림 조회 범위 타입을 StreamScope 공용 타입으로 교체
+ * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
  */
 
 "use client";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getStreamsListAction } from "@/features/stream/actions/list";
 import { queryKeys } from "@/lib/queryKeys";
-import type { BroadcastSummary, StreamScope } from "@/features/stream/types";
+import type {
+  BroadcastSummary,
+  StreamScope,
+  StreamsPage,
+} from "@/features/stream/types";
 
 interface UseStreamPaginationParams {
   scope: StreamScope;
@@ -35,11 +39,64 @@ export interface UseStreamPaginationResult {
 }
 
 /**
+ * 라이브 방송 목록 Route Handler 요청 URL 생성
+ *
+ * @param {UseStreamPaginationParams & { cursor: number | null }} params - 범위, 검색 조건, 조회자, 커서 정보
+ * @returns {string} 라이브 방송 목록 API URL
+ */
+function buildStreamsApiUrl({
+  scope,
+  searchParams,
+  viewerId,
+  cursor,
+}: UseStreamPaginationParams & { cursor: number | null }): string {
+  const params = new URLSearchParams({ scope });
+
+  if (cursor !== null) {
+    params.set("cursor", String(cursor));
+  }
+
+  if (viewerId !== undefined && viewerId !== null) {
+    params.set("viewerId", String(viewerId));
+  }
+
+  const category = searchParams.category;
+  const keyword = searchParams.keyword;
+
+  if (category) {
+    params.set("category", category);
+  }
+
+  if (keyword) {
+    params.set("keyword", keyword);
+  }
+
+  return `/api/streams?${params.toString()}`;
+}
+
+/**
+ * 라이브 방송 목록 Route Handler 응답 조회
+ * Client Component queryFn에서는 Server Action 직접 호출 대신 HTTP fetch를 사용해 초기 렌더 fetch waterfall 오류를 방지
+ *
+ * @param {string} url - 요청 URL
+ * @returns {Promise<StreamsPage>} 라이브 방송 목록 페이지
+ */
+async function fetchStreamsPage(url: string): Promise<StreamsPage> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error("스트리밍 목록을 불러오지 못했습니다.");
+  }
+
+  return (await response.json()) as StreamsPage;
+}
+
+/**
  * 스트리밍 목록 Suspense 무한 스크롤 훅
  *
  * [데이터 페칭 및 캐시 전략]
  * - `scope`와 검색 파라미터를 queryKey에 반영해 라이브 목록 캐시를 조건별로 분리
- * - `useSuspenseInfiniteQuery`로 커서 기반 다음 페이지 요청을 관리
+ * - Route Handler fetch와 `useSuspenseInfiniteQuery`로 Server Action 직접 호출을 피하고 커서 기반 다음 페이지 요청을 관리
  * - 누적 페이지를 평탄화한 `streams` 배열과 다음 페이지 제어값만 상위 리스트에 전달
  *
  * @param {UseStreamPaginationParams} params - 범위 필터와 검색 조건, 조회자 정보
@@ -57,12 +114,14 @@ export function useStreamPagination({
     useSuspenseInfiniteQuery({
       queryKey,
       queryFn: async ({ pageParam }) => {
-        // 서버 액션을 호출하여 커서 기반 다음 페이지 데이터를 가져옴
-        return await getStreamsListAction(
-          scope,
-          pageParam as number | null,
-          searchParams,
-          viewerId ?? null
+        // Client queryFn의 Server Action 직접 호출은 초기 렌더 waterfall 오류가 날 수 있어 Route Handler fetch 사용
+        return fetchStreamsPage(
+          buildStreamsApiUrl({
+            scope,
+            searchParams,
+            viewerId,
+            cursor: pageParam as number | null,
+          })
         );
       },
       initialPageParam: null as number | null,

--- a/features/stream/service/list.ts
+++ b/features/stream/service/list.ts
@@ -23,6 +23,7 @@
  * 2026.05.08  임도헌   Modified  보드게임 relation select 공용화 및 팔로우 상태 확인용 select factory 적용
  * 2026.05.15  임도헌   Modified  전체 방송/다시보기 목록에서도 PRIVATE 항목을 노출하고 카드 진입 시 비밀번호로 접근 제어하도록 복구
  * 2026.05.15  임도헌   Modified  유저 채널 VOD 조회에 커서 기반 페이징을 적용해 무한스크롤 대응
+ * 2026.05.18  임도헌   Modified  다시보기 카드 메타용 좋아요/댓글 수와 현재 사용자 좋아요 여부 매핑 추가
  */
 
 import "server-only";
@@ -168,7 +169,7 @@ export async function getStreamsList(params: {
  * - 처리 완료된 VOD(`ready_at`)만 조회 대상으로 한정
  * - 조회자 기반 차단 및 정지 유저 필터를 동일하게 적용
  * - `followingOnly` 보조 필터로 팔로잉한 스트리머의 다시보기만 좁혀볼 수 있음
- * - 카드에서 필요한 접근 제어 플래그와 메타데이터를 함께 반환
+ * - 카드에서 필요한 접근 제어 플래그와 메타데이터(길이, 조회수, 좋아요/댓글 수, 사용자 좋아요 여부)를 함께 반환
  */
 export async function getRecordingsList(params: {
   sort: "latest" | "popular";
@@ -179,7 +180,15 @@ export async function getRecordingsList(params: {
   cursor: number | null;
   take: number;
 }): Promise<VodForGrid[]> {
-  const { sort, followingOnly = false, category, keyword, viewerId, cursor, take } = params;
+  const {
+    sort,
+    followingOnly = false,
+    category,
+    keyword,
+    viewerId,
+    cursor,
+    take,
+  } = params;
   const blockedIds = await getBlockedUserIds(viewerId);
 
   const conditions: Prisma.VodAssetWhereInput[] = [
@@ -256,6 +265,7 @@ export async function getRecordingsList(params: {
       duration_sec: true,
       ready_at: true,
       views: true,
+      _count: { select: { recordingLikes: true, recordingComments: true } },
       thumbnail_url: true,
       created_at: true,
       broadcastId: true,
@@ -297,6 +307,22 @@ export async function getRecordingsList(params: {
     take,
   });
 
+  // 카드 하트 색상은 현재 조회자의 좋아요 여부를 의미하므로 현재 페이지 VOD만 배치 조회
+  const likedVodIds =
+    viewerId > 0 && vods.length > 0
+      ? new Set(
+          (
+            await db.recordingLike.findMany({
+              where: {
+                userId: viewerId,
+                vodId: { in: vods.map((vod) => vod.id) },
+              },
+              select: { vodId: true },
+            })
+          ).map((like) => like.vodId)
+        )
+      : new Set<number>();
+
   return vods.map((v) => {
     const b = v.broadcast;
     const isMine = b.liveInput.userId === viewerId;
@@ -318,6 +344,9 @@ export async function getRecordingsList(params: {
       readyAt: v.ready_at,
       duration: v.duration_sec ?? 0,
       viewCount: v.views,
+      likeCount: v._count.recordingLikes,
+      commentCount: v._count.recordingComments,
+      isLiked: likedVodIds.has(v.id),
       category: b.category,
       tags: b.tags,
       board_games: b.board_games.flatMap(({ boardGame }) => {
@@ -465,11 +494,13 @@ export async function getChannelLive(
  * @param {number} ownerId - 방송 소유자 ID
  * @param {number} take - 조회 개수
  * @param {number | null} cursor - 이전 페이지의 마지막 VOD id
+ * @param {number | null} viewerId - 현재 조회자 ID, 다시보기 카드의 좋아요 강조 여부 계산에 사용
  */
 export async function getChannelVods(
   ownerId: number,
   take: number,
-  cursor: number | null = null
+  cursor: number | null = null,
+  viewerId: number | null = null
 ): Promise<VodForGrid[]> {
   const vods = await db.vodAsset.findMany({
     where: {
@@ -484,6 +515,7 @@ export async function getChannelVods(
       duration_sec: true,
       ready_at: true,
       views: true,
+      _count: { select: { recordingLikes: true, recordingComments: true } },
       thumbnail_url: true,
       created_at: true,
       broadcast: {
@@ -509,6 +541,22 @@ export async function getChannelVods(
     take,
   });
 
+  // 채널 첫 페이지/추가 페이지 모두 같은 하트 색상 기준을 쓰도록 현재 조회자 좋아요 여부 주입
+  const likedVodIds =
+    viewerId && viewerId > 0 && vods.length > 0
+      ? new Set(
+          (
+            await db.recordingLike.findMany({
+              where: {
+                userId: viewerId,
+                vodId: { in: vods.map((vod) => vod.id) },
+              },
+              select: { vodId: true },
+            })
+          ).map((like) => like.vodId)
+        )
+      : new Set<number>();
+
   return vods.map((v) => {
     const b = v.broadcast;
     return {
@@ -523,6 +571,9 @@ export async function getChannelVods(
       readyAt: v.ready_at,
       duration: v.duration_sec ?? 0,
       viewCount: v.views,
+      likeCount: v._count.recordingLikes,
+      commentCount: v._count.recordingComments,
+      isLiked: likedVodIds.has(v.id),
       category: b.category,
       tags: b.tags,
       board_games: b.board_games.flatMap(({ boardGame }) => {

--- a/features/stream/service/liveInput.ts
+++ b/features/stream/service/liveInput.ts
@@ -12,6 +12,7 @@
  * 2026.01.23  임도헌   Merged    LiveInput 관련 로직 통합 및 Session 의존성 제거
  * 2026.01.28  임도헌   Modified  주석 보강
  * 2026.05.16  임도헌   Modified  Cloudflare Live Input 응답 타입을 명시해 any 캐스팅 제거
+ * 2026.05.19  임도헌   Modified  RTMP URL을 환경변수 override 없이 Cloudflare 기본 ingest URL로 통일
  */
 
 import "server-only";
@@ -26,9 +27,7 @@ const API_BASE = "https://api.cloudflare.com/client/v4";
 const CF_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 const CF_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
 const AUTH = `Bearer ${CF_TOKEN}`;
-const DEFAULT_RTMPS_URL =
-  process.env.NEXT_PUBLIC_CLOUDFLARE_RTMP_URL?.trim() ||
-  "rtmps://live.cloudflare.com:443/live/";
+const DEFAULT_RTMPS_URL = "rtmps://live.cloudflare.com:443/live/";
 
 type CloudflareLiveInputResponse = {
   result?: {

--- a/features/stream/types.ts
+++ b/features/stream/types.ts
@@ -27,6 +27,7 @@
  * 2026.05.16  임도헌   Modified  접근/상태 헬퍼를 utils/access.ts로 분리해 타입 파일 역할 정리
  * 2026.05.16  임도헌   Modified  live-status Realtime payload 공용 타입 추가
  * 2026.05.17  임도헌   Modified  Cloudflare Stream 웹훅 페이로드 타입 추가
+ * 2026.05.18  임도헌   Modified  다시보기 카드 통계 메타 표시를 위한 likeCount/commentCount/isLiked 필드 추가
  */
 
 import type { StreamChatMessage } from "@/features/chat/types";
@@ -136,6 +137,9 @@ export interface VodForGrid {
   readyAt: Date | null;
   duration?: number;
   viewCount?: number;
+  likeCount?: number; // 카드 메타용 녹화본 좋아요 수
+  commentCount?: number; // 카드 메타용 녹화본 댓글 수
+  isLiked?: boolean; // 현재 조회자의 녹화본 좋아요 여부
   category?: StreamCategory | null;
   tags?: StreamTag[];
   board_games?: Array<{

--- a/features/stream/utils/recordingListCache.ts
+++ b/features/stream/utils/recordingListCache.ts
@@ -1,0 +1,151 @@
+/**
+ * File Name : features/stream/utils/recordingListCache.ts
+ * Description : 녹화본 상세 상호작용 후 다시보기 목록 캐시를 동기화하는 클라이언트 유틸
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.05.18  임도헌   Created   녹화본 좋아요/댓글 변경 시 메인/채널 다시보기 목록 캐시 갱신 유틸 추가
+ */
+
+import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query";
+import type { RecordingsPage, VodForGrid } from "@/features/stream/types";
+import { queryKeys } from "@/lib/queryKeys";
+
+type RecordingInfiniteCache = InfiniteData<RecordingsPage>;
+type RecordingListSnapshot = Array<[QueryKey, RecordingInfiniteCache | undefined]>;
+
+export interface RecordingListSnapshots {
+  recordingLists: RecordingListSnapshot;
+  channelRecordings: RecordingListSnapshot;
+}
+
+/**
+ * 채널 다시보기 목록 query key 여부 확인
+ *
+ * @param queryKey - TanStack Query key
+ * @returns 채널 다시보기 목록 캐시이면 true
+ */
+export function isChannelRecordingsKey(queryKey: QueryKey) {
+  return queryKey[0] === "streams" && queryKey[1] === "channelRecordings";
+}
+
+/**
+ * 다시보기 메인/채널 목록 query 취소
+ *
+ * @param queryClient - TanStack Query Client
+ */
+export async function cancelRecordingListQueries(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.cancelQueries({
+      queryKey: queryKeys.streams.recordingLists(),
+    }),
+    queryClient.cancelQueries({
+      predicate: (query) => isChannelRecordingsKey(query.queryKey),
+    }),
+  ]);
+}
+
+/**
+ * 다시보기 목록 캐시 스냅샷 저장
+ *
+ * @param queryClient - TanStack Query Client
+ * @returns 낙관적 업데이트 rollback용 목록 캐시 스냅샷
+ */
+export function getRecordingListSnapshots(
+  queryClient: QueryClient
+): RecordingListSnapshots {
+  return {
+    recordingLists: queryClient.getQueriesData<RecordingInfiniteCache>({
+      queryKey: queryKeys.streams.recordingLists(),
+    }),
+    channelRecordings: queryClient.getQueriesData<RecordingInfiniteCache>({
+      predicate: (query) => isChannelRecordingsKey(query.queryKey),
+    }),
+  };
+}
+
+/**
+ * 다시보기 목록 캐시 스냅샷 복원
+ *
+ * @param queryClient - TanStack Query Client
+ * @param snapshots - rollback에 사용할 이전 목록 캐시
+ */
+export function restoreRecordingListSnapshots(
+  queryClient: QueryClient,
+  snapshots?: RecordingListSnapshots
+) {
+  snapshots?.recordingLists.forEach(([listQueryKey, listData]) => {
+    queryClient.setQueryData(listQueryKey, listData);
+  });
+  snapshots?.channelRecordings.forEach(([listQueryKey, listData]) => {
+    queryClient.setQueryData(listQueryKey, listData);
+  });
+}
+
+/**
+ * 다시보기 목록의 특정 녹화본 항목 패치
+ *
+ * @param oldData - 기존 infinite query 캐시
+ * @param vodId - 변경 대상 VOD ID
+ * @param patcher - 기존 녹화본을 기준으로 병합할 변경값 생성 함수
+ * @returns 패치된 infinite query 캐시
+ */
+function patchRecordingListCache(
+  oldData: RecordingInfiniteCache | undefined,
+  vodId: number,
+  patcher: (recording: VodForGrid) => Partial<VodForGrid>
+) {
+  if (!oldData?.pages) return oldData;
+
+  return {
+    ...oldData,
+    pages: oldData.pages.map((page) => ({
+      ...page,
+      recordings: page.recordings.map((recording) =>
+        recording.vodId === vodId
+          ? {
+              ...recording,
+              ...patcher(recording),
+            }
+          : recording
+      ),
+    })),
+  };
+}
+
+/**
+ * 다시보기 메인/채널 목록 캐시 일괄 갱신
+ *
+ * @param queryClient - TanStack Query Client
+ * @param vodId - 변경 대상 VOD ID
+ * @param patcher - 기존 녹화본을 기준으로 병합할 변경값 생성 함수
+ */
+export function updateRecordingListCaches(
+  queryClient: QueryClient,
+  vodId: number,
+  patcher: (recording: VodForGrid) => Partial<VodForGrid>
+) {
+  queryClient.setQueriesData<RecordingInfiniteCache>(
+    { queryKey: queryKeys.streams.recordingLists() },
+    (oldData) => patchRecordingListCache(oldData, vodId, patcher)
+  );
+  queryClient.setQueriesData<RecordingInfiniteCache>(
+    { predicate: (query) => isChannelRecordingsKey(query.queryKey) },
+    (oldData) => patchRecordingListCache(oldData, vodId, patcher)
+  );
+}
+
+/**
+ * 다시보기 메인/채널 목록 캐시 무효화
+ *
+ * @param queryClient - TanStack Query Client
+ */
+export function invalidateRecordingListCaches(queryClient: QueryClient) {
+  queryClient.invalidateQueries({
+    queryKey: queryKeys.streams.recordingLists(),
+  });
+  queryClient.invalidateQueries({
+    predicate: (query) => isChannelRecordingsKey(query.queryKey),
+  });
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -9,8 +9,10 @@
  * 2025.11.28  임도헌   Modified  Prisma 7 + adapter-better-sqlite3 적용
  * 2025.11.29  임도헌   Modified  PrismaClient 싱글톤 + DATABASE_URL 기본값 추가
  * 2025.12.20  임도헌   Modified  PostgreSQL(Supabase)용 PrismaPg 어댑터 적용
+ * 2026.05.19  임도헌   Modified  Prisma Client가 클라이언트 번들에 포함되지 않도록 server-only 가드 추가
  */
 
+import "server-only";
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 

--- a/lib/getQueryClient.ts
+++ b/lib/getQueryClient.ts
@@ -1,17 +1,19 @@
 /**
  * File Name : lib/getQueryClient.ts
- * Description : 서버 컴포넌트용 TanStack Query Client 싱글톤 팩토리
+ * Description : TanStack Query Client 공용 팩토리
  * Author : 임도헌
  *
  * History
  * Date        Author   Status    Description
  * 2026.03.03  임도헌   Created   SSR 환경에서의 안전한 캐시 하이드레이션을 위한 QueryClient 인스턴스 생성기 추가
+ * 2026.05.19  임도헌   Modified  서버 prefetch와 클라이언트 Provider가 같은 기본 옵션을 쓰도록 공용 팩토리 책임 명확화
  */
 
 import { QueryClient, isServer } from "@tanstack/react-query";
 
 /**
- * 기본 옵션이 적용된 QueryClient를 생성
+ * 기본 옵션이 적용된 QueryClient 생성
+ * SSR hydration 직후 즉시 재요청을 줄이기 위해 staleTime을 두고, 실패 재시도 횟수는 전역 기준으로 제한
  */
 function makeQueryClient() {
   return new QueryClient({
@@ -20,6 +22,7 @@ function makeQueryClient() {
         // SSR 환경을 고려하여 기본 staleTime을 1분으로 설정
         staleTime: 60 * 1000,
         refetchOnWindowFocus: false,
+        retry: 1,
       },
     },
   });
@@ -33,7 +36,7 @@ let browserQueryClient: QueryClient | undefined = undefined;
  * [캐시 제어 전략]
  * - 서버(SSR) 환경: 사용자 간 데이터 오염을 방지하기 위해 매 요청마다 새로운 QueryClient 인스턴스 생성 반환
  * - 클라이언트(CSR) 환경: 캐시 유지를 위한 싱글톤(Singleton) 인스턴스 생성 및 재사용 적용
- * - 기본 `staleTime` 1분 및 `refetchOnWindowFocus` 비활성화 등 글로벌 캐시 옵션 지정
+ * - 기본 `staleTime` 1분, `retry` 1회, `refetchOnWindowFocus` 비활성화 등 글로벌 캐시 옵션 지정
  */
 export function getQueryClient() {
   if (isServer) {

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -68,6 +68,8 @@ export const queryKeys = {
     detail: (id: number) => [...queryKeys.posts.details(), id] as const,
     comments: (postId: number) =>
       [...queryKeys.posts.all, "comments", postId] as const,
+    stats: (postId: number) =>
+      [...queryKeys.posts.detail(postId), "stats"] as const,
     likeStatus: (postId: number) =>
       [...queryKeys.posts.detail(postId), "likeStatus"] as const,
   },
@@ -103,6 +105,8 @@ export const queryKeys = {
       [...queryKeys.streams.all, "channelRecordings", ownerId] as const,
     vodComments: (vodId: number) =>
       [...queryKeys.streams.all, "vodComments", vodId] as const,
+    recordingStats: (vodId: number) =>
+      [...queryKeys.streams.all, "vod", vodId, "stats"] as const,
     likeStatus: (vodId: number) =>
       [...queryKeys.streams.all, "vod", vodId, "likeStatus"] as const,
   },

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -9,8 +9,10 @@
  * 2024.10.06  임도헌   Modified  iron-session으로 쿠키 암호화
  * 2025.08.14  임도헌   Modified  unlockedStreamIds 추가
  * 2026.02.06  임도헌   Modified  세션에 역할 추가
+ * 2026.05.19  임도헌   Modified  쿠키 기반 세션 헬퍼가 클라이언트 번들에 포함되지 않도록 server-only 가드 추가
  */
 
+import "server-only";
 import { getIronSession } from "iron-session";
 import { cookies } from "next/headers";
 

--- a/lib/socialCrawler.ts
+++ b/lib/socialCrawler.ts
@@ -13,7 +13,7 @@ const SOCIAL_CRAWLER_USER_AGENT =
 
 /**
  * 메신저/소셜 서비스의 링크 미리보기 크롤러 여부 판별
- * 로그인 보호 페이지 전체를 공개하지 않고, 공유 카드 생성에 필요한 요청만 별도 분기하기 위한 기준
+ * 로그인 보호 페이지 전체가 아닌 공유 카드 생성 요청만 허용하기 위한 기준
  */
 export function isSocialCrawlerUserAgent(userAgent?: string | null) {
   return !!userAgent && SOCIAL_CRAWLER_USER_AGENT.test(userAgent);
@@ -21,7 +21,7 @@ export function isSocialCrawlerUserAgent(userAgent?: string | null) {
 
 /**
  * Next.js file-based metadata 이미지 라우트의 인증 가드 예외 여부 판별
- * 빌드 결과에서는 `/opengraph-image-xxxxxx`처럼 해시가 붙을 수 있어 suffix까지 함께 허용
+ * 빌드 결과의 `/opengraph-image-xxxxxx` 해시 suffix 허용
  */
 export function isMetadataImagePath(pathname: string) {
   return /\/(?:opengraph-image|twitter-image)(?:-[a-z0-9]+)?(?:\.[a-z0-9]+)?$/i.test(
@@ -37,15 +37,15 @@ const FIXED_OG_IMAGE_PATH_PATTERN =
 
 /**
  * 공유 카드 메타에 직접 넣는 공개 OG 이미지 경로 판별
- * Next file-based metadata 라우트가 빌드 해시를 붙이는 경우가 있어, 공유 도메인은 별도 route handler로 고정 URL 제공
+ * Next file-based metadata 해시 경로와 별개로 고정 URL을 제공하는 route handler 기준
  */
 export function isFixedOgImagePath(pathname: string) {
   return FIXED_OG_IMAGE_PATH_PATTERN.test(pathname);
 }
 
 /**
- * 현재 공유 미리보기를 허용할 상세 페이지 범위 판별
- * 실제 공유 진입점이 있는 제품/게시글/방송 상세에만 적용해 공개 범위를 좁게 유지
+ * 공유 미리보기를 허용할 상세 페이지 범위 판별
+ * 실제 공유 진입점이 있는 제품/게시글/방송 상세로 제한하는 공개 범위 기준
  */
 export function isSharePreviewPath(pathname: string) {
   return SHAREABLE_DETAIL_PATH_PATTERN.test(pathname);


### PR DESCRIPTION
## Summary

BoardPort v1.2.0 안정화 작업을 develop에 머지한 뒤, 배포 사이트 기준으로 한 번 더 진행한 QA에서 확인된 후속 이슈를 보정했습니다.

이번 PR은 신규 기능 추가보다는 실제 사용 중 드러난 채팅 미읽음 뱃지, 상품 시간 기준, 좋아요/댓글 메타 표시, Client queryFn 조회 경로 문제를 정리하는 후속 안정화 작업입니다.

## Changes

[✅ QA Follow-up]
- develop 머지 이후 배포 사이트 재점검에서 확인된 채팅 뱃지, 상품 시간 기준, 메타 표시 불일치를 보정했습니다.
- 판매/예약/구매 내역 정렬과 표시 시간을 등록일이 아니라 실제 상태 전환 시각 기준으로 정리했습니다.
- 끌어올린 상품 카드는 목록 정렬 기준과 맞도록 등록일이 아니라 `refreshed_at` 기준 노출 시점을 표시하도록 보정했습니다.

[📡 Chat Realtime]
- TabBar 채팅 미읽음 수가 다른 페이지에서도 갱신되도록 전역 브리지와 API 재검증 흐름을 보정했습니다.
- 채팅방 진입/읽음 처리 이후 미읽음 badge가 늦게 사라지거나 남는 케이스를 정리했습니다.
- 채팅 목록과 TabBar가 같은 미읽음 기준을 바라보도록 query invalidate/refetch 흐름을 보강했습니다.

[💄 UX Meta]
- 상품/게시글 좋아요 하트 색상을 전체 좋아요 수가 아니라 현재 사용자 좋아요 여부 기준으로 통일했습니다.
- 다시보기 카드에 좋아요/댓글/조회수 메타를 추가하고 Heroicons 기반 표시 문법으로 정리했습니다.
- 게시글/녹화본 상세의 댓글 수와 댓글 작성 후 카운트 갱신 흐름을 보정했습니다.
- 보드게임 도감 페이지네이션 상단 배치와 직접 이동 버튼 정렬/아이콘을 보정했습니다.
- 서비스 성격에 맞춰 GitHub 로그인 버튼 노출을 제거하고 기존 OAuth 코드는 유지했습니다.

[🔎 Data Fetching]
- TanStack Query의 Client Component queryFn에서 조회용 Server Action을 직접 호출할 때 발생할 수 있는 Next.js Server Function 초기 렌더 호출 오류를 Route Handler fetch 분리로 보정했습니다.
- Server Component의 초기 데이터 준비와 prefetch는 service 계층 직접 호출을 유지하고, hydration 이후 클라이언트 재검증은 HTTP fetch로 수행하도록 역할을 분리했습니다.
- 상품, 게시글, 채팅, 방송, 도감 목록/댓글 조회의 queryFn 경로를 정리했습니다.
- queryKeys 기준을 함께 정리해 서버 prefetch, 클라이언트 캐시, mutation 후 무효화가 같은 cache identity를 공유하도록 보강했습니다.

[📝 Comment]
- 후속 QA에서 변경된 시간 기준, 메타 표시, 데이터 조회 경로 관련 히스토리 주석, JSDoc, 인라인 주석을 현재 코드 기준으로 최신화했습니다.

## Verification
- 배포 사이트 기준 주요 수동 QA 흐름 재확인
- 채팅 메시지 수신/읽음 처리 후 TabBar 미읽음 뱃지 갱신 확인
- 판매/예약/구매 내역 정렬 및 시간 표시 기준 확인
- 끌어올린 상품 카드의 노출 시점 표시 확인
- 상품/게시글 좋아요 하트 색상 기준 확인
- 게시글/녹화본 댓글 작성 후 댓글 수 갱신 확인
- 다시보기 카드 좋아요/댓글/조회수 메타 표시 확인
- 보드게임 도감 페이지네이션 직접 이동 UX 확인
- Client queryFn Route Handler fetch 전환 후 주요 목록/댓글 조회 확인

## Notes

- Server Action은 생성, 수정, 삭제, 토글 같은 사용자 의도 기반 변경 흐름에는 유지했습니다.
- 조회용 Client queryFn만 Route Handler fetch 기준으로 분리해 초기 렌더와 hydration 이후 재검증 경로를 안정화했습니다.
- GitHub OAuth 관련 코드는 유지하되, 서비스 성격에 맞춰 로그인 화면의 버튼 노출만 제거했습니다.