### PR TITLE
🚑 Fix : 삭제된 콘텐츠 알림 및 목록 복귀 안정화

### DIFF
--- a/docs/troubleshooting/troubleshooting-navigation-refresh-flag.md
+++ b/docs/troubleshooting/troubleshooting-navigation-refresh-flag.md
@@ -112,8 +112,8 @@ BoardPort에서는 `목록 -> 상세 -> 수정 -> 저장/취소/삭제` 흐름�
 ### 4. 풀페이지 상세 삭제
 
 - 게시글 / 제품 일반 상세 / 녹화 상세 삭제는 목록 또는 채널 문맥으로 진입했으면 `history back`을 우선 사용
-- 게시글 목록과 녹화 목록/채널은 기존 refresh 플래그를 1회 소비하고 `router.refresh()`로 stale 화면만 보정
-- 제품 목록(`/products`)과 내 판매 목록(`/profile/my-sales`)은 App Router back 복귀 시 상세 트리가 함께 복원되는 예외가 있어 `window.location.reload()`로 현재 엔트리를 다시 로드
+- 게시글 목록(`/posts`), 제품 목록(`/products`), 내 판매 목록(`/profile/my-sales`)은 App Router back 복귀 시 상세 트리가 함께 복원되는 예외가 있어 `window.location.reload()`로 현재 엔트리를 다시 로드
+- 녹화 목록/채널은 기존 refresh 플래그를 1회 소비하고 `router.refresh()`로 stale 화면만 보정
 - 직접 진입처럼 안전한 `back` 대상이 없을 때만 `router.replace(returnTo)` fallback 사용
 - 제품 모달 상세 삭제는 기존처럼 `back` 우선 정책 유지
 
@@ -124,6 +124,49 @@ BoardPort에서는 `목록 -> 상세 -> 수정 -> 저장/취소/삭제` 흐름�
 - `router.replace(returnTo)`만 사용하면 현재 상세 엔트리는 목록으로 바뀌지만, 이전 목록 엔트리가 그대로 남아서 뒤로가기에 같은 목록이 한 번 더 나타납니다.
 - 모바일 퍼스트 기준에서는 뒤로가기 UX가 앞으로가기 UX보다 중요하므로, forward history에 삭제된 상세가 남는 trade-off를 수용하고 `back`을 기본 정책으로 유지합니다.
 - `router.refresh()`는 브라우저 히스토리를 정리하지는 않지만, back 복귀 직후 stale list를 보정하는 수준에서는 충분합니다.
+
+#### 4.1 게시글 삭제 후 mixed tree 사례
+
+게시글 상세에서 삭제 후 `/posts` 목록으로 복귀하는 과정에서 App Router mixed tree 문제가 확인됐습니다.
+
+증상:
+
+- URL은 `/posts`로 바뀌었지만 화면 상단에 삭제된 게시글 상세 segment가 그대로 남음
+- 스크롤을 내리면 그 아래에 게시글 목록이 함께 렌더링됨
+- 새로고침해야 정상적인 `/posts` 목록 화면으로 돌아옴
+- 다른 페이지로 이동해도 삭제된 상세 UI가 상단에 남는 경우 발생
+
+원인:
+
+`router.refresh()`는 서버 데이터를 다시 가져오지만, 메모리상의 라우터 트리 구조 자체를 재구성하지는 않습니다. `router.back()`으로 `/posts`로 복귀해도 App Router가 이전 상세 segment를 트리에서 제거하지 않은 채 목록을 함께 렌더링하면서 mixed tree 상태가 발생했습니다.
+
+즉 이 문제는 단순 데이터 stale 문제가 아니라 **라우터 트리 자체가 꼬인 mixed tree 상태**였습니다.
+
+해결:
+
+- `PostListRefreshRelay`에서 `router.refresh()` 대신 `window.location.reload()`를 사용해 전체 문서를 재요청하고 라우터 트리를 초기화
+- TanStack Query의 게시글 목록 infinite cache에서 삭제된 post id를 즉시 제거
+- 삭제된 post id가 `nextCursor`로 남아 있으면 다음 페이지 요청이 깨질 수 있으므로 cursor도 함께 보정
+- 삭제된 게시글 상세/좋아요 query cache를 제거하고 posts query를 invalidate
+
+`window.location.reload()`를 선택한 이유:
+
+`router.refresh()`는 SPA 방식으로 서버 데이터만 갱신합니다. 반면 `window.location.reload()`는 브라우저가 전체 문서를 새로 요청하면서 메모리의 라우터 트리를 처음부터 다시 구성합니다. mixed tree 잔상을 제거하는 데 가장 확실한 방법이지만, SPA 상태 전체가 초기화되는 비용도 있습니다. 삭제 직후 목록 복귀라는 문맥에서는 이 비용이 허용 가능하다고 판단했습니다.
+
+cursor 보정이 필요했던 이유:
+
+무한스크롤은 이전 페이지의 마지막 항목 id를 `nextCursor`로 사용합니다. 삭제된 post id가 cursor로 남아 있으면 다음 페이지 요청에서 존재하지 않는 기준점을 참조하게 됩니다. 그래서 cache에서 항목 제거와 동시에 cursor도 보정했습니다.
+
+이 문제의 범위:
+
+녹화 목록/채널은 `router.refresh()`로 stale 보정만 해도 충분했습니다. 반면 게시글 목록(`/posts`), 제품 목록(`/products`), 내 판매 목록(`/profile/my-sales`)은 mixed tree 잔상이 재현되어 `window.location.reload()`를 사용합니다.
+
+관련 파일:
+
+- `PostOwnerMenu.tsx`
+- `PostListRefreshRelay.tsx`
+- `features/post/service/post.ts`
+- `lib/queryKeys.ts`
 
 ### 5. 삭제된 상세 재진입 방어
 
