### PR TITLE
🚑 Fix : 모바일 댓글 입력 Enter 정책 정리

### DIFF
--- a/features/post/components/postComment/PostCommentForm.tsx
+++ b/features/post/components/postComment/PostCommentForm.tsx
@@ -23,6 +23,7 @@
  * 2026.03.30  임도헌   Modified  게시글 카테고리 plain 라벨 정리에 맞춰 댓글 플레이스홀더를 일반 문맥으로 조정
  * 2026.04.20  임도헌   Modified  댓글 입력 포커스가 내부 textarea 기본 outline으로 보이지 않도록 외곽 패널 중심으로 정리
  * 2026.04.26  임도헌   Modified  댓글 등록 버튼의 다크모드 hover 색조를 primary CTA 톤과 맞춰 정리
+ * 2026.05.30  임도헌   Modified  모바일 버튼 전송, 데스크톱 Enter 전송 기준으로 댓글 입력 정책 정리
  */
 "use client";
 
@@ -38,7 +39,8 @@ import { toast } from "sonner";
  * [상호작용 및 상태 제어 로직]
  * - `useCreatePostCommentMutation` 훅을 활용한 댓글 데이터 서버 전송 및 캐시 무효화 유도
  * - `textarea` 입력 내용 기반 자동 높이 조절 로직 적용
- * - IME(한글 등) 조합 중 중복 전송 방지(`isComposing`) 및 단축키(Enter 전송, Shift+Enter 개행) 처리
+ * - 모바일 버튼 전송, 데스크톱 Enter 전송, Shift+Enter 개행 처리
+ * - IME(한글 등) 조합 중 Enter 전송 방지와 명시 버튼 전송 허용
  * - 작성 시도 즉시 입력창 초기화 후, 실패 시 입력값 복원(Rollback) 적용
  */
 export default function PostCommentForm({ postId }: { postId: number }) {
@@ -56,8 +58,8 @@ export default function PostCommentForm({ postId }: { postId: number }) {
     el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
   }, [text]);
 
-  const submit = async () => {
-    if (isPending || isComposing) return;
+  const submit = async (options?: { allowComposing?: boolean }) => {
+    if (isPending || (!options?.allowComposing && isComposing)) return;
     const trimmed = text.trim();
     if (!trimmed) return;
 
@@ -83,7 +85,11 @@ export default function PostCommentForm({ postId }: { postId: number }) {
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey && !isComposing) {
+    const isDesktopInput =
+      typeof window !== "undefined" &&
+      window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+    if (e.key === "Enter" && !e.shiftKey && !isComposing && isDesktopInput) {
       e.preventDefault();
       submit();
     }
@@ -111,7 +117,7 @@ export default function PostCommentForm({ postId }: { postId: number }) {
       </div>
 
       <button
-        onClick={submit}
+        onClick={() => submit({ allowComposing: true })}
         disabled={isPending || !text.trim()}
         className={cn(
           "focus-ring-soft shrink-0 size-10 rounded-full flex items-center justify-center transition-[background-color,color,border-color,box-shadow] shadow-sm",

--- a/features/stream/components/recording/recordingComment/RecordingCommentForm.tsx
+++ b/features/stream/components/recording/recordingComment/RecordingCommentForm.tsx
@@ -19,6 +19,7 @@
  * 2026.03.25  임도헌   Modified  라이트 모드 댓글 입력창 대비를 소폭 올려 첫인상 가시성을 보강
  * 2026.03.27  임도헌   Modified  녹화 댓글 전송 버튼에 다크 밀집 화면용 아이콘 전용 quiet-dark 버튼 변형 적용
  * 2026.04.20  임도헌   Modified  댓글 입력 포커스가 내부 textarea 기본 outline으로 보이지 않도록 외곽 패널 중심으로 정리
+ * 2026.05.30  임도헌   Modified  모바일 버튼 전송, 데스크톱 Enter 전송 기준으로 녹화 댓글 입력 정책 정리
  */
 "use client";
 
@@ -33,7 +34,8 @@ import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
  * [상호작용 및 상태 제어 로직]
  * - `useCreateRecordingCommentMutation` 훅을 활용한 댓글 데이터 서버 전송 및 캐시 갱신 유도
  * - `textarea` 입력 텍스트 길이에 따른 자동 높이 조절 로직 적용
- * - IME(한글 등) 조합 중 중복 전송 방지(`isComposing`) 및 단축키(Enter 전송, Shift+Enter 개행) 지원
+ * - 모바일 버튼 전송, 데스크톱 Enter 전송, Shift+Enter 개행 처리
+ * - IME(한글 등) 조합 중 Enter 전송 방지와 명시 버튼 전송 허용
  * - 작성 시도 즉시 입력창 비움 처리(Optimistic Clear) 후, 실패 시 입력값 복원(Rollback) 수행
  */
 export default function RecordingCommentForm({ vodId }: { vodId: number }) {
@@ -51,8 +53,8 @@ export default function RecordingCommentForm({ vodId }: { vodId: number }) {
     el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
   }, [text]);
 
-  const submit = async () => {
-    if (isLoading || isComposing) return;
+  const submit = async (options?: { allowComposing?: boolean }) => {
+    if (isLoading || (!options?.allowComposing && isComposing)) return;
     const trimmed = text.trim();
     if (!trimmed) return;
 
@@ -73,7 +75,11 @@ export default function RecordingCommentForm({ vodId }: { vodId: number }) {
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey && !isComposing) {
+    const isDesktopInput =
+      typeof window !== "undefined" &&
+      window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+    if (e.key === "Enter" && !e.shiftKey && !isComposing && isDesktopInput) {
       e.preventDefault();
       submit();
     }
@@ -96,7 +102,7 @@ export default function RecordingCommentForm({ vodId }: { vodId: number }) {
       </div>
 
       <button
-        onClick={submit}
+        onClick={() => submit({ allowComposing: true })}
         disabled={isLoading || !text.trim()}
         className={cn(
           "btn-primary-quiet-dark-icon flex size-10 shrink-0 items-center justify-center rounded-full border border-black/[0.06] transition-[background-color,color,border-color,box-shadow] shadow-sm dark:border-border-subtle",


### PR DESCRIPTION
## Summary

모바일 textarea 입력에서 Enter가 전송으로 처리되던 댓글 입력 정책을 정리했습니다.

1:1 채팅과 스트리밍 채팅에서 정리한 기준과 맞춰, 게시글 댓글과 녹화본 댓글도 모바일에서는 Enter를 IME 확정/줄바꿈 흐름으로 유지하고, 데스크톱에서만 Enter 전송 단축키로 동작하도록 보정했습니다.

## Changes

[⌨️ Input Policy]

- 게시글 댓글 textarea의 모바일 Enter 전송 방지
- 녹화본 댓글 textarea의 모바일 Enter 전송 방지
- 모바일 Enter는 IME 확정/줄바꿈 흐름으로 유지
- 데스크톱 Enter 전송, Shift+Enter 줄바꿈 기준 유지
- 명시 전송 버튼은 IME 조합 중에도 전송할 수 있도록 보정

[📝 Comments]

- 댓글 입력 컴포넌트 History/JSDoc을 현재 모바일/데스크톱 입력 정책 기준으로 정리

## Verification

- `npx tsc --noEmit`
- `npm run lint`