### PR TITLE
🚀 Chore : CI VAPID placeholder 키 형식 보정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,11 @@ jobs:
     steps:
       # GitHub runner에 저장소 코드를 내려받음
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # package-lock.json 기준 npm cache를 사용해 설치 시간 단축
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
       CLOUDFLARE_API_TOKEN: ci-cloudflare-api-token
       CLOUDFLARE_WEBHOOK_SECRET: ci-cloudflare-webhook-secret
       CLOUDFLARE_STREAM_WEBHOOK_SECRET: ci-cloudflare-stream-webhook-secret
-      NEXT_PUBLIC_VAPID_PUBLIC_KEY: ci-vapid-public-key
-      VAPID_PRIVATE_KEY: ci-vapid-private-key
+      NEXT_PUBLIC_VAPID_PUBLIC_KEY: BDQxa9WYcbzWsT2ehj226zkdh9l4lOFuMIQIGalUmPoZVOdvQIV9-bDDHbxPeO5mdi681SSOLtj-jFUZwju9e-s
+      VAPID_PRIVATE_KEY: 5PzSaFz9DSLMyg1yptrbwN6gzpYv3zmukFvvrU-hJ9g
       NEXT_PUBLIC_KAKAO_MAP_API_KEY: ci-kakao-map-api-key
     steps:
       # GitHub runner에 저장소 코드를 내려받음

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,8 +46,8 @@ jobs:
       CLOUDFLARE_API_TOKEN: ci-cloudflare-api-token
       CLOUDFLARE_WEBHOOK_SECRET: ci-cloudflare-webhook-secret
       CLOUDFLARE_STREAM_WEBHOOK_SECRET: ci-cloudflare-stream-webhook-secret
-      NEXT_PUBLIC_VAPID_PUBLIC_KEY: ci-vapid-public-key
-      VAPID_PRIVATE_KEY: ci-vapid-private-key
+      NEXT_PUBLIC_VAPID_PUBLIC_KEY: BDQxa9WYcbzWsT2ehj226zkdh9l4lOFuMIQIGalUmPoZVOdvQIV9-bDDHbxPeO5mdi681SSOLtj-jFUZwju9e-s
+      VAPID_PRIVATE_KEY: 5PzSaFz9DSLMyg1yptrbwN6gzpYv3zmukFvvrU-hJ9g
       NEXT_PUBLIC_KAKAO_MAP_API_KEY: ci-kakao-map-api-key
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,11 +51,11 @@ jobs:
       NEXT_PUBLIC_KAKAO_MAP_API_KEY: ci-kakao-map-api-key
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # package-lock.json 기준 npm cache를 사용해 설치 시간 단축
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -115,7 +115,7 @@ jobs:
       # 실패 시 Playwright error context와 trace를 GitHub artifact로 보관
       - name: Upload Playwright results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-results
           path: test-results


### PR DESCRIPTION
[🔐 CI Env]

GitHub Actions CI workflow의 VAPID placeholder를 web-push 형식 검증 통과용 더미 키쌍으로 교체

Next production build 중 setVapidDetails 키 형식 오류로 /api/chats/rooms page data 수집이 실패하는 흐름 보정

[🎭 E2E Env]

Playwright E2E workflow도 동일한 VAPID 더미 키쌍을 사용하도록 정리

운영 VAPID 키를 하드코딩하지 않고 CI/E2E 전용 비운영 값만 사용

[✅ Verification]

actionlint 기준 workflow 문법 검증

git diff --check 기준 공백 오류 확인

npm run build 기준 production build 통과 확인