@@ -225,7 +268,7 @@ BoardPort에서 `router.back()`은 단순히 `window.history.length > 1`만으�
 
 역할:
 
-- 복귀 직후 대상 화면에서 `router.refresh()`를 1회 호출하도록 만드는 단발성 신호 전달
+- 복귀 직후 대상 화면을 1회 재동기화하도록 만드는 단발성 신호 전달
 - 현재 refresh flag는 `sessionStorage` 기반이며, 같은 탭의 navigation 복귀 보정만 목적으로 합니다.
 - `returnTo`를 대체하지 않음
 - 히스토리 정책을 결정하지 않음
@@ -233,7 +276,7 @@ BoardPort에서 `router.back()`은 단순히 `window.history.length > 1`만으�
 즉 이 유틸은:
 
 > “어디로 돌아갈지”를 정하는 도구가 아니라
-> “돌아간 화면에서 서버 컴포넌트 payload를 다시 요청하고, 이미 revalidate된 데이터를 한 번 반영할지”를 정하는 도구
+> “돌아간 화면에서 서버 컴포넌트 payload를 다시 요청하거나, 도메인별 예외에서는 현재 문서를 다시 로드해 라우터 트리를 초기화할지”를 정하는 도구
 
 입니다.
 
@@ -279,8 +322,8 @@ BoardPort에서 `router.back()`은 단순히 `window.history.length > 1`만으�
 
 1. 수정 저장은 기존 상세/모달 문맥을 재사용한다.
 2. 삭제는 목록/채널 문맥으로 복귀한다.
-3. `returnTo`는 복귀 목적지, `navigationRefreshFlag`는 복귀 후 1회 `router.refresh()` 신호다.
-   단, `/products`와 `/profile/my-sales`는 mixed tree 예외 때문에 현재 엔트리 `window.location.reload()`를 사용한다.
+3. `returnTo`는 복귀 목적지, `navigationRefreshFlag`는 복귀 후 1회 재동기화 신호다.
+   단, `/posts`, `/products`, `/profile/my-sales`는 mixed tree 예외 때문에 현재 엔트리 `window.location.reload()`를 사용한다.
 4. `back`을 쓰는 경우 삭제된 forward 엔트리 재진입은 서버에서 방어한다.
 5. fallback은 도메인별 라우터 트리 위험에 맞춘다. 제품 일반 상세 편집 fallback은 `window.location.replace()`, 그 외 단순 명시 복귀는 `router.replace()`를 사용한다.
 
@@ -290,6 +333,7 @@ BoardPort에서 `router.back()`은 단순히 `window.history.length > 1`만으�
 2. 제품 `detail-edit`는 `push + back + detail refresh`, 취소도 안전한 내부 문맥이면 `back` 우선
 3. 제품 `modal-edit`는 `push + back`이 기본이고, `ProductModalReopenRelay`는 모달 재오픈 fallback만 담당한다.
 4. 풀페이지 상세 삭제는 모바일 퍼스트 기준으로 `back + refresh flag`가 기본
-5. 제품 목록 mixed tree 정리는 `ProductListRefreshRelay`, 내 판매 mixed tree 정리는 `MySalesRefreshRelay`가 담당한다.
+5. 게시글 목록 mixed tree 정리는 `PostListRefreshRelay`가 담당한다.
+6. 제품 목록 mixed tree 정리는 `ProductListRefreshRelay`, 내 판매 mixed tree 정리는 `MySalesRefreshRelay`가 담당한다.
 
 수정 복귀 정책은 공통 규칙 하나로 통일하기보다, **도메인/진입 방식별 요구사항에 맞춰 분리한 상태**로 보는 편이 맞습니다.

--- a/features/notification/components/NotificationListContainer.tsx
+++ b/features/notification/components/NotificationListContainer.tsx
@@ -30,6 +30,8 @@
  * 2026.04.26  임도헌   Modified  좁은 화면에서도 링크형 알림의 보기 버튼이 제목 행 오른쪽에 유지되도록 2열 배치로 정리
  * 2026.04.26  임도헌   Modified  개별 읽음 처리를 "읽음으로 표시" 보조 버튼으로 정리해 보기 액션과 구분
  * 2026.04.26  임도헌   Modified  읽음 액션 토스트 문구를 화면 버튼 라벨과 같은 표현으로 통일
+ * 2026.05.23  임도헌   Modified  삭제된 콘텐츠의 오래된 알림 이미지가 깨질 때 타입 아이콘으로 fallback 처리
+ * 2026.05.24  임도헌   Modified  삭제된 콘텐츠 알림의 이동 불가 보조 문구 추가
  */
 "use client";
 
@@ -84,6 +86,13 @@ const KeywordAlertModal = dynamic(
   { ssr: false }
 );
 
