### PR TITLE
🚀 Chore : GitHub Actions CI/CD 검증 워크플로 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+# develop은 통합 브랜치, master는 Vercel production branch 기준으로 검증
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+  push:
+    branches:
+      - develop
+      - master
+
+permissions:
+  contents: read
+
+# 같은 ref에 새 실행이 생기면 이전 CI를 취소해 불필요한 runner 사용 방지
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Unit, Type, Lint, Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # build/type check가 참조하는 런타임 env를 placeholder로 채워 외부 서비스 호출 없이 검증
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+      COOKIE_PASSWORD: ci-cookie-password-at-least-32-chars
+      NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
+      CRON_SECRET: ci-cron-secret
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_PUBLIC_KEY: ci-supabase-public-key
+      KAKAO_CLIENT_ID: ci-kakao-client-id
+      KAKAO_CLIENT_SECRET: ci-kakao-client-secret
+      KAKAO_REDIRECT_URI: http://127.0.0.1:3000/kakao/callback
+      GITHUB_CLIENT_ID: ci-github-client-id
+      GITHUB_CLIENT_SECRET: ci-github-client-secret
+      COOLSMS_API_KEY: ci-coolsms-api-key
+      COOLSMS_API_SECRET: ci-coolsms-api-secret
+      COOLSMS_SENDER_NUMBER: "01000000000"
+      RESEND_API_KEY: re_ci_placeholder
+      NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_HASH: ci-cloudflare-account-hash
+      NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN: https://customer-fllme7un34f7981k.cloudflarestream.com
+      CLOUDFLARE_ACCOUNT_ID: ci-cloudflare-account-id
+      CLOUDFLARE_API_TOKEN: ci-cloudflare-api-token
+      CLOUDFLARE_WEBHOOK_SECRET: ci-cloudflare-webhook-secret
+      CLOUDFLARE_STREAM_WEBHOOK_SECRET: ci-cloudflare-stream-webhook-secret
+      NEXT_PUBLIC_VAPID_PUBLIC_KEY: ci-vapid-public-key
+      VAPID_PRIVATE_KEY: ci-vapid-private-key
+      NEXT_PUBLIC_KAKAO_MAP_API_KEY: ci-kakao-map-api-key
+    steps:
+      # GitHub runner에 저장소 코드를 내려받음
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # package-lock.json 기준 npm cache를 사용해 설치 시간 단축
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test
+
+      - name: Run type check
+        run: npx tsc --noEmit
+
+      - name: Run lint
+        run: npm run lint
+
+      # Vercel 배포 전에 production build 가능 여부를 CI에서 먼저 확인
+      - name: Run production build
+        run: npm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,122 @@
+name: E2E
+
+# develop 통합 PR과 master 릴리즈 PR에서 seed 기반 회귀 확인
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# E2E는 공유 테스트 DB에 seed/cleanup을 수행하므로 동시에 여러 실행을 허용하지 않음
+concurrency:
+  group: e2e-shared-db
+  cancel-in-progress: false
+
+jobs:
+  playwright:
+    name: Playwright Chromium
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # DB와 public runtime 값은 E2E 환경 재현을 위해 GitHub Secrets로 고정
+    env:
+      DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+      DIRECT_URL: ${{ secrets.E2E_DIRECT_URL }}
+      COOKIE_PASSWORD: ${{ secrets.E2E_COOKIE_PASSWORD }}
+      NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
+      CRON_SECRET: ci-cron-secret
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLIC_KEY: ${{ secrets.E2E_NEXT_PUBLIC_SUPABASE_PUBLIC_KEY }}
+      KAKAO_CLIENT_ID: ci-kakao-client-id
+      KAKAO_CLIENT_SECRET: ci-kakao-client-secret
+      KAKAO_REDIRECT_URI: http://127.0.0.1:3000/kakao/callback
+      GITHUB_CLIENT_ID: ci-github-client-id
+      GITHUB_CLIENT_SECRET: ci-github-client-secret
+      COOLSMS_API_KEY: ci-coolsms-api-key
+      COOLSMS_API_SECRET: ci-coolsms-api-secret
+      COOLSMS_SENDER_NUMBER: "01000000000"
+      RESEND_API_KEY: re_ci_placeholder
+      NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_HASH: ${{ secrets.E2E_NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_HASH }}
+      NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN: ${{ secrets.E2E_NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN }}
+      CLOUDFLARE_ACCOUNT_ID: ci-cloudflare-account-id
+      CLOUDFLARE_API_TOKEN: ci-cloudflare-api-token
+      CLOUDFLARE_WEBHOOK_SECRET: ci-cloudflare-webhook-secret
+      CLOUDFLARE_STREAM_WEBHOOK_SECRET: ci-cloudflare-stream-webhook-secret
+      NEXT_PUBLIC_VAPID_PUBLIC_KEY: ci-vapid-public-key
+      VAPID_PRIVATE_KEY: ci-vapid-private-key
+      NEXT_PUBLIC_KAKAO_MAP_API_KEY: ci-kakao-map-api-key
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # package-lock.json 기준 npm cache를 사용해 설치 시간 단축
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Validate E2E secrets
+        run: |
+          test -n "$DATABASE_URL"
+          test -n "$DIRECT_URL"
+          test -n "$COOKIE_PASSWORD"
+          test -n "$NEXT_PUBLIC_SUPABASE_URL"
+          test -n "$NEXT_PUBLIC_SUPABASE_PUBLIC_KEY"
+          test -n "$NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_HASH"
+          test -n "$NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright system dependencies
+        run: npm run install:e2e:deps
+
+      - name: Install Playwright browsers
+        run: npm run install:e2e
+
+      # test:e2e는 이미 떠 있는 dev server를 대상으로 하므로 백그라운드에서 Next 실행
+      - name: Start E2E server
+        run: |
+          npm run dev:e2e > /tmp/boardport-next.log 2>&1 &
+          echo $! > /tmp/boardport-next.pid
+
+      # 서버 준비 전에 Playwright가 시작되지 않도록 health check 대기
+      - name: Wait for E2E server
+        run: |
+          for attempt in {1..60}; do
+            if curl -fsS "$PLAYWRIGHT_BASE_URL" >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          cat /tmp/boardport-next.log
+          exit 1
+
+      - name: Seed E2E data
+        id: seed
+        run: npm run seed:e2e
+
+      - name: Run Playwright E2E
+        env:
+          E2E_SEEDED: "1"
+        run: npm run test:e2e -- --project=chromium
+
+      # 테스트 실패 시에도 seed가 성공했다면 테스트 데이터 정리
+      - name: Cleanup E2E data
+        if: always() && steps.seed.outcome == 'success'
+        run: npm run cleanup:e2e
+
+      # 실패 시 Playwright error context와 trace를 GitHub artifact로 보관
+      - name: Upload Playwright results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: test-results
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ BoardPort는 보드게임 거래, 커뮤니티, 채팅 약속, 라이브 방송,
 - [Project Overview](./docs/architecture/boardport-project-overview.md)
 - [State Management Modernization](./docs/architecture/case-study-state-management-modernization.md)
 - [UI/UX Design Standard](./docs/design/boardport-uiux-design-standard.md)
