### PR TITLE
🚑 Fix : 채팅 왕복 후 상품 모달 닫기 라우팅 보정

### DIFF
--- a/docs/troubleshooting/troubleshooting-navigation-refresh-flag.md
+++ b/docs/troubleshooting/troubleshooting-navigation-refresh-flag.md
@@ -93,6 +93,7 @@ BoardPort에서는 `목록 -> 상세 -> 수정 -> 저장/취소/삭제` 흐름�
 - `history back` 대상이 없는 직접 진입/새로고침 문맥만 `/products?openProductId={id}&returnTo=...` fallback 릴레이 사용
 - 모달 상세는 `product-modal-refresh:{id}` 플래그를 1회 소비하고 `router.refresh()`
 - 목록 릴레이는 필요할 때만 중간 URL을 `returnTo`로 먼저 정리한 뒤 인터셉트 상세를 다시 `push`
+- X/배경/ESC 닫기는 편집 복귀와 분리해 `returnTo` 기반 `router.replace()`로 처리
 
 이유:
 
@@ -100,6 +101,7 @@ BoardPort에서는 `목록 -> 상세 -> 수정 -> 저장/취소/삭제` 흐름�
 - 초기에 `replace + reopen relay`를 기본 전략으로 사용했지만, 이 방식은 목록/상세 엔트리 중복을 만들기 쉬웠습니다.
 - 현재는 `back` 기반 복귀를 기본 정책으로 두고, 브라우저 히스토리가 없는 경우만 릴레이를 fallback으로 사용합니다.
 - 모달 수정의 취소는 풀페이지 상세 취소와 달리 수정 화면 엔트리를 상세 모달 엔트리로 되돌리는 동작이므로 `back`이 더 자연스럽습니다.
+- 반면 단순 닫기는 채팅 왕복 후 이전 채팅 히스토리를 다시 탈 수 있어 명시적인 `returnTo` 복귀가 더 안전합니다.
 
 관련 파일:
 

--- a/docs/troubleshooting/troubleshooting-product-modal-routing.md
+++ b/docs/troubleshooting/troubleshooting-product-modal-routing.md
@@ -11,7 +11,7 @@ BoardPort의 제품 상세는 동일한 URL(`/products/view/[id]`)을 두 가지
 
 **Before:** 모달에서 수정 후 저장하면 404가 발생하거나, 뒤로가기에서 목록/상세 히스토리가 중복되는 문제가 반복됐습니다.
 
-**After:** `back 우선 + relay fallback` 정책으로 기본 흐름의 히스토리 중복을 줄이고, 모달/상세 문맥별 복귀 기준을 분리했습니다.
+**After:** 수정 복귀는 `back 우선 + relay fallback`으로 유지하고, 모달 닫기는 `returnTo replace`로 분리해 채팅 왕복 후 이전 히스토리를 다시 타는 문제를 줄였습니다.
 
 이 구조에서 `상세 -> 수정 -> 저장/취소/삭제 -> 복귀` 흐름을 처리하는 과정에서 다음 문제가 반복됐습니다.
 
@@ -36,6 +36,7 @@ BoardPort의 제품 상세는 동일한 URL(`/products/view/[id]`)을 두 가지
 - 모달이 닫히지 않음
 - 뒤로가기를 여러 번 해야 목록으로 복귀
 - 수정 후 복귀 위치가 모달/페이지 문맥에 따라 섞임
+- 상품 모달에서 채팅으로 이동한 뒤 브라우저 뒤로가기로 돌아오고, 다시 X로 닫으면 제품 목록이 스켈레톤 로딩 상태로 남음
 
 ### 1.3 히스토리 중복
 
@@ -104,7 +105,17 @@ App Router는 soft navigation 상태를 메모리에 유지합니다.
 
 으로 정리했습니다.
 
-### 전략 3. `navigationRefreshFlag`는 복귀 후 1회 최신화만 담당
+### 전략 3. 모달 닫기는 `returnTo replace`로 고정
+
+모달 수정 복귀와 달리 X/배경/ESC 닫기는 `router.back()`을 사용하지 않습니다.
+
+- 상품 모달에서 채팅으로 이동하면 채팅 상세가 히스토리에 추가됨
+- 채팅에서 브라우저 뒤로가기로 모달에 복귀한 뒤 X를 누르면, 단순 목록 닫기가 아니라 채팅/모달 히스토리를 다시 건드릴 수 있음
+- 이 흐름에서 제품 목록이 스켈레톤 로딩 상태로 남는 문제가 재현됨
+
+따라서 닫기는 카드가 넘긴 `returnTo`를 정규화한 뒤 `router.replace(returnTo)`로 처리합니다.
+
+### 전략 4. `navigationRefreshFlag`는 복귀 후 1회 최신화만 담당
 
 `product-modal-refresh:{id}`는:
 
@@ -124,13 +135,14 @@ App Router는 soft navigation 상태를 메모리에 유지합니다.
 
 현재 정책:
 
-- 닫기 시 기존 목록/모달 히스토리 문맥이 확인되면 `router.back()` 우선
-- back 대상이 없을 때만 `router.replace(returnTo)`
+- X/배경/ESC 닫기는 모두 정규화된 `returnTo`로 `router.replace(returnTo)`
+- 공통 `CloseButton`의 `preferHistoryBack`은 상품 모달 닫기에서 사용하지 않음
 
 의미:
 
