### PR TITLE
🚑 Fix : 릴리즈 QA 중 발견된 캐시 정합성 보정

### DIFF
--- a/app/(app)/streams/[id]/recording/page.tsx
+++ b/app/(app)/streams/[id]/recording/page.tsx
@@ -35,6 +35,7 @@
  * 2026.03.22  임도헌   Modified  녹화본 댓글 섹션 상단 절개선을 제거해 메타 정보 아래 흐름을 단순화
  * 2026.03.25  임도헌   Modified  owner 삭제 액션을 본문 버튼 대신 상단 관리 메뉴로 이동해 시청 흐름 우선순위 정리
  * 2026.04.12  임도헌   Moved     파일 경로를 app/streams/[id]/recording/page.tsx 에서 app/(app)/streams/[id]/recording/page.tsx 로 변경 (라우트 그룹 개편)
+ * 2026.06.07  임도헌   Modified  녹화본 좋아요 캐시를 시청자별로 분리하기 위해 viewerId 전달
 */
 export const dynamic = "force-dynamic";
 
@@ -178,6 +179,7 @@ export default async function RecordingVodPage({
         <RecordingDetail
           broadcast={base.broadcast}
           vodId={vodId}
+          viewerId={viewerId}
           uid={base.uid}
           duration={durationSec}
           created={created}
@@ -202,4 +204,3 @@ export default async function RecordingVodPage({
     </div>
   );
 }
-

--- a/components/global/TabBar.tsx
+++ b/components/global/TabBar.tsx
@@ -29,6 +29,7 @@
  * 2026.05.17  임도헌   Modified  rooms_refresh 구독을 ChatRoomsRealtimeBridge로 이동해 탭바는 query 표시만 담당
  * 2026.05.18  임도헌   Modified  서버 초기 미읽음 수를 query cache에 명시 동기화해 탭 전환 후 뱃지 잔상 보정
  * 2026.05.18  임도헌   Modified  미읽음 수 클라이언트 재검증을 Server Action 대신 전용 API 조회로 전환
+ * 2026.06.07  임도헌   Modified  오래된 서버 초기값이 클라이언트 미읽음 차감을 되돌리지 않도록 보정
  */
 "use client";
 
@@ -108,11 +109,17 @@ export default function TabBar({
   useEffect(() => {
     if (!userId) return;
 
-    // 라우트 전환 시 서버 레이아웃이 계산한 최신 미읽음 수를 기존 클라이언트 캐시에 반영
-    queryClient.setQueryData(
-      queryKeys.chats.unreadCount(userId),
-      initialUnreadChatCount
-    );
+    const unreadQueryKey = queryKeys.chats.unreadCount(userId);
+    const cachedUnreadCount =
+      queryClient.getQueryData<number>(unreadQueryKey);
+
+    // 채팅방 진입 후 클라이언트가 줄인 미읽음 수를 오래된 서버 초기값으로 되살리지 않음
+    if (
+      cachedUnreadCount === undefined ||
+      initialUnreadChatCount < cachedUnreadCount
+    ) {
+      queryClient.setQueryData(unreadQueryKey, initialUnreadChatCount);
+    }
   }, [initialUnreadChatCount, queryClient, userId]);
 
   const tabs = [

--- a/features/chat/components/ChatMessagesList.tsx
+++ b/features/chat/components/ChatMessagesList.tsx
@@ -58,6 +58,7 @@
  * 2026.04.22  임도헌   Modified  메시지 삭제 확인을 브라우저 confirm 대신 공용 ConfirmDialog로 통일
  * 2026.05.18  임도헌   Modified  채팅방 진입 직후 목록/TabBar 미읽음 캐시를 읽음 상태와 즉시 동기화
  * 2026.05.28  임도헌   Modified  입력바와 메시지 리스트 사이의 불필요한 하단 여백 제거
+ * 2026.06.07  임도헌   Modified  채팅방 확인만으로도 TabBar 미읽음 수가 즉시 차감되도록 보강
  */
 "use client";
 
@@ -208,16 +209,32 @@ export default function ChatMessagesList({
 
   useEffect(() => {
     // 서버 컴포넌트에서 이미 읽음 처리한 결과를 클라이언트 Query Cache에도 즉시 반영
+    let clearedUnreadCount = 0;
+
     queryClient.setQueryData(
       queryKeys.chats.list(user.id),
       (oldRooms: ChatRoom[] | undefined) => {
         if (!oldRooms) return oldRooms;
 
+        clearedUnreadCount =
+          oldRooms.find((room) => room.id === productChatRoomId)
+            ?.unreadCount ?? 0;
+
         return oldRooms.map((room) =>
-          room.id === productChatRoomId ? { ...room, unreadCount: 0 } : room
+          room.id === productChatRoomId
+            ? { ...room, unreadCount: 0 }
+            : room
         );
       }
     );
+
+    if (clearedUnreadCount > 0) {
+      queryClient.setQueryData<number>(
+        queryKeys.chats.unreadCount(user.id),
+        (current) => Math.max((current ?? 0) - clearedUnreadCount, 0)
+      );
+    }
+
     void queryClient.refetchQueries({
       queryKey: queryKeys.chats.unreadCount(user.id),
       type: "all",

--- a/features/stream/components/recording/recordingDetail/RecordingLikeButton.tsx
+++ b/features/stream/components/recording/recordingDetail/RecordingLikeButton.tsx
@@ -15,6 +15,7 @@
  * 2026.04.17  임도헌   Modified  녹화본 상세 좋아요 버튼의 낙관 업데이트와 접근성 이름 책임 설명 보강
  * 2026.05.18  임도헌   Modified  녹화본 상세 좋아요 변경 시 메인/채널 다시보기 목록 캐시 동기화 추가
  * 2026.05.26  임도헌   Modified  initialData 기반 likeStatus query에 local queryFn을 부여하고 목록 캐시만 재검증
+ * 2026.06.07  임도헌   Modified  계정 전환 시 이전 사용자의 VOD 좋아요 캐시가 재사용되지 않도록 viewer scope 추가
  */
 
 "use client";
@@ -45,6 +46,7 @@ interface RecordingLikeButtonProps {
   isLiked: boolean;
   likeCount: number;
   vodId: number;
+  viewerId: number;
 }
 
 /**
@@ -62,9 +64,10 @@ export default function RecordingLikeButton({
   isLiked: initialIsLiked,
   likeCount: initialLikeCount,
   vodId,
+  viewerId,
 }: RecordingLikeButtonProps) {
   const queryClient = useQueryClient();
-  const queryKey = queryKeys.streams.likeStatus(vodId);
+  const queryKey = queryKeys.streams.likeStatus(vodId, viewerId);
   const initialLikeStatus = {
     isLiked: initialIsLiked,
     likeCount: initialLikeCount,

--- a/features/stream/components/recording/recordingDetail/index.tsx
+++ b/features/stream/components/recording/recordingDetail/index.tsx
@@ -18,6 +18,7 @@
  * 2026.05.05  임도헌   Modified  방송 상세과 같은 보드게임 카드형 표시로 통일
  * 2026.05.12  임도헌   Modified  녹화 상세 본문에 방송 카테고리/태그 노출 추가
  * 2026.05.18  임도헌   Modified  RecordingMeta가 VodAsset 기준 댓글 수 캐시를 갱신할 수 있도록 vodId 전달
+ * 2026.06.07  임도헌   Modified  녹화본 좋아요 상태를 시청자별 캐시로 분리하기 위해 viewerId 전달
  * ===============================================================================================
  * RecordingDetail (녹화본 상세) 정보를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * - RecordingTitle.tsx      : 녹화본 제목
@@ -51,6 +52,7 @@ interface RecordingDetailProps {
 
   /** VodAsset 식별/표시용 */
   vodId: number; // 좋아요/댓글/조회수는 VodAsset 기준
+  viewerId: number;
   uid: string; // VodAsset.provider_asset_id
   duration: number;
   created: Date;
@@ -75,6 +77,7 @@ interface RecordingDetailProps {
 export default function RecordingDetail({
   broadcast,
   vodId,
+  viewerId,
   uid,
   duration,
   created,
@@ -106,6 +109,7 @@ export default function RecordingDetail({
           LikeButtonComponent={
             <RecordingLikeButton
               vodId={vodId} // streamId → vodId 로 전환
+              viewerId={viewerId}
               isLiked={isLiked}
               likeCount={likeCount}
             />

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -30,6 +30,7 @@
  * 2026.05.12  임도헌   Modified  채팅 미읽음 수 뱃지용 query key 추가
  * 2026.05.15  임도헌   Modified  유저 채널 다시보기 무한스크롤용 query key 추가
  * 2026.05.17  임도헌   Modified  query key 필터 객체 타입을 QueryKeyParams로 명시
+ * 2026.06.07  임도헌   Modified  VOD 좋아요 상태 query key를 시청자별로 분리
  */
 
 import type { QueryKeyParams } from "@/lib/types";
@@ -107,8 +108,14 @@ export const queryKeys = {
       [...queryKeys.streams.all, "vodComments", vodId] as const,
     recordingStats: (vodId: number) =>
       [...queryKeys.streams.all, "vod", vodId, "stats"] as const,
-    likeStatus: (vodId: number) =>
-      [...queryKeys.streams.all, "vod", vodId, "likeStatus"] as const,
+    likeStatus: (vodId: number, viewerId?: number | null) =>
+      [
+        ...queryKeys.streams.all,
+        "vod",
+        vodId,
+        "likeStatus",
+        viewerId ?? "guest",
+      ] as const,
   },
 
   // 6. 유저(User) 도메인


### PR DESCRIPTION
## Summary

릴리즈 QA 중 확인된 채팅 미읽음 뱃지와 VOD 좋아요 캐시 정합성 문제를 보정했습니다.

채팅방에 진입해 미읽음 상태가 해소된 뒤에도 신호 탭 뱃지가 오래된 서버 초기값으로 다시 살아나는 흐름을 막고, 녹화본 상세 좋아요 상태가 계정 전환 직후 이전 사용자의 캐시를 재사용하지 않도록 query key를 시청자 기준으로 분리했습니다.

## Changes

[💬 Chat Badge]

- 채팅방 진입 즉시 신호 탭의 미읽음 수가 차감되도록 로직 보정
- 서버의 오래된 초기 데이터가 클라이언트의 최신 미읽음 카운트를 덮어쓰는 현상 방지

[🎥 VOD Like]

- 녹화본 좋아요 상태 query key를 시청자별로 분리
- 녹화본 상세 페이지에서 viewerId를 좋아요 버튼까지 전달

## Verification

- `npx tsc --noEmit`
- `npm run lint`
- `npm run test`
- `git diff --check`