+- [CI/CD Workflows](./docs/operations/ci-cd-workflows.md)
 - [Product Modal Routing Troubleshooting](./docs/troubleshooting/troubleshooting-product-modal-routing.md)
 - [Appointment Atomic Transition Troubleshooting](./docs/troubleshooting/troubleshooting-appointment-atomic-transition.md)
 - [PWA Web Push Routing Troubleshooting](./docs/troubleshooting/troubleshooting-pwa-web-push-routing.md)

--- a/docs/operations/ci-cd-workflows.md
+++ b/docs/operations/ci-cd-workflows.md
@@ -1,0 +1,70 @@
+# CI/CD Workflows
+
+BoardPort의 전체 CI/CD 흐름은 GitHub Actions CI와 Vercel CD로 나뉩니다. GitHub Actions는 배포 전 코드 품질과 회귀 테스트를 확인하고, Vercel은 Git 연동을 기준으로 preview 또는 production 배포를 자동 수행합니다.
+
+브랜치 역할:
+
+- `develop`: 통합 및 릴리즈 준비 브랜치
+- `master`: 최종 릴리즈 브랜치이자 Vercel production branch
+
+## 1. 기본 CI
+
+`.github/workflows/ci.yml`은 `develop`/`master` 대상 PR과 `develop`/`master` push에서 실행합니다.
+
+검증 항목:
+
+- `npm run test`
+- `npx tsc --noEmit`
+- `npm run lint`
+- `npm run build`
+
+기본 CI는 외부 서비스 호출 없이 컴파일과 정적 검증을 수행하기 위해 placeholder 환경 변수를 사용합니다.
+
+## 2. Playwright E2E
+
+`.github/workflows/e2e.yml`은 `develop`/`master` 대상 PR과 수동 실행에서 Playwright Chromium E2E를 실행합니다.
+
+실행 순서:
+
+- 의존성 설치
+- Playwright Linux 의존성 설치
+- Playwright Chromium 설치
+- `npm run dev:e2e` 서버 실행
+- `npm run seed:e2e`
+- `E2E_SEEDED=1 npm run test:e2e -- --project=chromium`
+- `npm run cleanup:e2e`
+
+E2E는 공유 테스트 DB를 사용하므로 workflow concurrency를 `e2e-shared-db`로 고정해 동시에 여러 E2E가 seed/cleanup을 수행하지 않도록 제한합니다.
+
+## 3. E2E Secrets
+
+GitHub Actions에서 E2E를 실행하려면 아래 secrets를 설정합니다.
+
+| Secret | 설명 |
+| ------ | ---- |
+| `E2E_DATABASE_URL` | E2E 앱 런타임용 DB 연결 문자열 |
+| `E2E_DIRECT_URL` | E2E seed/cleanup용 직접 DB 연결 문자열 |
+| `E2E_COOKIE_PASSWORD` | iron-session 쿠키 암호화 키 |
+| `E2E_NEXT_PUBLIC_SUPABASE_URL` | E2E Supabase URL |
+| `E2E_NEXT_PUBLIC_SUPABASE_PUBLIC_KEY` | E2E Supabase anon key |
+| `E2E_NEXT_PUBLIC_CLOUDFLARE_ACCOUNT_HASH` | E2E 이미지 delivery hash |
+| `E2E_NEXT_PUBLIC_CLOUDFLARE_STREAM_DOMAIN` | E2E Stream/VOD 재생 도메인 |
+
+## 4. CD
+
+Vercel은 GitHub branch/PR 이벤트를 받아 preview 또는 production 배포를 수행합니다. `master`가 production branch이므로 `master`로 merge 또는 push된 변경은 Vercel production deployment 대상입니다.
+
+GitHub Actions에서 별도 deploy job을 두지 않는 이유:
+
+- Vercel Git 연동이 이미 배포 lifecycle을 관리
+- 배포 토큰과 프로젝트 ID를 GitHub Actions에 중복 보관하지 않아도 됨
+- CI 실패 시 PR에서 병합을 보류하고, 병합 후 Vercel 배포는 기존 흐름을 유지
+
+`master` production 배포를 CI 통과 후에만 허용하려면 GitHub branch protection 또는 ruleset에서 필수 check를 설정합니다. 기본 권장 check:
+
+- `Unit, Type, Lint, Build`
+- `Playwright Chromium`
+
+Vercel Deployment Checks까지 사용해 production promotion을 제어할 경우, Vercel이 확인하는 commit SHA에 필요한 GitHub check가 실제로 생성되는지 함께 확인합니다.
+
+운영 배포 검증은 Vercel 배포 결과와 production smoke QA를 기준으로 확인합니다.