-- 기존 목록/모달 문맥이 있으면 재사용
-- 직접 진입/새로고침 같은 경우만 안전 경로 fallback
+- 상품 목록의 필터/검색/스크롤 문맥은 `returnTo`로 유지
+- 채팅 왕복 후 X 닫기가 이전 채팅 히스토리를 다시 타지 않도록 차단
+- 모달 편집 저장/취소의 `back` 우선 정책과 닫기 정책을 분리
 
 ### 4.2 컨텍스트 명시화
 
@@ -212,6 +224,7 @@ App Router는 soft navigation 상태를 메모리에 유지합니다.
 | --- | --- |
 | 저장 후 404 | 라우터 트리 불일치 원인 파악 후 복귀 경로 정리 |
 | 히스토리 중복 순환 | `back 우선` 정책으로 기본 목록/모달 엔트리 중복 완화 |
+| 채팅 왕복 후 목록 무한 로딩 | 모달 닫기를 `returnTo replace`로 고정해 이전 채팅 히스토리 재진입 차단 |
 | stale 데이터 복귀 | `navigationRefreshFlag` 1회 소비로 복귀 직후 최신화 |
 | 모달 직접 진입/새로고침 문맥 | `ProductModalReopenRelay`가 fallback 재오픈만 담당 |
 

--- a/features/product/components/productDetail/modal/ProductDetailModalContainer.tsx
+++ b/features/product/components/productDetail/modal/ProductDetailModalContainer.tsx
@@ -27,6 +27,7 @@
  * 2026.04.24  임도헌   Modified  navigation refresh helper로 모달 refresh flag 소비와 back 가능 여부 판별을 정리
  * 2026.05.30  임도헌   Modified  모달 상세 상단 닫기/액션바 높이를 모바일 서브 헤더 기준으로 정리
  * 2026.06.01  임도헌   Modified  제품 모달 닫기 버튼의 배경과 hover 톤 조정
+ * 2026.06.12  임도헌   Modified  채팅 왕복 후 모달 닫기 시 returnTo replace로 이전 히스토리 재진입 방지
  */
 "use client";
 
@@ -41,7 +42,6 @@ import { lockBodyScroll, unlockBodyScroll } from "@/lib/bodyScrollLock";
 import type { ProductDetailType } from "@/features/product/types";
 import { cn } from "@/lib/utils";
 import {
-  canUseBrowserBack,
   consumeNavigationRefresh,
   NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
@@ -58,7 +58,7 @@ interface ProductDetailProps {
  * - 배경 스크롤 잠금, 포커스 트랩, ESC 닫기 등 모달 필수 기능을 제공
  * - 닫기 시 `returnTo` 쿼리 파라미터를 사용하여 이전 목록 상태를 유지하며 복귀
  * - 모달 편집은 `flow=modal-edit`로 진입하고 저장 후 기존 모달 히스토리로 back 복귀를 우선 사용
- * - history back 대상이 없을 때만 ProductModalReopenRelay fallback으로 같은 모달 상세를 다시 연다
+ * - 닫기는 히스토리 상태 대신 returnTo replace로 처리해 채팅 왕복 후 이전 히스토리 재진입을 방지한다
  */
 export default function ProductDetailModalContainer(props: ProductDetailProps) {
   const router = useRouter();
@@ -95,14 +95,9 @@ export default function ProductDetailModalContainer(props: ProductDetailProps) {
     router.refresh();
   }, [props.product.id, router]);
 
-  // 모달 닫기와 편집 진입에 재사용하는 복귀 경로 정제
+  // 모달 닫기 시 히스토리 상태 대신 사용할 안전한 목록 복귀 경로
   const returnTo = sanitizeCallbackUrl(sp.get("returnTo") ?? "/products");
   const handleOverlayClick = () => {
-    if (canUseBrowserBack()) {
-      router.back();
-      return;
-    }
-
     router.replace(returnTo);
   };
 
@@ -130,7 +125,6 @@ export default function ProductDetailModalContainer(props: ProductDetailProps) {
           <CloseButton
             fallbackHref="/products"
             returnTo={returnTo}
-            preferHistoryBack
             className="bg-surface-dim/45 text-muted/80 hover:bg-surface-dim hover:text-primary active:bg-border/50 dark:bg-surface-dim/35 dark:hover:bg-surface-dim/70"
           />
           <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary

- 상품 상세 모달 닫기 동작을 `router.back()` 우선에서 `returnTo` 기반 `router.replace()`로 변경했습니다.
- 상품 모달에서 채팅방으로 이동한 뒤 브라우저 뒤로가기로 모달에 복귀하고, X/배경/ESC로 닫을 때 이전 채팅 히스토리를 다시 타는 문제를 방지했습니다.
- 상품 모달 라우팅 및 navigation refresh 관련 troubleshooting 문서를 현재 정책에 맞게 업데이트했습니다.

## Changes

- `ProductDetailModalContainer`
  - overlay close: `router.replace(returnTo)`로 고정
  - `CloseButton`에서 `preferHistoryBack` 제거
  - 관련 히스토리/주석 업데이트

- Docs
  - `troubleshooting-product-modal-routing.md`
  - `troubleshooting-navigation-refresh-flag.md`

## Verification

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`