+const CONTENT_LINKED_NOTIFICATION_TYPES = new Set([
+  "TRADE",
+  "CHAT",
+  "STREAM",
+  "KEYWORD",
+]);
+
 /**
  * 알림함 목록 및 읽음 처리 컨테이너 컴포넌트
  *
@@ -104,6 +113,9 @@ export default function NotificationListContainer({
   const [notifications, setNotifications] = useState<NotificationItem[]>(
     data.items
   );
+  const [failedImageIds, setFailedImageIds] = useState<Set<number>>(
+    () => new Set()
+  );
   const [isKeywordModalOpen, setIsKeywordModalOpen] = useState(false);
   const [isMarkingAll, startMarkingAll] = useTransition();
   const router = useRouter();
@@ -119,6 +131,7 @@ export default function NotificationListContainer({
   useEffect(() => {
     // 서버 응답 기준 로컬 목록 재동기화
     setNotifications(data.items);
+    setFailedImageIds(new Set());
   }, [data.items]);
 
   // Zustand 액션 가져오기
@@ -203,6 +216,11 @@ export default function NotificationListContainer({
     "KEYWORD",
     "SYSTEM",
   ];
+  const shouldShowUnavailableCopy = (notification: NotificationItem) =>
+    !notification.link && CONTENT_LINKED_NOTIFICATION_TYPES.has(notification.type);
+
+  // 링크가 제거된 콘텐츠형 알림에만 이동 불가 안내를 보여준다.
+  // 시스템/배지 알림은 원래 링크가 없을 수 있어 안내 대상에서 제외한다.
   /**
    * 선택한 알림 필터로 이동하며 page 쿼리는 1페이지 기준으로 초기화
    * - 알림 센터 내부 상태 전환이므로 히스토리를 남기지 않도록 replace 사용
@@ -310,40 +328,50 @@ export default function NotificationListContainer({
           </div>
         ) : (
           <ul className="divide-y divide-border-subtle">
-            {notifications.map((notification) => (
-              <li
-                key={notification.id}
-                style={{
-                  contentVisibility: "auto",
-                  containIntrinsicSize: "136px",
-                }}
-                className={cn(
-                  "flex items-start gap-4 px-5 py-4 transition-colors sm:items-center",
-                  notification.isRead
-                    ? "bg-surface"
-                    : "bg-surface hover:bg-surface-dim/50"
-                )}
-              >
-                <div className="relative size-11 shrink-0 flex items-center justify-center rounded-xl bg-surface-dim border border-border-subtle text-brand dark:text-brand-light">
-                  {notification.image ? (
-                    <Image
-                      src={notification.image}
-                      alt=""
-                      fill
-                      sizes="44px"
-                      className="object-cover rounded-xl"
-                    />
-                  ) : (
-                    <span className="drop-shadow-sm">
-                      {typeIcons[notification.type] || (
-                        <BellAlertIcon className="size-5" />
-                      )}
-                    </span>
+            {notifications.map((notification) => {
+              const icon = typeIcons[notification.type] || (
+                <BellAlertIcon className="size-5" />
+              );
+              const canRenderImage =
+                !!notification.image && !failedImageIds.has(notification.id);
+
+              return (
+                <li
+                  key={notification.id}
+                  style={{
+                    contentVisibility: "auto",
+                    containIntrinsicSize: "136px",
+                  }}
+                  className={cn(
+                    "flex items-start gap-4 px-5 py-4 transition-colors sm:items-center",
+                    notification.isRead
+                      ? "bg-surface"
+                      : "bg-surface hover:bg-surface-dim/50"
                   )}
-                  {!notification.isRead && (
-                    <span className="absolute -top-1 -right-1 size-3 bg-danger rounded-full border-2 border-surface animate-pulse" />
-                  )}
-                </div>
+                >
+                  <div className="relative size-11 shrink-0 flex items-center justify-center rounded-xl bg-surface-dim border border-border-subtle text-brand dark:text-brand-light">
+                    {canRenderImage ? (
+                      <Image
+                        src={notification.image!}
+                        alt=""
+                        fill
+                        sizes="44px"
+                        className="object-cover rounded-xl"
+                        onError={() => {
+                          setFailedImageIds((prev) => {
+                            const next = new Set(prev);
+                            next.add(notification.id);
+                            return next;
+                          });
+                        }}
+                      />
+                    ) : (
+                      <span className="drop-shadow-sm">{icon}</span>
+                    )}
+                    {!notification.isRead && (
+                      <span className="absolute -top-1 -right-1 size-3 bg-danger rounded-full border-2 border-surface animate-pulse" />
+                    )}
+                  </div>
 
                 <div className="flex-1 min-w-0">
                   {notification.link ? (
@@ -389,6 +417,11 @@ export default function NotificationListContainer({
                   <p className="mt-0.5 line-clamp-2 text-sm leading-snug text-slate-600 dark:text-slate-300">
                     {notification.body}
                   </p>
+                  {shouldShowUnavailableCopy(notification) && (
+                    <p className="mt-1 text-xs leading-snug text-slate-500 dark:text-slate-400">
+                      연결된 콘텐츠가 삭제되어 이동할 수 없습니다.
+                    </p>
+                  )}
                   <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
                     <TimeAgo
                       date={notification.created_at}
@@ -407,8 +440,9 @@ export default function NotificationListContainer({
                     )}
                   </div>
                 </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/features/notification/service/notification.ts
+++ b/features/notification/service/notification.ts
@@ -14,6 +14,7 @@
  * 2026.04.02  임도헌   Modified  공용 알림 타입과 필터 상수를 types/constants 파일로 분리
  * 2026.04.26  임도헌   Modified  읽음 처리 실패 문구를 알림 센터 UI 액션 라벨과 같은 표현으로 정리
  * 2026.05.16  임도헌   Modified  미읽음 알림 카운트 조회를 service 계층으로 분리
+ * 2026.05.24  임도헌   Modified  삭제된 콘텐츠를 가리키는 오래된 알림 링크/이미지 응답 정규화 추가
  */
 
 import "server-only";
@@ -34,6 +35,105 @@ import type {
   NotificationListResponse,
 } from "@/features/notification/types";
 import type { ServiceResult } from "@/lib/types";