### PR DESCRIPTION
## Summary

GitHub Actions 기반 CI 검증과 Playwright E2E workflow를 추가했습니다.

BoardPort의 배포는 기존 Vercel Git 연동을 유지하고, GitHub Actions는 `develop`/`master` 병합 전 품질 게이트 역할을 맡도록 정리했습니다. `master`는 최종 릴리즈 및 Vercel production branch 기준으로 문서화했습니다.

## Changes

[🔁 CI/CD]

- `develop`/`master` PR 및 push 대상 기본 CI workflow 추가
- `develop`/`master` PR 및 수동 실행 대상 Playwright E2E workflow 추가
- Vercel Git 연동 CD와 `master` production branch 기준 문서화

[✅ Quality Gate]

- `npm run test`, `npx tsc --noEmit`, `npm run lint`, `npm run build` 검증 자동화
- E2E seed/test/cleanup 순서와 공유 DB concurrency 적용
- E2E 실행에 필요한 GitHub Actions secrets 검증 추가

[📚 Docs]

- README에 CI/CD 운영 문서 링크 추가
- GitHub Actions CI와 Vercel CD 역할 분리 설명
- branch protection required checks와 Vercel production deployment 기준 정리

## Verification

- `npm run build`
- `npm run test`
- `npx tsc --noEmit`
- `npm run lint`
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml`
- `git diff --cached --check`