### PR TITLE
🚑 Fix : 무한스크롤 sentinel 관찰 기준 보정

### DIFF
--- a/features/post/components/PostList.tsx
+++ b/features/post/components/PostList.tsx
@@ -90,7 +90,7 @@ export default function PostList({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible, // 탭이 백그라운드면 로딩 중단
-    rootMargin: "1000px 0px 0px 0px", // 조기 프리패치 여유
+    rootMargin: "0px 0px 1000px 0px", // 하단 조기 프리패치 여유
     threshold: 0.01,
   });
 

--- a/features/post/components/postComment/PostCommentList.tsx
+++ b/features/post/components/postComment/PostCommentList.tsx
@@ -67,7 +67,7 @@ export default function PostCommentList({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible,
-    rootMargin: "400px 0px 0px 0px",
+    rootMargin: "0px 0px 400px 0px",
     threshold: 0.1,
   });
 

--- a/features/product/components/MyLikesList.tsx
+++ b/features/product/components/MyLikesList.tsx
@@ -60,7 +60,7 @@ export default function MyLikesList({ userId }: { userId: number }) {
     isLoading: liked.isFetchingNextPage,
     onLoadMore: liked.loadMore,
     enabled: isVisible,
-    rootMargin: "600px",
+    rootMargin: "0px 0px 600px 0px",
     threshold: 0.1,
   });
 

--- a/features/product/components/MyPurchasesList.tsx
+++ b/features/product/components/MyPurchasesList.tsx
@@ -66,7 +66,7 @@ export default function MyPurchasesList({ userId }: MyPurchasesListProps) {
     isLoading: purchased.isFetchingNextPage, // 하단 스크롤 중복 로드 방지
     onLoadMore: purchased.loadMore,
     enabled: isVisible,
-    rootMargin: "600px", // 사용자 경험 향상을 위한 조기 로딩 여유 영역
+    rootMargin: "0px 0px 600px 0px", // 하단 조기 로딩 여유 영역
     threshold: 0.1,
   });
 

--- a/features/product/components/MySalesProductList.tsx
+++ b/features/product/components/MySalesProductList.tsx
@@ -334,7 +334,7 @@ function SalesTabContent({
     isLoading: current.isFetchingNextPage,
     onLoadMore: current.loadMore,
     enabled: isVisible,
-    rootMargin: "1000px 0px 0px 0px",
+    rootMargin: "0px 0px 1000px 0px",
     threshold: 0.01,
   });
 

--- a/features/product/components/ProductList.tsx
+++ b/features/product/components/ProductList.tsx
@@ -110,7 +110,7 @@ export default function ProductList({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible,
-    rootMargin: "1400px 0px 0px 0px", // 조기 프리패치 여유 마진
+    rootMargin: "0px 0px 1400px 0px", // 하단 조기 프리패치 여유 마진
     threshold: 0.01,
   });
 

--- a/features/stream/components/RecordingList.tsx
+++ b/features/stream/components/RecordingList.tsx
@@ -71,7 +71,7 @@ export default function RecordingList({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible,
-    rootMargin: "1200px 0px 0px 0px",
+    rootMargin: "0px 0px 1200px 0px",
     threshold: 0.01,
   });
 

--- a/features/stream/components/StreamList.tsx
+++ b/features/stream/components/StreamList.tsx
@@ -81,7 +81,7 @@ export default function StreamList({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible,
-    rootMargin: "1200px 0px 0px 0px", // 사용자 경험 향상을 위한 조기 프리패치 여유 공간
+    rootMargin: "0px 0px 1200px 0px", // 하단 조기 프리패치 여유 공간
     threshold: 0.01,
   });
 

--- a/features/stream/components/channel/RecordingGrid.tsx
+++ b/features/stream/components/channel/RecordingGrid.tsx
@@ -88,7 +88,7 @@ export default function RecordingGrid({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible,
-    rootMargin: "1000px 0px 0px 0px",
+    rootMargin: "0px 0px 1000px 0px",
     threshold: 0.01,
   });
 

--- a/features/stream/components/recording/recordingComment/RecordingCommentList.tsx
+++ b/features/stream/components/recording/recordingComment/RecordingCommentList.tsx
@@ -54,7 +54,7 @@ export default function RecordingCommentList({
     isLoading: isFetchingNextPage,
     onLoadMore: loadMore,
     enabled: isVisible,
-    rootMargin: "400px 0px 0px 0px",
+    rootMargin: "0px 0px 400px 0px",
     threshold: 0.1,
   });
 

--- a/features/user/components/follow/FollowListModal.tsx
+++ b/features/user/components/follow/FollowListModal.tsx
@@ -143,7 +143,7 @@ export default function FollowListModal({
     onLoadMore: onLoadMore,
     enabled: isOpen && hasMore && !isMoreError,
     rootRef: scrollAreaRef,
-    rootMargin: "400px 0px 0px 0px",
+    rootMargin: "0px 0px 400px 0px",
     threshold: 0.1,
   });
 