+
+type NotificationListRow = NotificationListResponse["items"][number];
+
+function extractIdFromPath(link: string | null, pattern: RegExp) {
+  if (!link) return null;
+  const match = link.match(pattern);
+  if (!match?.[1]) return null;
+  const id = Number(match[1]);
+  return Number.isInteger(id) ? id : null;
+}
+
+function extractChatRoomId(link: string | null) {
+  if (!link) return null;
+  const match = link.match(/^\/chats\/([^/?#]+)/);
+  return match?.[1] ?? null;
+}
+
+async function normalizeDeletedContentNotifications(
+  items: NotificationListRow[]
+): Promise<NotificationListRow[]> {
+  if (items.length === 0) return items;
+
+  // 기존 DB에 남은 오래된 알림도 응답 단계에서 안전하게 정규화한다.
+  // hard delete 이후 원본 콘텐츠가 없으면 링크/이미지를 제거해 404 이동과 깨진 썸네일을 막는다.
+  const productIds = new Set<number>();
+  const postIds = new Set<number>();
+  const streamIds = new Set<number>();
+  const chatRoomIds = new Set<string>();
+
+  for (const item of items) {
+    const productId = extractIdFromPath(item.link, /^\/products\/view\/(\d+)/);
+    if (productId) productIds.add(productId);
+
+    const postId = extractIdFromPath(item.link, /^\/posts\/(\d+)/);
+    if (postId) postIds.add(postId);
+
+    const streamId = extractIdFromPath(item.link, /^\/streams\/(\d+)/);
+    if (streamId) streamIds.add(streamId);
+
+    const chatRoomId = extractChatRoomId(item.link);
+    if (chatRoomId) chatRoomIds.add(chatRoomId);
+  }
+
+  const [products, posts, streams, chatRooms] = await Promise.all([
+    productIds.size
+      ? db.product.findMany({
+          where: { id: { in: [...productIds] } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+    postIds.size
+      ? db.post.findMany({
+          where: { id: { in: [...postIds] } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+    streamIds.size
+      ? db.broadcast.findMany({
+          where: { id: { in: [...streamIds] } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+    chatRoomIds.size
+      ? db.productChatRoom.findMany({
+          where: { id: { in: [...chatRoomIds] } },
+          select: { id: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const existingProductIds = new Set(products.map((item) => item.id));
+  const existingPostIds = new Set(posts.map((item) => item.id));
+  const existingStreamIds = new Set(streams.map((item) => item.id));
+  const existingChatRoomIds = new Set(chatRooms.map((item) => item.id));
+
+  return items.map((item) => {
+    const productId = extractIdFromPath(item.link, /^\/products\/view\/(\d+)/);
+    if (productId && !existingProductIds.has(productId)) {
+      return { ...item, link: null, image: null };
+    }
+
+    const postId = extractIdFromPath(item.link, /^\/posts\/(\d+)/);
+    if (postId && !existingPostIds.has(postId)) {
+      return { ...item, link: null, image: null };
+    }
+
+    const streamId = extractIdFromPath(item.link, /^\/streams\/(\d+)/);
+    if (streamId && !existingStreamIds.has(streamId)) {
+      return { ...item, link: null, image: null };
+    }
+
+    const chatRoomId = extractChatRoomId(item.link);
+    if (chatRoomId && !existingChatRoomIds.has(chatRoomId)) {
+      return { ...item, link: null, image: null };
+    }
+
+    return item;
+  });
+}
 
 /**
  * DB 알림 타입을 알림 센터 필터 그룹으로 정규화
@@ -293,11 +393,12 @@ export async function getNotifications(
       skip,
       take: limit,
     });
+    const normalizedItems = await normalizeDeletedContentNotifications(items);
 
     return {
       success: true,
       data: {
-        items,
+        items: normalizedItems,
         total,
         totalPages,
         currentPage,

--- a/features/post/components/PostListRefreshRelay.tsx
+++ b/features/post/components/PostListRefreshRelay.tsx
@@ -8,11 +8,11 @@
  * 2026.04.07  임도헌   Created   게시글 상세 삭제 후 history back 복귀 시 목록 stale 상태를 1회 refresh로 보정
  * 2026.04.24  임도헌   Modified  같은 탭 sessionStorage 기반 router.refresh 트리거라는 역할이 드러나도록 주석 보강
  * 2026.04.24  임도헌   Modified  navigation refresh helper로 목록 refresh flag 소비 로직을 단순화
+ * 2026.05.24  임도헌   Modified  삭제 후 /posts mixed tree 잔상을 지우기 위해 router.refresh 대신 문서 reload 사용
  */
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import {
   consumeNavigationRefresh,
   NAVIGATION_REFRESH_ROOT_ID,
@@ -24,11 +24,10 @@ import {
  *
  * [기능]
  * - 상세 삭제 후 `router.back()`으로 돌아온 게시글 목록이 stale 상태로 남지 않도록
- *   같은 탭 세션 플래그를 1회 소비해 `router.refresh()`를 수행
+ *   같은 탭 세션 플래그를 1회 소비해 현재 문서를 다시 로드
+ * - URL은 `/posts`인데 삭제된 상세 segment가 위에 남는 App Router mixed tree 상태를 정리
  */
 export default function PostListRefreshRelay() {
-  const router = useRouter();
-
   useEffect(() => {
     if (
       !consumeNavigationRefresh(
@@ -38,8 +37,10 @@ export default function PostListRefreshRelay() {
     ) {
       return;
     }
-    router.refresh();
-  }, [router]);
+    // router.refresh()는 URL이 /posts여도 삭제된 상세 segment가 남는
+    // mixed tree를 지우지 못해 문서 reload를 사용한다.
+    window.location.reload();
+  }, []);
 
   return null;
 }

--- a/features/post/components/postsDetail/PostOwnerMenu.tsx
+++ b/features/post/components/postsDetail/PostOwnerMenu.tsx
@@ -8,12 +8,15 @@
  * 2026.04.06  임도헌   Created   게시글 상세의 수정/삭제 액션을 상단 관리 메뉴로 통합
  * 2026.04.08  임도헌   Modified  삭제 후 목록 진입 문맥이면 back + posts 목록 refresh로 복귀하도록 보강
  * 2026.04.24  임도헌   Modified  navigation refresh helper 기준으로 삭제 후 back 복귀 플래그 기록 중복을 정리
+ * 2026.05.23  임도헌   Modified  게시글 삭제 후 /posts 목록 문맥에서만 history back을 사용하도록 복귀 기준 보강
+ * 2026.05.23  임도헌   Modified  삭제 성공 시 게시글 infinite query 캐시와 stale cursor를 즉시 정리
  */
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   EllipsisVerticalIcon,
@@ -30,6 +33,8 @@ import {
   NAVIGATION_REFRESH_ROOT_ID,
   NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
+import { queryKeys } from "@/lib/queryKeys";
+import type { PostsPage } from "@/features/post/types";
 
 interface PostOwnerMenuProps {
   postId: number;
@@ -55,6 +60,7 @@ export default function PostOwnerMenu({
   preferHistoryBack = false,
 }: PostOwnerMenuProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const menuRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
@@ -88,21 +94,59 @@ export default function PostOwnerMenu({
         toast.success("게시글이 삭제되었습니다.");
         setConfirmOpen(false);
         setIsOpen(false);
+        queryClient.setQueriesData(
+          { queryKey: queryKeys.posts.lists() },
+          (oldData:
+            | { pages: PostsPage[]; pageParams?: unknown[] }
+            | undefined) => {
+            if (!oldData?.pages) return oldData;
 
-        if (preferHistoryBack && canUseBrowserBack()) {
-          // 게시글 목록 문맥은 back 전에 flag를 남겨 복귀 후 stale list 보정
-          if (nextAfterDelete.startsWith("/posts")) {
-            markNavigationRefresh(
-              NAVIGATION_REFRESH_SCOPES.POSTS_LIST,
-              NAVIGATION_REFRESH_ROOT_ID
-            );
+            return {
+              ...oldData,
+              pages: oldData.pages.map((page) => {
+                const posts = page.posts.filter((post) => post.id !== postId);
+                const removedFromPage = posts.length !== page.posts.length;
+                const nextCursor =
+                  page.nextCursor === postId
+                    ? (posts[posts.length - 1]?.id ?? null)
+                    : page.nextCursor;
+
+                return {
+                  ...page,
+                  posts,
+                  nextCursor,
+                  totalCount:
+                    removedFromPage && typeof page.totalCount === "number"
+                      ? Math.max(0, page.totalCount - 1)
+                      : page.totalCount,
+                };
+              }),
+            };
           }
+        );
+        queryClient.removeQueries({ queryKey: queryKeys.posts.detail(postId) });
+        queryClient.removeQueries({
+          queryKey: queryKeys.posts.likeStatus(postId),
+        });
+        queryClient.invalidateQueries({ queryKey: queryKeys.posts.all });
+
+        const isPostsListReturn = nextAfterDelete.startsWith("/posts");
+
+        // 게시글 목록 문맥에서만 back 복귀를 허용한다.
+        // 다른 returnTo에서 back을 쓰면 삭제된 상세 tree가 남을 수 있다.
+        if (isPostsListReturn) {
+          markNavigationRefresh(
+            NAVIGATION_REFRESH_SCOPES.POSTS_LIST,
+            NAVIGATION_REFRESH_ROOT_ID
+          );
+        }
+
+        if (preferHistoryBack && isPostsListReturn && canUseBrowserBack()) {
           router.back();
           return;
         }
 
         router.replace(nextAfterDelete);
-        router.refresh();
       } catch (error) {
         console.error(error);
         toast.error("게시글 삭제 중 오류가 발생했습니다.");

--- a/features/post/service/post.ts
+++ b/features/post/service/post.ts
@@ -41,6 +41,7 @@
  * 2026.05.13  임도헌   Modified  게시글 목록 검색을 제목/본문/태그 대소문자 무시 조건으로 통일
  * 2026.05.16  임도헌   Modified  수정 액션의 기존 첨부 동영상 확인 쿼리를 service 헬퍼로 분리
  * 2026.05.18  임도헌   Modified  게시글 목록 카드 하트 색상을 현재 사용자 좋아요 여부 기준으로 표시하도록 isLiked 매핑 추가
+ * 2026.05.23  임도헌   Modified  삭제된 게시글 알림 링크/이미지 정리 및 삭제 cursor 목록 페이지네이션 실패 방어
  */
 import "server-only";
 
@@ -258,6 +259,20 @@ export async function hardDeletePostWithCleanup(
         },
       });
     }
+
+    // 삭제된 게시글을 가리키는 알림은 더 이상 상세 이동/썸네일을 노출하지 않음
+    await tx.notification.updateMany({
+      where: {
+        OR: [
+          { link: `/posts/${target.id}` },
+          { link: { startsWith: `/posts/${target.id}?` } },
+        ],
+      },
+      data: {
+        image: null,
+        link: null,
+      },
+    });
 
     // 게시글 첨부 동영상은 부모 콘텐츠와 함께 정리해 orphan record를 남기지 않음
     await tx.postVideo.deleteMany({ where: { postId: target.id } });
@@ -523,6 +538,17 @@ export async function getPostsList(
   const blockedIds = await getBlockedUserIds(viewerId);
   if (blockedIds.length > 0) {
     where.userId = { notIn: blockedIds };
+  }
+
+  if (cursor) {
+    const cursorExists = await db.post.findUnique({
+      where: { id: cursor },
+      select: { id: true },
+    });
+    if (!cursorExists) {
+      const totalCount = await db.post.count({ where });
+      return { posts: [], nextCursor: null, totalCount };
+    }
   }
 
   const [rows, totalCount] = await Promise.all([

--- a/features/product/components/productDetail/ProductOwnerMenu.tsx
+++ b/features/product/components/productDetail/ProductOwnerMenu.tsx
@@ -11,11 +11,13 @@
  * 2026.04.24  임도헌   Modified  내 판매 목록 삭제 복귀는 replace+refresh를 우선 적용하고 일반 back 분기와 주석을 현재 정책 기준으로 정리
  * 2026.04.24  임도헌   Modified  내 판매 목록도 전용 refresh relay를 통해 back + 1회 refresh 복귀를 사용하도록 조정
  * 2026.04.24  임도헌   Modified  returnTo 문맥 분류와 navigation refresh helper로 삭제/숨김 복귀 분기 중복을 정리
+ * 2026.05.23  임도헌   Modified  삭제 성공 시 제품 infinite query 캐시와 stale cursor를 즉시 정리
  */
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   EllipsisVerticalIcon,
@@ -36,6 +38,11 @@ import {
   NAVIGATION_REFRESH_ROOT_ID,
   NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  removeProductFromInfiniteCache,
+  type ProductInfiniteCache,
+} from "@/features/product/utils/productQueryCache";
 
 interface ProductOwnerMenuProps {
   productId: number;
@@ -71,6 +78,7 @@ export default function ProductOwnerMenu({
   isHidden = false,
 }: ProductOwnerMenuProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const menuRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
@@ -203,6 +211,24 @@ export default function ProductOwnerMenu({
       setConfirmOpen(false);
       setIsOpen(false);
       removeRecentViewedProduct(productId);
+      queryClient.setQueriesData(
+        {
+          predicate: (query) =>
+            Array.isArray(query.queryKey) &&
+            query.queryKey[0] === "products" &&
+            (query.queryKey[1] === "list" ||
+              query.queryKey[1] === "userScope"),
+        },
+        (oldData: ProductInfiniteCache<{ id: number }> | undefined) =>
+          removeProductFromInfiniteCache(oldData, productId)
+      );
+      queryClient.removeQueries({
+        queryKey: queryKeys.products.detail(productId),
+      });
+      queryClient.removeQueries({
+        queryKey: queryKeys.products.likeStatus(productId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.products.all });
 
       if (returnContext === "products") {
         // 제품 목록에서 진입한 상세 삭제는 모바일 back UX를 우선 유지

--- a/features/product/service/admin.ts
+++ b/features/product/service/admin.ts
@@ -13,6 +13,7 @@
  * 2026.04.02  임도헌   Modified  관리자 서비스 JSDoc 태그 형식 정리
  * 2026.05.15  임도헌   Modified  관리자 상품 검색 범위에 검색 태그명 포함
  * 2026.05.16  임도헌   Modified  관리자 검색 where 조건 타입 명시
+ * 2026.05.24  임도헌   Modified  관리자 상품 삭제 시 채팅방 알림 링크 cleanup 대상 포함
  */
 
 import "server-only";
@@ -132,7 +133,9 @@ export async function deleteProductByAdmin(
         reservation_userId: true,
         search_tags: { select: { name: true } },
         images: { select: { url: true } },
-        chat_rooms: { select: { users: { select: { id: true } } } },
+        chat_rooms: {
+          select: { id: true, users: { select: { id: true } } },
+        },
       },
     });
 
@@ -148,6 +151,7 @@ export async function deleteProductByAdmin(
       id: productId,
       search_tags: product.search_tags,
       images: product.images,
+      chat_rooms: product.chat_rooms,
     });
 
     // 감사 로그 기록

--- a/features/product/service/delete.ts
+++ b/features/product/service/delete.ts
@@ -17,6 +17,8 @@
  * 2026.03.31  임도헌   Modified  일반 삭제/관리자 삭제 공통 cleanup helper와 Cloudflare 이미지 자산 정리 추가
  * 2026.04.02  임도헌   Modified  Cloudflare imageId 추출 유틸 분리 및 보조 함수 JSDoc 보강
  * 2026.04.04  임도헌   Modified  삭제 대상 조회/cleanup/메타 반환 단계의 인라인 주석 보강
+ * 2026.05.23  임도헌   Modified  삭제된 상품을 가리키는 알림 이미지/링크 정리와 리뷰 FK cleanup 추가
+ * 2026.05.24  임도헌   Modified  상품 삭제로 함께 제거되는 채팅방 알림 링크 정리 추가
  */
 import "server-only";
 
@@ -71,6 +73,7 @@ type HardDeleteProductTarget = {
   id: number;
   search_tags: { name: string }[];
   images: { url: string }[];
+  chat_rooms: { id: string }[];
 };
 
 /**
@@ -87,6 +90,11 @@ export async function hardDeleteProductWithCleanup(
   // 태그/이미지 cleanup용 원시 목록 추출
   const tagNames = target.search_tags.map((tag) => tag.name);
   const imageUrls = target.images.map((image) => image.url);
+  const chatRoomIds = target.chat_rooms.map((room) => room.id);
+  const notificationImageUrls = imageUrls.flatMap((url) => [
+    url,
+    `${url}/public`,
+  ]);
 
   await db.$transaction(async (tx) => {
     // 연결된 태그 count 감소
@@ -100,6 +108,38 @@ export async function hardDeleteProductWithCleanup(
         )
       );
     }
+
+    // 삭제된 상품을 가리키는 오래된 알림은 깨진 이미지/상세 링크를 남기지 않음
+    await tx.notification.updateMany({
+      where: {
+        OR: [
+          { link: `/products/view/${target.id}` },
+          { link: { startsWith: `/products/view/${target.id}?` } },
+          ...(notificationImageUrls.length
+            ? [{ image: { in: notificationImageUrls } }]
+            : []),
+        ],
+      },
+      data: {
+        image: null,
+        link: null,
+      },
+    });
+
+    if (chatRoomIds.length > 0) {
+      await tx.notification.updateMany({
+        where: {
+          OR: chatRoomIds.flatMap((roomId) => [
+            { link: `/chats/${roomId}` },
+            { link: { startsWith: `/chats/${roomId}?` } },
+          ]),
+        },
+        data: { link: null },
+      });
+    }
+
+    // Review는 Product FK가 필수 관계이므로 하드 삭제 전에 함께 정리
+    await tx.review.deleteMany({ where: { productId: target.id } });
 
     // 상품 본문 하드 삭제
     await tx.product.delete({ where: { id: target.id } });
@@ -148,7 +188,7 @@ export async function deleteProduct(
         search_tags: { select: { name: true } },
         images: { select: { url: true } },
         chat_rooms: {
-          select: { users: { select: { id: true } } },
+          select: { id: true, users: { select: { id: true } } },
         },
       },
     });
@@ -171,6 +211,7 @@ export async function deleteProduct(
       id: productId,
       search_tags: product.search_tags,
       images: product.images,
+      chat_rooms: product.chat_rooms,
     });
 
     // 후속 캐시 무효화용 메타데이터 반환

--- a/features/product/service/list.ts
+++ b/features/product/service/list.ts
@@ -21,6 +21,7 @@
  * 2026.05.12  임도헌   Modified  제품 검색의 제목/본문/태그 조건을 대소문자 무시 기준으로 통일
  * 2026.05.18  임도헌   Modified  목록 카드 하트 색상용 현재 유저 좋아요 여부를 DTO에 포함
  * 2026.05.20  임도헌   Modified  refreshed_at 정렬 주석의 2차 기준을 실제 id 기준으로 정정
+ * 2026.05.24  임도헌   Modified  삭제된 상품 cursor로 인한 목록 페이지네이션 실패 방어
  */
 import "server-only";
 import db from "@/lib/db";
@@ -191,6 +192,17 @@ export async function getProductsList(
   const blockedIds = await getBlockedUserIds(viewerId);
   if (blockedIds.length > 0) {
     where.userId = { notIn: blockedIds };
+  }
+
+  if (cursor) {
+    const cursorExists = await db.product.findUnique({
+      where: { id: cursor },
+      select: { id: true },
+    });
+    if (!cursorExists) {
+      const totalCount = await db.product.count({ where });
+      return { products: [], nextCursor: null, totalCount };
+    }
   }
 
   // 커서 기반 페이지네이션용 cursor 객체 구성

--- a/features/product/utils/productQueryCache.ts
+++ b/features/product/utils/productQueryCache.ts
@@ -7,6 +7,7 @@
  * Date        Author   Status    Description
  * 2026.03.06  임도헌   Created   LIKED 스코프 판별 및 목록 캐시 스냅샷 추출 유틸 분리
  * 2026.05.16  임도헌   Modified  무한스크롤 캐시 shape 타입을 명시해 캐시 조작부 any 의존 완화
+ * 2026.05.23  임도헌   Modified  삭제된 상품을 infinite cache와 nextCursor에서 제거하는 유틸 추가
  */
 
 import type { Paginated } from "@/features/product/types";
@@ -57,4 +58,43 @@ export function pickProductFromLists<T extends { id: number }>(
     }
   }
   return null;
+}
+
+/**
+ * infinite query 캐시에서 삭제된 상품과 해당 상품을 가리키는 nextCursor를 함께 제거
+ *
+ * - 삭제된 상품이 페이지 마지막 아이템이면 기존 nextCursor가 삭제된 id로 남을 수 있음
+ * - 그 상태에서 다음 페이지를 요청하면 Prisma cursor가 존재하지 않아 무한스크롤이 실패할 수 있음
+ */
+export function removeProductFromInfiniteCache<T extends { id: number }>(
+  oldData: ProductInfiniteCache<T> | undefined,
+  productId: number
+): ProductInfiniteCache<T> | undefined {
+  if (!oldData?.pages) return oldData;
+
+  return {
+    ...oldData,
+    pages: oldData.pages.map((page) => {
+      const products = page.products.filter(
+        (product) => product.id !== productId
+      );
+      const removedFromPage = products.length !== page.products.length;
+      // 삭제된 상품이 다음 페이지 cursor였으면 남은 마지막 항목으로 되돌려
+      // 존재하지 않는 Prisma cursor 요청을 막는다.
+      const nextCursor =
+        page.nextCursor === productId
+          ? (products[products.length - 1]?.id ?? null)
+          : page.nextCursor;
+
+      return {
+        ...page,
+        products,
+        nextCursor,
+        totalCount:
+          removedFromPage && typeof page.totalCount === "number"
+            ? Math.max(0, page.totalCount - 1)
+            : page.totalCount,
+      };
+    }),
+  };
 }

--- a/features/stream/service/delete.ts
+++ b/features/stream/service/delete.ts
@@ -12,6 +12,7 @@
  * 2026.03.31  임도헌   Modified  일반 삭제/관리자 삭제 공통 cleanup helper와 Cloudflare VOD/썸네일 자산 정리 추가
  * 2026.04.02  임도헌   Modified  Cloudflare 이미지 ID 파싱을 stream image utils로 분리하고 삭제 helper 설명 보강
  * 2026.05.16  임도헌   Modified  방송 삭제 액션의 사전 조회용 메타 헬퍼 추가
+ * 2026.05.24  임도헌   Modified  삭제된 방송을 가리키는 알림 링크/이미지 정리 추가
  */
 
 import "server-only";
@@ -114,6 +115,23 @@ async function deleteCloudflareThumbnailAsset(
   }
 }
 
+function buildBroadcastNotificationCleanupWhere(
+  broadcastId: number,
+  thumbnailUrl: string | null
+) {
+  const imageUrls = thumbnailUrl
+    ? [thumbnailUrl, `${thumbnailUrl}/public`]
+    : [];
+
+  return {
+    OR: [
+      { link: `/streams/${broadcastId}` },
+      { link: { startsWith: `/streams/${broadcastId}?` } },
+      ...(imageUrls.length > 0 ? [{ image: { in: imageUrls } }] : []),
+    ],
+  };
+}
+
 /**
  * 방송 하드 삭제 공통 cleanup
  *
@@ -131,6 +149,13 @@ export async function hardDeleteBroadcastWithCleanup(
   const vodAssetIds = target.vodAssets.map((item) => item.provider_asset_id);
 
   await db.$transaction(async (tx) => {
+    await tx.notification.updateMany({
+      where: buildBroadcastNotificationCleanupWhere(
+        target.id,
+        target.thumbnail
+      ),
+      data: { link: null, image: null },
+    });
     await tx.vodAsset.deleteMany({ where: { broadcastId: target.id } });
     await tx.broadcast.delete({ where: { id: target.id } });
   });
@@ -172,6 +197,13 @@ export async function deleteBroadcastTx(
       return { success: false, error: "이미 삭제된 방송입니다." };
     }
 
+    await tx.notification.updateMany({
+      where: buildBroadcastNotificationCleanupWhere(
+        broadcastId,
+        broadcast.thumbnail
+      ),
+      data: { link: null, image: null },
+    });
     await tx.vodAsset.deleteMany({ where: { broadcastId } });
     await tx.broadcast.delete({ where: { id: broadcastId } });
 

--- a/features/user/service/withdraw.ts
+++ b/features/user/service/withdraw.ts
@@ -8,6 +8,7 @@
  * 2026.02.23  임도헌   Created   회원 탈퇴 로직 추가
  * 2026.03.07  임도헌   Modified  탈퇴 실패 문구를 구체화(v1.2)
  * 2026.03.31  임도헌   Modified  도메인별 cleanup helper를 거쳐 외부 자산과 태그 정산까지 반영하도록 보강
+ * 2026.05.24  임도헌   Modified  회원 탈퇴 시 상품 채팅방 알림 링크 cleanup 메타 포함
  */
 
 import "server-only";
@@ -46,6 +47,7 @@ export async function withdrawUser(userId: number): Promise<ServiceResult> {
             id: true,
             search_tags: { select: { name: true } },
             images: { select: { url: true } },
+            chat_rooms: { select: { id: true } },
           },
         },
         post_videos: {
@@ -83,6 +85,7 @@ export async function withdrawUser(userId: number): Promise<ServiceResult> {
         id: product.id,
         search_tags: product.search_tags,
         images: product.images,
+        chat_rooms: product.chat_rooms,
       });
     }
 


### PR DESCRIPTION
## Summary

삭제된 상품/게시글/방송을 참조하는 알림과, 삭제 후 목록 복귀 과정에서 발생하던 UI/캐시 불일치 문제를 안정화했습니다.

이번 PR은 릴리즈 전 데모/QA 과정에서 확인한 hard delete 이후의 알림 링크, 깨진 이미지, 목록 캐시, App Router mixed tree 문제를 정리하는 작업입니다.

## Changes

[🚑 Deleted Content Cleanup]

- 상품/게시글/방송 hard delete 시 연결된 알림의 `link`/`image`를 정리했습니다.
- 기존 알림이 삭제된 상품/게시글/방송/채팅방을 가리키면 응답 단계에서 `link`/`image`를 제거하도록 보강했습니다.
- 삭제된 콘텐츠 알림은 `보기` 버튼 대신 이동 불가 안내와 타입 아이콘 fallback을 표시하도록 정리했습니다.
- 상품 삭제 시 연결된 리뷰 FK와 상품 채팅방 알림 링크도 함께 정리했습니다.

[🧭 Navigation & Cache]

- 게시글/상품 삭제 후 infinite query cache에서 삭제 항목과 stale cursor를 즉시 제거했습니다.
- 삭제된 cursor로 인해 상품/게시글 목록 페이지네이션이 실패하지 않도록 service 단계 방어 로직을 추가했습니다.
- 게시글 삭제 후 `/posts` URL에 삭제된 상세 segment가 남는 App Router mixed tree 문제를 `PostListRefreshRelay`에서 `window.location.reload()` 기준으로 보정했습니다.
- 제품 목록과 내 판매 목록의 mixed tree 정리 기준과 동일하게 삭제 후 목록 복귀 정책을 정리했습니다.

[📚 Docs]

- navigation refresh flag 문서에 게시글 삭제 후 mixed tree 사례를 추가했습니다.
- `returnTo`, `navigationRefreshFlag`, `router.refresh`, `window.location.reload()`의 역할 차이를 현재 구현 기준으로 정리했습니다.

## Notes

- 전체 soft delete 전환은 이번 범위에 포함하지 않고, hard delete 이후 남는 참조를 정리하는 방식으로 안정화했습니다.