--- a/features/user/components/profile/ReviewsList.tsx
+++ b/features/user/components/profile/ReviewsList.tsx
@@ -59,7 +59,7 @@ export default function ReviewsList({
     enabled: isVisible,
     rootRef: scrollParentRef, // 모달 등 특정 스크롤 컨테이너를 기준으로 동작하도록 설정
     threshold: 0.1,
-    rootMargin: "200px", // 조기 로딩을 위한 여유 마진 확보
+    rootMargin: "0px 0px 200px 0px", // 하단 조기 로딩 여유 마진
   });
 
   // 데이터가 없을 경우 표시되는 Empty State

--- a/features/user/components/profile/UserProfile.tsx
+++ b/features/user/components/profile/UserProfile.tsx
@@ -495,7 +495,7 @@ function SalesTabContent({
     isLoading: current.isFetchingNextPage,
     onLoadMore: current.loadMore,
     enabled: isVisible,
-    rootMargin: "1000px 0px 0px 0px",
+    rootMargin: "0px 0px 1000px 0px",
     threshold: 0.01,
   });
 

--- a/hooks/useInfiniteScroll.ts
+++ b/hooks/useInfiniteScroll.ts
@@ -12,6 +12,7 @@
  * 2026.02.02  임도헌   Modified  주석 보강
  * 2026.02.28  임도헌   Modified  TanStack Query(fetchNextPage) 연동을 위해 onLoadMore 반환 타입(unknown) 확장
  * 2026.03.05  임도헌   Modified  주석 최신화
+ * 2026.06.13  임도헌   Modified  hasMore/isLoading 변경 시 sentinel 재관찰되도록 effect 의존성 보강
  */
 
 "use client";
@@ -39,7 +40,7 @@ interface UseInfiniteScrollProps {
   rootRef?: React.RefObject<Element | null>;
   /**
    * 관찰 영역 확장 범위 (미리 로딩하기 위함)
-   * @default "1200px 0px 0px 0px"
+   * @default "0px 0px 1200px 0px"
    */
   rootMargin?: string;
   /**
@@ -66,7 +67,7 @@ export function useInfiniteScroll({
   onLoadMore,
   enabled = true,
   rootRef,
-  rootMargin = "1200px 0px 0px 0px",
+  rootMargin = "0px 0px 1200px 0px",
   threshold = 0.01,
 }: UseInfiniteScrollProps): void {
   const hasMoreRef = useRef(hasMore);
@@ -88,7 +89,7 @@ export function useInfiniteScroll({
   }, [onLoadMore]);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !hasMore || isLoading) return;
 
     const el = triggerRef.current;
     if (!el) return;
@@ -118,7 +119,15 @@ export function useInfiniteScroll({
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [enabled, triggerRef, rootRef, rootMargin, threshold]);
+  }, [
+    enabled,
+    hasMore,
+    isLoading,
+    triggerRef,
+    rootRef,
+    rootMargin,
+    threshold,
+  ]);
 }
 
 export default useInfiniteScroll;


### PR DESCRIPTION
## Summary

- 공통 `useInfiniteScroll` 훅이 `hasMore` / `isLoading` 변경 시 sentinel을 다시 관찰하도록 보강했습니다.
- 하단 sentinel 기반 무한스크롤 목록들의 `rootMargin`을 bottom 기준으로 정리했습니다.
- 상품 목록에서 지역 범위를 변경한 뒤 하단에 머문 상태로 무한스크롤이 멈추는 문제를 방지했습니다.

## Background

상품 목록에서 `동 단위`처럼 결과가 적은 범위로 하단까지 이동한 뒤, `전국 전체보기`로 범위를 넓히면 새 목록의 sentinel이 이미 viewport 근처에 있는 상태가 됩니다.

기존 훅은 observer가 최초 교차 이벤트를 놓치거나, 로딩 상태 변화 직후 같은 위치에서 다시 교차 이벤트가 발생하지 않으면 다음 페이지 요청을 트리거하지 못할 수 있었습니다.

또한 하단 무한스크롤 목록의 `rootMargin`이 `1400px 0px 0px 0px`처럼 top 기준으로 잡힌 곳들이 있어, 실제 의도였던 하단 조기 로딩과 맞지 않았습니다.

## Changes

- `hooks/useInfiniteScroll.ts`
  - `hasMore` 변경 시 observer 재등록
  - `isLoading` 종료 후 observer 재등록
  - 기본 `rootMargin`을 bottom 기준으로 변경

- 하단 무한스크롤 목록
  - Product / Post / Stream / VOD / Profile / Follow / Comment 목록의 `rootMargin`을 bottom 기준으로 정리

- 제외한 항목
  - 채팅 메시지처럼 상단에서 이전 데이터를 불러오는 top pagination
  - 상세 위치 lazy load, 라이브 히어로 lazy load처럼 무한스크롤이 아닌 observer

## Verification

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`