### PR TITLE
✨ Feat : 릴리즈 전 데모 QA 일관성 보강

### DIFF
--- a/app/(app)/(tabs)/posts/loading.tsx
+++ b/app/(app)/(tabs)/posts/loading.tsx
@@ -17,6 +17,7 @@
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/posts/loading.tsx 에서 app/(app)/(tabs)/posts/loading.tsx 로 변경 (라우트 그룹 개편)
  * 2026.04.20  임도헌   Modified  앱 셸(sm) 기준과 헤더 스켈레톤 분기 기준을 일치시켜 640~767px 구간 mismatch 정리
  * 2026.06.01  임도헌   Modified  모바일 게시글 목록 헤더와 뷰 토글 압축 밀도에 맞춘 스켈레톤 조정
+ * 2026.06.21  임도헌   Modified  실제 뷰 토글 버튼 크기(모바일 36px, sm 이상 44px)에 맞춰 로딩 스켈레톤 정렬
  */
 import PostListSkeleton from "@/features/post/components/PostListSkeleton";
 import Skeleton from "@/components/ui/Skeleton";
@@ -64,9 +65,9 @@ export default function Loading() {
       {/* List Skeleton */}
       <div className="px-page-x py-6">
         <div className="flex justify-end mb-4">
-          <div className="flex rounded-2xl border border-border-subtle bg-surface-dim/80 p-1 shadow-sm">
-            <Skeleton className="size-10 rounded-xl" />
-            <Skeleton className="size-10 rounded-xl" />
+          <div className="flex rounded-xl border border-border-subtle bg-surface-dim/80 p-1 shadow-sm">
+            <Skeleton className="size-9 rounded-lg sm:size-11" />
+            <Skeleton className="size-9 rounded-lg sm:size-11" />
           </div>
         </div>
         <PostListSkeleton viewMode="list" />

--- a/app/(app)/(tabs)/posts/page.tsx
+++ b/app/(app)/(tabs)/posts/page.tsx
@@ -41,6 +41,8 @@
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/posts/page.tsx 에서 app/(app)/(tabs)/posts/page.tsx 로 변경 (라우트 그룹 개편)
  * 2026.04.20  임도헌   Modified  앱 셸(sm) 기준과 헤더 분기 기준을 일치시켜 640~767px 구간 헤더 레이아웃 mismatch 정리
  * 2026.05.17  임도헌   Modified  prefetch 데이터 타입을 InfiniteData로 명시
+ * 2026.06.18  임도헌   Modified  정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
+ * 2026.06.18  임도헌   Modified  게시글 목록 쿼리 키에 실제 지역값을 포함해 동네 변경 캐시 충돌 방지
  */
 
 import { Suspense } from "react";
@@ -66,6 +68,7 @@ import PostListRefreshRelay from "@/features/post/components/PostListRefreshRela
 import { getUserLocation } from "@/features/user/service/profile";
 import { getPostsListAction } from "@/features/post/actions/list";
 import { getUnreadNotificationCount } from "@/features/notification/actions/count";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 import type {
   PostSearchParams,
   PostsPage as PostsListPage,
@@ -124,15 +127,19 @@ export default async function PostsPage({ searchParams }: PostsPageProps) {
   const userRegion2 = userLocation?.region2;
   const userRegion3 = userLocation?.region3;
   const currentRange = (userLocation?.regionRange as RegionRange) ?? "GU";
+  const postListScope = {
+    range: currentRange,
+    region1: userRegion1 ?? "",
+    region2: userRegion2 ?? "",
+    region3: userRegion3 ?? "",
+  };
   const postListQueryKey = {
     ...params,
-    __scope: currentRange,
+    __scope: postListScope,
   };
 
   const fullLocation = userLocation
-    ? [userLocation.region1, userLocation.region2, userLocation.region3]
-        .filter(Boolean)
-        .join(" ")
+    ? formatNormalizedRegion(userLocation)
     : null;
 
   await queryClient.prefetchInfiniteQuery({
@@ -191,9 +198,9 @@ export default async function PostsPage({ searchParams }: PostsPageProps) {
             <HydrationBoundary state={dehydrate(queryClient)}>
               <Suspense fallback={<PostListSkeleton viewMode="list" />}>
                 <PostList
-                  key={`${JSON.stringify(searchParams)}-${currentRange}`}
+                  key={`${JSON.stringify(searchParams)}-${JSON.stringify(postListScope)}`}
                   searchParams={params}
-                  queryKeyExtra={currentRange}
+                  queryKeyExtra={postListScope}
                 />
               </Suspense>
             </HydrationBoundary>
@@ -205,7 +212,4 @@ export default async function PostsPage({ searchParams }: PostsPageProps) {
     </div>
   );
 }
-
-
-
 

--- a/app/(app)/(tabs)/products/@modal/(..)products/view/[id]/page.tsx
+++ b/app/(app)/(tabs)/products/@modal/(..)products/view/[id]/page.tsx
@@ -35,6 +35,7 @@
  * 2026.03.23  임도헌   Modified  인터셉트 모달도 일반 상세와 같은 양수 ID 가드로 정리해 잘못된 경로의 조회수/서비스 호출을 방지
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/products/@modal/(..)products/view/[id]/page.tsx 에서 app/(app)/(tabs)/products/@modal/(..)products/view/[id]/page.tsx 로 변경 (라우트 그룹 개편)
  * 2026.04.14  임도헌   Modified  일반 상세와 동일한 공통 상세 로더/조회수 보정 흐름을 적용하고 서버 본문을 children으로 재사용
+ * 2026.06.17  임도헌   Modified  제품 좋아요 상태 캐시를 조회자 기준으로 분리하도록 viewerId 전달
  */
 
 import { notFound, redirect } from "next/navigation";
@@ -113,12 +114,11 @@ export default async function ProductDetailModal({
         isOwner={isOwner}
         likeCount={likeStatus.likeCount}
         isLiked={likeStatus.isLiked}
+        viewerId={userId}
         isModalContext
       />
     </ProductDetailModalContainer>
   );
 }
-
-
 
 

--- a/app/(app)/(tabs)/products/loading.tsx
+++ b/app/(app)/(tabs)/products/loading.tsx
@@ -18,6 +18,7 @@
  * 2026.04.20  임도헌   Modified  앱 셸(sm) 기준과 헤더 스켈레톤 분기 기준을 일치시켜 640~767px 구간 mismatch 정리
  * 2026.05.09  임도헌   Modified  보드게임 도감/키워드 알림 액션이 포함된 상품 목록 헤더 구조 반영
  * 2026.06.01  임도헌   Modified  모바일 상품 목록 헤더와 뷰 토글 압축 밀도에 맞춘 스켈레톤 조정
+ * 2026.06.21  임도헌   Modified  실제 뷰 토글 버튼 크기(모바일 36px, sm 이상 44px)에 맞춰 로딩 스켈레톤 정렬
  */
 
 import ProductListSkeleton from "@/features/product/components/ProductListSkeleton";
@@ -69,9 +70,9 @@ export default function Loading() {
             <Skeleton className="h-8 w-24 rounded-full" />
             <Skeleton className="h-8 w-9 rounded-full sm:w-28" />
           </div>
-          <div className="flex rounded-2xl border border-border-subtle bg-surface-dim/80 p-1 shadow-sm">
-            <Skeleton className="size-10 rounded-xl" />
-            <Skeleton className="size-10 rounded-xl" />
+          <div className="flex rounded-xl border border-border-subtle bg-surface-dim/80 p-1 shadow-sm">
+            <Skeleton className="size-9 rounded-lg sm:size-11" />
+            <Skeleton className="size-9 rounded-lg sm:size-11" />
           </div>
         </div>
         <ProductListSkeleton viewMode="list" showToolbar={false} />

--- a/app/(app)/(tabs)/products/page.tsx
+++ b/app/(app)/(tabs)/products/page.tsx
@@ -59,6 +59,8 @@
  * 2026.04.28  임도헌   Modified  항구 목록에서 보드게임 도감 진입 액션 추가
  * 2026.05.05  임도헌   Modified  URL 쿼리 숫자 파싱 helper JSDoc 보강
  * 2026.05.17  임도헌   Modified  prefetch 데이터 타입을 InfiniteData로 명시
+ * 2026.06.15  임도헌   Modified  제품 빈 상태가 검색어와 상세 조건 0건을 구분하도록 조건 여부 전달
+ * 2026.06.18  임도헌   Modified  정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
  */
 
 import { Suspense } from "react";
@@ -92,6 +94,7 @@ import { getProductsAction } from "@/features/product/actions/list";
 import { getUnreadNotificationCount } from "@/features/notification/actions/count";
 import { getMyKeywordAlerts } from "@/features/notification/service/keyword";
 import { getUserLocation } from "@/features/user/service/profile";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 import type { Paginated, ProductType } from "@/features/product/types";
 import type { RegionRange } from "@/generated/prisma/enums";
 
@@ -152,6 +155,13 @@ export default async function ProductsPage({
   const hasSearchParams = Object.keys(searchParams).length > 0;
   const minPrice = parseNumberParam(searchParams.minPrice);
   const maxPrice = parseNumberParam(searchParams.maxPrice);
+  const hasRefinementParams = [
+    searchParams.category,
+    minPrice,
+    maxPrice,
+    searchParams.game_type,
+    searchParams.condition,
+  ].some(Boolean);
 
   const queryParams = {
     keyword: searchParams.keyword,
@@ -207,9 +217,7 @@ export default async function ProductsPage({
   await prefetchProductsPromise;
 
   const fullLocation = userLocation
-    ? [userLocation.region1, userLocation.region2, userLocation.region3]
-        .filter(Boolean)
-        .join(" ")
+    ? formatNormalizedRegion(userLocation)
     : null;
 
   const currentSearchKeyword = searchParams.keyword?.trim().toLowerCase();
@@ -267,6 +275,7 @@ export default async function ProductsPage({
           {isDataEmpty ? (
             <ProductEmptyState
               hasSearchParams={hasSearchParams}
+              hasRefinementParams={hasRefinementParams}
               keyword={searchParams.keyword}
               alertId={matchedAlert?.id}
               currentRange={currentRange}

--- a/app/(app)/(tabs)/profile/(product)/my-sales/loading.tsx
+++ b/app/(app)/(tabs)/profile/(product)/my-sales/loading.tsx
@@ -12,6 +12,7 @@
  * 2026.03.17  임도헌   Modified  현재 판매 카드 하단 액션 밀도에 맞춰 액션 영역 두께와 대비 정리
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/profile/(product)/my-sales/loading.tsx 에서 app/(app)/(tabs)/profile/(product)/my-sales/loading.tsx 로 변경 (라우트 그룹 개편)
  * 2026.04.17  임도헌   Modified  실카드와 맞춰 태그-메타 사이 구분선을 제거하고 간격만 유지하도록 스켈레톤 리듬 정리
+ * 2026.06.21  임도헌   Modified  실제 뷰 토글 버튼 크기(모바일 36px, sm 이상 44px)에 맞춰 로딩 스켈레톤 정렬
  */
 
 import Skeleton from "@/components/ui/Skeleton";
@@ -29,8 +30,8 @@ export default function Loading() {
 
         {/* View Toggle */}
         <div className="flex justify-end gap-2 mb-3">
-          <Skeleton className="size-9 rounded-lg" />
-          <Skeleton className="size-9 rounded-lg" />
+          <Skeleton className="size-9 rounded-lg sm:size-11" />
+          <Skeleton className="size-9 rounded-lg sm:size-11" />
         </div>
 
         {/* List Skeleton */}
@@ -81,5 +82,4 @@ export default function Loading() {
     </div>
   );
 }
-
 

--- a/app/(app)/(tabs)/profile/[username]/loading.tsx
+++ b/app/(app)/(tabs)/profile/[username]/loading.tsx
@@ -11,7 +11,8 @@
  * 2026.03.17  임도헌   Modified  방송국 rail 카드 폭과 판매 패널 외곽선을 현재 프로필 톤에 맞춰 정리
  * 2026.03.28  임도헌   Modified  타인 프로필 sticky 액션 헤더와 현재 판매 패널 문법에 맞춰 로딩 정리
  * 2026.04.12  임도헌   Moved     파일 경로를 app/(tabs)/profile/[username]/loading.tsx 에서 app/(app)/(tabs)/profile/[username]/loading.tsx 로 변경 (라우트 그룹 개편)
-*/
+ * 2026.06.21  임도헌   Modified  판매 목록 뷰 토글 스켈레톤을 실제 모바일 36px 기준과 맞춤
+ */
 
 import Skeleton from "@/components/ui/Skeleton";
 
@@ -110,8 +111,8 @@ export default function Loading() {
 
             {/* 보기 전환 */}
             <div className="flex justify-end gap-1 mb-3">
-              <Skeleton className="size-11 rounded-lg" />
-              <Skeleton className="size-11 rounded-lg" />
+              <Skeleton className="size-9 rounded-lg sm:size-11" />
+              <Skeleton className="size-9 rounded-lg sm:size-11" />
             </div>
 
             {/* 목록 아이템 */}
@@ -139,4 +140,3 @@ export default function Loading() {
     </div>
   );
 }
-

--- a/app/(app)/posts/[id]/page.tsx
+++ b/app/(app)/posts/[id]/page.tsx
@@ -36,6 +36,7 @@
  * 2026.04.12  임도헌   Moved     파일 경로를 app/posts/[id]/page.tsx 에서 app/(app)/posts/[id]/page.tsx 로 변경 (라우트 그룹 개편)
  * 2026.04.14  임도헌   Modified  제품 상세와 동일하게 가드 후 조회수 반영/화면 보정 순서로 조정
  * 2026.05.15  임도헌   Modified  게시글 공유 미리보기용 OG 이미지 메타와 공유 크롤러 접근 분기 추가
+ * 2026.06.17  임도헌   Modified  게시글 좋아요 상태 캐시를 조회자 기준으로 분리하도록 viewerId 전달
  */
 
 export const dynamic = "force-dynamic";
@@ -193,6 +194,7 @@ export default async function PostDetailPage({
         views={currentViews}
         likeCount={likeStatus.likeCount}
         isLiked={likeStatus.isLiked}
+        viewerId={userId}
         returnTo={returnTo}
         hasExplicitReturnTo={!!rawReturnTo}
       />

--- a/app/(app)/products/view/[id]/page.tsx
+++ b/app/(app)/products/view/[id]/page.tsx
@@ -49,6 +49,7 @@
  * 2026.04.14  임도헌   Modified  상세/모달 공통 상세 로더를 적용하고 조회수 반영 시점을 가드 이후로 조정
  * 2026.05.15  임도헌   Modified  제품 공유 미리보기용 OG 이미지 메타와 소셜 크롤러 접근 분기 추가
  * 2026.05.30  임도헌   Modified  제품 상세 상단 액션바 높이와 좌우 여백을 압축
+ * 2026.06.17  임도헌   Modified  제품 좋아요 상태 캐시를 조회자 기준으로 분리하도록 viewerId 전달
  */
 
 import { notFound, redirect } from "next/navigation";
@@ -240,8 +241,8 @@ export default async function ProductDetailPage({
         isOwner={isOwner}
         likeCount={likeStatus.likeCount}
         isLiked={likeStatus.isLiked}
+        viewerId={userId}
       />
     </div>
   );
 }
-

--- a/app/(app)/streams/[id]/recording/page.tsx
+++ b/app/(app)/streams/[id]/recording/page.tsx
@@ -36,7 +36,8 @@
  * 2026.03.25  임도헌   Modified  owner 삭제 액션을 본문 버튼 대신 상단 관리 메뉴로 이동해 시청 흐름 우선순위 정리
  * 2026.04.12  임도헌   Moved     파일 경로를 app/streams/[id]/recording/page.tsx 에서 app/(app)/streams/[id]/recording/page.tsx 로 변경 (라우트 그룹 개편)
  * 2026.06.07  임도헌   Modified  녹화본 좋아요 캐시를 시청자별로 분리하기 위해 viewerId 전달
-*/
+ * 2026.06.22  임도헌   Modified  녹화 삭제 후 목록/채널 캐시에서 현재 VOD를 즉시 제거할 수 있도록 vodId 전달
+ */
 export const dynamic = "force-dynamic";
 
 import { notFound, redirect } from "next/navigation";
@@ -162,6 +163,7 @@ export default async function RecordingVodPage({
     <div className="flex min-h-screen flex-col bg-background transition-colors">
       {/* 상단바: 뒤로가기 및 작성자 정보 */}
       <RecordingTopbar
+        vodId={vodId}
         broadcastId={base.broadcast.id}
         ownerId={owner.id}
         username={owner.username}

--- a/app/api/streams/[id]/delete/route.ts
+++ b/app/api/streams/[id]/delete/route.ts
@@ -10,12 +10,13 @@
  * 2025.11.22  임도헌   Modified  broadcast-list 캐시 태그 제거 및 user-streams-id 태그 무효화 추가
  * 2026.01.04  임도헌   Modified  Prisma Route Handler runtime=nodejs 명시
  * 2026.03.05  임도헌   Modified  방송 목록 갱신용 레거시 `revalidateTag` 제거 및 클라이언트 Query Cache로 무효화 책임 위임
+ * 2026.06.22  임도헌   Modified  삭제 후 방송국 경로 서버 캐시도 무효화해 새로고침/직접 진입 상태 보정
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import db from "@/lib/db";
 import getSession from "@/lib/session";
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import * as T from "@/lib/cacheTags";
 import { deleteBroadcastTx } from "@/features/stream/service/delete";
 
@@ -58,7 +59,13 @@ export async function DELETE(
       select: {
         id: true,
         status: true,
-        liveInput: { select: { userId: true, provider_uid: true } },
+        liveInput: {
+          select: {
+            userId: true,
+            provider_uid: true,
+            user: { select: { username: true } },
+          },
+        },
       },
     });
 
@@ -104,6 +111,9 @@ export async function DELETE(
     // 6. 캐시 무효화 (상세 페이지 & 유저 방송 목록)
     try {
       revalidateTag(T.BROADCAST_DETAIL(row.id));
+      const username = row.liveInput.user.username;
+      revalidatePath(`/profile/${encodeURIComponent(username)}/channel`);
+      revalidatePath("/streams");
     } catch (err) {
       console.warn("[DELETE STREAM] revalidateTag failed:", err);
     }
@@ -117,4 +127,3 @@ export async function DELETE(
     );
   }
 }
-

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,8 @@
    2026.04.20  임도헌 - 라이트모드 primary CTA 포커스가 배경과 겹치지 않도록 btn-primary 계열을 inset white ring 중심으로 보강
    2026.04.29  임도헌 - 네이티브 select option 색을 시맨틱 토큰으로 고정해 다크모드 드롭다운 가독성 보강
    2026.05.30  임도헌 - 다크모드 border 토큰 대비를 낮춰 모바일 밀집 화면 경계선 톤 정리
+   2026.06.19  임도헌 - 모달 보조 버튼 공통 클래스에 inline-flex 정렬을 추가해 버튼 크기/정렬 기준 통일
+   2026.06.19  임도헌 - 모바일 Empty State 상단 여백을 줄여 필터 직후 빈 상태 피드백이 더 빨리 보이도록 조정
  */
 
 @tailwind base;
@@ -192,7 +194,7 @@
   }
 
   .btn-secondary-modal {
-    @apply rounded-xl border border-border bg-surface-dim px-4 py-2 text-muted transition-colors
+    @apply inline-flex items-center justify-center whitespace-nowrap rounded-xl border border-border bg-surface-dim px-4 py-2 text-muted transition-colors
     hover:border-border-strong hover:bg-surface hover:text-primary
     focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/40 dark:focus-visible:ring-brand-light/40
     disabled:opacity-50 disabled:cursor-not-allowed
@@ -222,7 +224,7 @@
   }
 
   .state-screen {
-    @apply flex flex-col items-center justify-center px-6 py-20 text-center;
+    @apply flex flex-col items-center justify-center px-6 pt-8 pb-20 text-center sm:py-20;
   }
 
   .state-card {

--- a/components/global/ConfirmDialog.tsx
+++ b/components/global/ConfirmDialog.tsx
@@ -18,10 +18,14 @@
  * 2026.04.21  임도헌   Modified  중첩 모달 위에서도 확인 다이얼로그가 안정적으로 보이도록 포털 레이어 우선순위를 10단위 규칙으로 정리
  * 2026.04.29  임도헌   Modified  비파괴 확인 액션에서도 사용할 수 있도록 confirm 버튼 primary 톤 옵션 추가
  * 2026.05.05  임도헌   Modified  키보드/배경 클릭 처리 helper JSDoc 보강
+ * 2026.06.19  임도헌   Modified  모바일 확인 다이얼로그를 공용 BottomSheet로 분기해 차단/신고 계열 문법 통일
+ * 2026.06.19  임도헌   Modified  모바일 BottomSheet에서는 X 닫기와 중복되는 취소 버튼을 제거해 확인 CTA만 남김
  */
 
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import BottomSheet from "@/components/global/BottomSheet";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { lockBodyScroll, unlockBodyScroll } from "@/lib/bodyScrollLock";
 import { cn } from "@/lib/utils";
 
@@ -55,6 +59,7 @@ export default function ConfirmDialog({
   onCancel,
   loading = false,
 }: ConfirmDialogProps) {
+  const isMobile = useIsMobile();
   const firstRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const prevFocusedRef = useRef<HTMLElement | null>(null);
@@ -70,6 +75,8 @@ export default function ConfirmDialog({
   // 포커스 진입/복원 + 바디 스크롤 잠금
   useEffect(() => {
     if (!open) return;
+    if (isMobile) return;
+
     prevFocusedRef.current = document.activeElement as HTMLElement | null;
 
     const t = setTimeout(() => firstRef.current?.focus(), 0);
@@ -81,11 +88,12 @@ export default function ConfirmDialog({
       // 닫히면 이전 포커스로 복귀
       prevFocusedRef.current?.focus?.();
     };
-  }, [open]);
+  }, [isMobile, open]);
 
   // ESC + 포커스 트랩(Tab 순환)
   useEffect(() => {
     if (!open) return;
+    if (isMobile) return;
 
     /**
      * ESC 닫기와 Tab 포커스 순환을 처리
@@ -122,14 +130,16 @@ export default function ConfirmDialog({
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, loading, onCancel]);
+  }, [isMobile, open, loading, onCancel]);
 
   // open이 false거나 마운트 전이면 렌더링 안 함
   if (!open || !mounted) return null;
 
-  const onBackdropClick = () => {
+  const onCancelIfIdle = () => {
     if (!loading) onCancel();
   };
+
+  const onBackdropClick = onCancelIfIdle;
 
   /**
    * 패널 내부 클릭이 backdrop close로 전파되지 않도록 차단
@@ -137,6 +147,68 @@ export default function ConfirmDialog({
    * @param e - 패널 클릭 이벤트
    */
   const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  const actionButtons = (
+    <div className="flex justify-end gap-3">
+      <button
+        ref={firstRef}
+        type="button"
+        onClick={onCancel}
+        disabled={loading}
+        className="focus-ring-soft inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
+      >
+        {cancelLabel}
+      </button>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={loading}
+        className={cn(
+          "focus-ring-strong inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium text-white shadow-sm transition-colors disabled:opacity-50",
+          confirmVariant === "primary"
+            ? "bg-brand hover:bg-brand-dark"
+            : "bg-danger hover:bg-red-600"
+        )}
+      >
+        {loading ? "처리 중..." : confirmLabel}
+      </button>
+    </div>
+  );
+
+  const mobileConfirmButton = (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={loading}
+        className={cn(
+          "focus-ring-strong inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium text-white shadow-sm transition-colors disabled:opacity-50",
+          confirmVariant === "primary"
+            ? "bg-brand hover:bg-brand-dark"
+            : "bg-danger hover:bg-red-600"
+        )}
+      >
+        {loading ? "처리 중..." : confirmLabel}
+      </button>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open
+        title={title}
+        onClose={onCancelIfIdle}
+        footer={mobileConfirmButton}
+      >
+        {description && (
+          <div className="pt-4 text-sm leading-relaxed text-muted">
+            {description}
+          </div>
+        )}
+      </BottomSheet>
+    );
+  }
 
   return createPortal(
     <div
@@ -175,29 +247,8 @@ export default function ConfirmDialog({
           )}
         </div>
 
-        <div className="mt-6 flex shrink-0 justify-end gap-3 border-t border-border-subtle pt-4">
-          <button
-            ref={firstRef}
-            type="button"
-            onClick={onCancel}
-            disabled={loading}
-            className="focus-ring-soft rounded-lg px-4 py-2 text-sm font-medium text-muted transition-colors hover:bg-surface-dim hover:text-primary"
-          >
-            {cancelLabel}
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={loading}
-            className={cn(
-              "focus-ring-strong rounded-lg px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors disabled:opacity-50",
-              confirmVariant === "primary"
-                ? "bg-brand hover:bg-brand-dark"
-                : "bg-danger hover:bg-red-600"
-            )}
-          >
-            {loading ? "처리 중..." : confirmLabel}
-          </button>
+        <div className="mt-6 shrink-0 border-t border-border-subtle pt-4">
+          {actionButtons}
         </div>
       </div>
     </div>,

--- a/components/global/TabBar.tsx
+++ b/components/global/TabBar.tsx
@@ -30,6 +30,7 @@
  * 2026.05.18  임도헌   Modified  서버 초기 미읽음 수를 query cache에 명시 동기화해 탭 전환 후 뱃지 잔상 보정
  * 2026.05.18  임도헌   Modified  미읽음 수 클라이언트 재검증을 Server Action 대신 전용 API 조회로 전환
  * 2026.06.07  임도헌   Modified  오래된 서버 초기값이 클라이언트 미읽음 차감을 되돌리지 않도록 보정
+ * 2026.06.21  임도헌   Modified  하단 신호 탭 미읽음 뱃지가 탭바 상단에서 잘려 보이지 않도록 위치 조정
  */
 "use client";
 
@@ -271,7 +272,7 @@ export default function TabBar({
                     <span
                       aria-hidden="true"
                       className={cn(
-                        "absolute -right-2.5 -top-2 inline-flex h-4 min-w-4 items-center justify-center rounded-full",
+                        "absolute -right-2.5 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full",
                         "bg-danger px-1 text-[10px] font-bold leading-none text-white shadow-sm"
                       )}
                     >

--- a/components/ui/TagInput.tsx
+++ b/components/ui/TagInput.tsx
@@ -14,6 +14,7 @@
  * 2026.02.26  임도헌   Modified  다크모드 개선
  * 2026.04.04  임도헌   Modified  export 주석을 보강해 react-hook-form 기반 태그 입력 역할을 더 명확히 정리
  * 2026.05.17  임도헌   Modified  control/name props를 react-hook-form 제네릭 타입으로 구체화
+ * 2026.06.18  임도헌   Modified  모바일 키보드 Enter/blur 시 태그 확정 흐름 보강
  */
 "use client";
 
@@ -64,15 +65,21 @@ export default function TagInput<TFieldValues extends FieldValues>({
     setTagInput("");
   }, [resetSignal]);
 
+  const commitTag = (rawTag: string) => {
+    if (disabled) return;
+    const newTag = rawTag.trim().replace(/,+$/g, "").trim();
+    if (newTag && !tags.includes(newTag) && tags.length < maxTags) {
+      onChange([...tags, newTag]);
+    }
+    setTagInput("");
+  };
+
   const handleAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (disabled) return;
+    if (e.nativeEvent.isComposing) return;
     if (e.key === "Enter" || e.key === ",") {
       e.preventDefault();
-      const newTag = tagInput.trim();
-      if (newTag && !tags.includes(newTag) && tags.length < maxTags) {
-        onChange([...tags, newTag]);
-        setTagInput("");
-      }
+      commitTag(tagInput);
     }
   };
 
@@ -115,6 +122,11 @@ export default function TagInput<TFieldValues extends FieldValues>({
         value={tagInput}
         onChange={(e) => setTagInput(e.target.value)}
         onKeyDown={handleAddTag}
+        onBlur={() => {
+          if (tagInput.trim()) commitTag(tagInput);
+        }}
+        enterKeyHint="done"
+        autoComplete="off"
         placeholder={
           tags.length >= maxTags ? "태그가 꽉 찼습니다" : "태그 입력 (Enter)"
         }

--- a/features/boardgame/components/detail/RelatedContentSection.tsx
+++ b/features/boardgame/components/detail/RelatedContentSection.tsx
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.05  임도헌   Created   상품/게시글/방송 관련 콘텐츠 UI 분리
+ * 2026.06.19  임도헌   Modified  관련 방송 링크를 라이브/종료 상태에 따라 방송 상세 또는 VOD 상세로 분기
  */
 
 import Image from "next/image";
@@ -170,7 +171,7 @@ function RelatedBroadcastList({
       {broadcasts.map((broadcast) => (
         <Link
           key={broadcast.id}
-          href={`/streams/${broadcast.id}`}
+          href={getBroadcastHref(broadcast)}
           className="focus-ring-soft block rounded-xl border border-border-subtle bg-surface-dim p-3 transition hover:border-brand/50 hover:bg-surface"
         >
           <p className="truncate text-sm font-bold text-primary">
@@ -209,6 +210,23 @@ function RelatedContentGroup({
       <div className="mt-2 space-y-2">{children}</div>
     </div>
   );
+}
+
+/**
+ * 관련 방송 이동 경로 결정
+ * 진행 중인 방송은 라이브 상세, 종료 방송은 처리 완료된 VOD가 있으면 녹화본 상세로 이동
+ *
+ * @param broadcast - 관련 방송 요약
+ * @returns 방송 상태에 맞는 상세 경로
+ */
+function getBroadcastHref(
+  broadcast: BoardGameRelatedContent["broadcasts"][number]
+): string {
+  if (broadcast.status === "CONNECTED") return `/streams/${broadcast.id}`;
+  if (broadcast.vodIdForRecording) {
+    return `/streams/${broadcast.vodIdForRecording}/recording`;
+  }
+  return `/streams/${broadcast.id}`;
 }
 
 /**

--- a/features/boardgame/service/publicQuery/relatedContent.ts
+++ b/features/boardgame/service/publicQuery/relatedContent.ts
@@ -8,6 +8,7 @@
  * 2026.05.03  임도헌   Created   보드게임 상세에서 연결된 상품/게시글/방송을 역방향 조회하도록 추가
  * 2026.05.03  임도헌   Modified  관련 상품 썸네일에 Cloudflare Images public variant 정규화 적용
  * 2026.05.05  임도헌   Modified  상품/게시글/방송 역방향 연결 콘텐츠 조회 분리
+ * 2026.06.19  임도헌   Modified  종료 방송 관련 콘텐츠가 ready VOD 상세로 이동하도록 최신 VOD id 포함
  */
 
 import "server-only";
@@ -82,6 +83,12 @@ export async function getBoardGameRelatedContent(
               status: true,
               thumbnail: true,
               started_at: true,
+              vodAssets: {
+                where: { ready_at: { not: null } },
+                select: { id: true, thumbnail_url: true },
+                orderBy: { ready_at: "desc" },
+                take: 1,
+              },
             },
           },
         },
@@ -109,7 +116,8 @@ export async function getBoardGameRelatedContent(
           id: broadcast.id,
           title: broadcast.title,
           status: broadcast.status,
-          thumbnail: broadcast.thumbnail,
+          vodIdForRecording: broadcast.vodAssets[0]?.id ?? null,
+          thumbnail: broadcast.vodAssets[0]?.thumbnail_url ?? broadcast.thumbnail,
           startedAt: broadcast.started_at,
         })),
       },

--- a/features/boardgame/types/public.ts
+++ b/features/boardgame/types/public.ts
@@ -94,6 +94,7 @@ export interface BoardGameRelatedContent {
     id: number;
     title: string;
     status: string;
+    vodIdForRecording: number | null;
     thumbnail: string | null;
     startedAt: Date | null;
   }>;

--- a/features/chat/components/AppointmentMapModal.tsx
+++ b/features/chat/components/AppointmentMapModal.tsx
@@ -10,6 +10,7 @@
  * 2026.03.22  임도헌   Modified  최근 모달 셸 기준에 맞춰 높이 단위와 외곽선/헤더/푸터 보더 강도 정리
  * 2026.04.02  임도헌   Modified  약속 지도 모달 컴포넌트 JSDoc 보강
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.06.19  임도헌   Modified  X 닫기와 중복되는 하단 닫기 버튼을 제거해 길찾기 CTA 중심으로 정리
  */
 
 import { useEffect, useRef } from "react";
@@ -124,18 +125,12 @@ export default function AppointmentMapModal({
           <p className="text-base font-bold text-primary mb-4 leading-snug">
             {locationName}
           </p>
-          <div className="flex gap-3">
-            <button
-              onClick={onClose}
-              className="flex-1 btn-secondary h-12 text-sm"
-            >
-              닫기
-            </button>
+          <div>
             <a
               href={mapLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex-1 btn-primary h-12 text-sm flex items-center justify-center gap-2"
+              className="btn-primary flex h-12 w-full items-center justify-center gap-2 text-sm"
             >
               <span>길찾기</span>
               <ArrowTopRightOnSquareIcon className="size-4" />

--- a/features/chat/components/ChatHeaderMenuItems.tsx
+++ b/features/chat/components/ChatHeaderMenuItems.tsx
@@ -6,11 +6,20 @@
  * History
  * Date        Author   Status    Description
  * 2026.04.21  임도헌   Created   ChatHeader의 데스크톱/모바일 액션 메뉴 중복 UI를 공통 컴포넌트로 분리
+ * 2026.06.18  임도헌   Modified  데스크톱 액션 메뉴의 아이콘/라벨을 한 줄 정렬로 고정
+ * 2026.06.21  임도헌   Modified  채팅 헤더 메뉴 항목을 아이콘+텍스트 문법으로 통일
  */
 
 import {
+  ArrowPathIcon,
+  ArrowRightOnRectangleIcon,
+  ArrowUturnLeftIcon,
+  CheckCircleIcon,
   ExclamationTriangleIcon,
+  ShoppingBagIcon,
+  UserCircleIcon,
   UserMinusIcon,
+  UserPlusIcon,
 } from "@heroicons/react/24/outline";
 import { cn } from "@/lib/utils";
 
@@ -61,7 +70,7 @@ export default function ChatHeaderMenuItems({
   const isDesktop = variant === "desktop";
 
   const desktopActionClass =
-    "focus-ring-soft block w-full px-4 py-2.5 text-left text-primary hover:bg-surface-dim";
+    "focus-ring-soft flex w-full items-center gap-3 px-4 py-2.5 text-left text-primary hover:bg-surface-dim";
   const mobileActionClass =
     "focus-ring-soft flex min-h-[52px] w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium text-primary transition-colors hover:bg-surface-dim";
 
@@ -69,6 +78,7 @@ export default function ChatHeaderMenuItems({
   const dividerClass = isDesktop
     ? "my-1 border-t border-border-subtle"
     : "my-2 border-t border-border-subtle";
+  const iconClass = isDesktop ? "size-4 shrink-0" : "size-5 shrink-0";
 
   const renderActionButton = (
     label: string,
@@ -93,15 +103,20 @@ export default function ChatHeaderMenuItems({
       )}
     >
       {options?.icon}
-      {label}
+      <span className="whitespace-nowrap">{label}</span>
     </button>
   );
 
   return (
     <>
-      {!isGhost && renderActionButton("상대 프로필", onGoToProfile)}
+      {!isGhost &&
+        renderActionButton("상대 프로필", onGoToProfile, {
+          icon: <UserCircleIcon className={iconClass} />,
+        })}
 
-      {renderActionButton("상품 상세", onGoToProduct)}
+      {renderActionButton("상품 상세", onGoToProduct, {
+        icon: <ShoppingBagIcon className={iconClass} />,
+      })}
 
       {isSeller && (
         <>
@@ -110,19 +125,26 @@ export default function ChatHeaderMenuItems({
           {/* 판매자만 현재 대화 상대를 예약자/구매자로 전환 가능 */}
           {isSelling &&
             !isGhost &&
-            renderActionButton("예약자로 지정", onReserveCounterparty)}
+            renderActionButton("예약자로 지정", onReserveCounterparty, {
+              icon: <UserPlusIcon className={iconClass} />,
+            })}
 
           {isReserved && isCurrentReservationHolder && (
             <>
-              {renderActionButton("예약 취소 (판매중)", onReservedToSelling)}
+              {renderActionButton("예약 취소 (판매중)", onReservedToSelling, {
+                icon: <ArrowUturnLeftIcon className={iconClass} />,
+              })}
               {renderActionButton("판매완료 처리", onReservedToSold, {
+                icon: <CheckCircleIcon className={iconClass} />,
                 emphasize: true,
               })}
             </>
           )}
 
           {isSold &&
-            renderActionButton("판매중으로 되돌리기", onOpenRevertDialog)}
+            renderActionButton("판매중으로 되돌리기", onOpenRevertDialog, {
+              icon: <ArrowPathIcon className={iconClass} />,
+            })}
         </>
       )}
 
@@ -130,16 +152,17 @@ export default function ChatHeaderMenuItems({
         <>
           <div className={dividerClass} />
           {renderActionButton("상대방 차단하기", onOpenBlockConfirm, {
-            icon: <UserMinusIcon className="size-5 shrink-0" />,
+            icon: <UserMinusIcon className={iconClass} />,
           })}
           {renderActionButton("사용자 신고하기", onOpenReport, {
-            icon: <ExclamationTriangleIcon className="size-5 shrink-0" />,
+            icon: <ExclamationTriangleIcon className={iconClass} />,
           })}
         </>
       )}
 
       <div className={dividerClass} />
       {renderActionButton("채팅방 나가기", onOpenLeaveDialog, {
+        icon: <ArrowRightOnRectangleIcon className={iconClass} />,
         danger: true,
       })}
     </>

--- a/features/chat/components/ChatMessageBubble.tsx
+++ b/features/chat/components/ChatMessageBubble.tsx
@@ -33,6 +33,7 @@
  * 2026.04.10  임도헌   Modified  채팅 타이포 정책에 맞춰 메타 타임 크기를 text-xs 기준으로 정리
  * 2026.04.14  임도헌   Modified  채팅 상세 최적화 대응으로 이미지 확대 모달과 상대 아바타 초기 비용을 줄임
  * 2026.05.12  임도헌   Modified  이미지 캡션 구분선을 제거하고 여백으로만 말풍선 내부 흐름을 정리
+ * 2026.06.17  임도헌   Modified  삭제된 본인 메시지 placeholder에 미읽음 표시가 남지 않도록 보강
  */
 "use client";
 
@@ -115,6 +116,8 @@ export default function ChatMessageBubble({
     !!onReact;
   const canReportMessage = !isOwnMessage && !!onReport && !message.deleted_at;
   const canDeleteMessage = isOwnMessage && !!onDelete && !message.deleted_at;
+  const showUnreadMarker =
+    isOwnMessage && !message.deleted_at && !message.isRead;
   const hasMessageActions =
     canReactMessage || canCopyMessage || canReportMessage || canDeleteMessage;
   const hasDesktopQuickActions = canReactMessage || hasMessageActions;
@@ -542,7 +545,7 @@ export default function ChatMessageBubble({
               <div className="mb-0.5 flex shrink-0 flex-col text-xs font-medium text-muted">
                 {isOwnMessage && (
                   <span className="text-brand dark:text-brand-light text-right">
-                    {message.isRead ? "" : "1"}
+                    {showUnreadMarker ? "1" : ""}
                   </span>
                 )}
                 <TimeAgo

--- a/features/chat/components/ScheduleModal.tsx
+++ b/features/chat/components/ScheduleModal.tsx
@@ -13,6 +13,8 @@
  * 2026.04.26  임도헌   Modified  약속 설정 모달에 dialog 의미와 날짜/시간 입력 라벨 연결, ESC 닫기 흐름을 보강
  * 2026.04.26  임도헌   Modified  약속 입력 오류 문구를 사용자가 수정할 항목 기준으로 구체화
  * 2026.05.12  임도헌   Modified  약속 모달을 닫은 뒤 다음 제안이 빈 입력값으로 시작되도록 드래프트 초기화
+ * 2026.06.19  임도헌   Modified  X 닫기와 중복되는 푸터 취소 버튼을 제거해 약속 제안 CTA 중심으로 정리
+ * 2026.06.19  임도헌   Modified  모바일 약속 입력 UI를 공용 BottomSheet로 분기해 모달 문법 통일
  */
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
@@ -22,8 +24,10 @@ import {
   CalendarIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import BottomSheet from "@/components/global/BottomSheet";
 import LocationPicker from "@/features/map/components/LocationPicker";
 import type { LocationData } from "@/features/map/types";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 interface ScheduleModalProps {
   isOpen: boolean;
@@ -44,6 +48,7 @@ export default function ScheduleModal({
   onClose,
   onConfirm,
 }: ScheduleModalProps) {
+  const isMobile = useIsMobile();
   const [dateStr, setDateStr] = useState("");
   const [timeStr, setTimeStr] = useState("");
   const [location, setLocation] = useState<LocationData | null>(null);
@@ -72,6 +77,7 @@ export default function ScheduleModal({
 
   useEffect(() => {
     if (!isOpen || showMap) return;
+    if (isMobile) return;
 
     const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -83,7 +89,7 @@ export default function ScheduleModal({
       window.clearTimeout(timer);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [handleClose, isOpen, isPending, showMap]);
+  }, [handleClose, isMobile, isOpen, isPending, showMap]);
 
   if (!isOpen) return null;
 
@@ -104,6 +110,119 @@ export default function ScheduleModal({
       handleClose();
     });
   };
+
+  const bodyContent = (
+    <div className="space-y-5">
+      {/* 날짜/시간 선택 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <label
+            htmlFor="schedule-date"
+            className="text-xs font-bold text-muted"
+          >
+            날짜
+          </label>
+          <input
+            id="schedule-date"
+            type="date"
+            value={dateStr}
+            onChange={(e) => setDateStr(e.target.value)}
+            className="input-primary text-sm bg-surface-dim h-10 px-3 rounded-xl w-full border-none ring-1 ring-border focus:ring-brand dark:focus:ring-brand-light"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label
+            htmlFor="schedule-time"
+            className="text-xs font-bold text-muted"
+          >
+            시간
+          </label>
+          <input
+            id="schedule-time"
+            type="time"
+            value={timeStr}
+            onChange={(e) => setTimeStr(e.target.value)}
+            className="input-primary text-sm bg-surface-dim h-10 px-3 rounded-xl w-full border-none ring-1 ring-border focus:ring-brand dark:focus:ring-brand-light"
+          />
+        </div>
+      </div>
+
+      {/* 장소 선택 */}
+      <div className="space-y-2">
+        <span className="text-xs font-bold text-muted">만날 장소</span>
+        {location ? (
+          <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-brand/30 dark:border-brand-light/30 shadow-sm group">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="p-2 bg-brand/10 text-brand dark:bg-brand-light/10 dark:text-brand-light rounded-full shrink-0">
+                <MapPinIcon className="size-5" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-primary truncate">
+                  {location.locationName}
+                </p>
+                <p className="text-xs text-muted truncate">
+                  {location.region2} {location.region3}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => setShowMap(true)}
+              className="focus-ring-soft rounded-lg px-2 py-1 text-xs text-muted transition-colors hover:bg-surface-dim hover:text-primary"
+            >
+              변경
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowMap(true)}
+            className="focus-ring-soft w-full h-12 flex items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-surface-dim/30 text-muted hover:text-primary hover:bg-surface-dim hover:border-brand/30 dark:hover:border-brand-light/30 transition-colors"
+          >
+            <MapPinIcon className="size-5" />
+            <span className="text-sm font-medium">지도에서 장소 선택</span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const footer = (
+    <button
+      onClick={handleSubmit}
+      disabled={!location || !dateStr || !timeStr || isPending}
+      className="btn-primary h-10 w-full px-6 text-sm sm:w-auto"
+    >
+      {isPending ? "전송 중..." : "약속 제안하기"}
+    </button>
+  );
+
+  const locationPicker = showMap ? (
+    <LocationPicker
+      onClose={() => setShowMap(false)}
+      onSelect={(loc) => {
+        setLocation(loc);
+        setShowMap(false);
+      }}
+      initialData={location ?? undefined}
+    />
+  ) : null;
+
+  if (isMobile) {
+    return (
+      <>
+        <BottomSheet
+          open={isOpen}
+          title="약속 잡기"
+          description="거래 약속 날짜, 시간, 장소를 선택합니다."
+          onClose={handleClose}
+          contentClassName="pt-4"
+          footer={footer}
+        >
+          {bodyContent}
+        </BottomSheet>
+        {locationPicker}
+      </>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
@@ -134,108 +253,16 @@ export default function ScheduleModal({
         </div>
 
         {/* Body */}
-        <div className="p-5 space-y-5">
-          {/* 날짜/시간 선택 */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <label
-                htmlFor="schedule-date"
-                className="text-xs font-bold text-muted"
-              >
-                날짜
-              </label>
-              <input
-                id="schedule-date"
-                type="date"
-                value={dateStr}
-                onChange={(e) => setDateStr(e.target.value)}
-                className="input-primary text-sm bg-surface-dim h-10 px-3 rounded-xl w-full border-none ring-1 ring-border focus:ring-brand dark:focus:ring-brand-light"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <label
-                htmlFor="schedule-time"
-                className="text-xs font-bold text-muted"
-              >
-                시간
-              </label>
-              <input
-                id="schedule-time"
-                type="time"
-                value={timeStr}
-                onChange={(e) => setTimeStr(e.target.value)}
-                className="input-primary text-sm bg-surface-dim h-10 px-3 rounded-xl w-full border-none ring-1 ring-border focus:ring-brand dark:focus:ring-brand-light"
-              />
-            </div>
-          </div>
-
-          {/* 장소 선택 */}
-          <div className="space-y-2">
-            <span className="text-xs font-bold text-muted">만날 장소</span>
-            {location ? (
-              <div className="flex items-center justify-between p-3 rounded-xl bg-surface border border-brand/30 dark:border-brand-light/30 shadow-sm group">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="p-2 bg-brand/10 text-brand dark:bg-brand-light/10 dark:text-brand-light rounded-full shrink-0">
-                    <MapPinIcon className="size-5" />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-bold text-primary truncate">
-                      {location.locationName}
-                    </p>
-                    <p className="text-xs text-muted truncate">
-                      {location.region2} {location.region3}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => setShowMap(true)}
-                  className="focus-ring-soft rounded-lg px-2 py-1 text-xs text-muted transition-colors hover:bg-surface-dim hover:text-primary"
-                >
-                  변경
-                </button>
-              </div>
-            ) : (
-              <button
-                onClick={() => setShowMap(true)}
-                className="focus-ring-soft w-full h-12 flex items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-surface-dim/30 text-muted hover:text-primary hover:bg-surface-dim hover:border-brand/30 dark:hover:border-brand-light/30 transition-colors"
-              >
-                <MapPinIcon className="size-5" />
-                <span className="text-sm font-medium">지도에서 장소 선택</span>
-              </button>
-            )}
-          </div>
-        </div>
+        <div className="p-5">{bodyContent}</div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-border-subtle bg-surface flex justify-end gap-2">
-          <button
-            onClick={handleClose}
-            className="btn-secondary-modal h-10 px-4 text-sm font-medium"
-            disabled={isPending}
-          >
-            취소
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!location || !dateStr || !timeStr || isPending}
-            className="btn-primary h-10 text-sm px-6"
-          >
-            {isPending ? "전송 중..." : "약속 제안하기"}
-          </button>
+        <div className="p-4 border-t border-border-subtle bg-surface flex justify-end">
+          {footer}
         </div>
       </div>
 
       {/* LocationPicker Modal */}
-      {showMap && (
-        <LocationPicker
-          onClose={() => setShowMap(false)}
-          onSelect={(loc) => {
-            setLocation(loc);
-            setShowMap(false);
-          }}
-          initialData={location ?? undefined}
-        />
-      )}
+      {locationPicker}
     </div>
   );
 }

--- a/features/chat/service/appointment.ts
+++ b/features/chat/service/appointment.ts
@@ -15,6 +15,9 @@
  * 2026.05.16  임도헌   Modified  약속 처리 에러 분기를 unknown-safe 방식으로 정리
  * 2026.05.25  임도헌   Modified  약속 수락 가드/거래 참여자 산정 규칙을 테스트 가능한 유틸로 분리
  * 2026.05.25  임도헌   Modified  약속 제안 시간/거래 가능 상태/상대방 식별 규칙을 테스트 가능한 유틸로 분리
+ * 2026.06.21  임도헌   Modified  약속 제안 수신자에게 거래 알림 전송 추가
+ * 2026.06.21  임도헌   Modified  약속 취소/거절 결과를 상대방에게 거래 알림으로 전송
+ * 2026.06.21  임도헌   Modified  약속 수락 알림 실패가 수락 처리를 막지 않도록 정리
  */
 
 import "server-only";
@@ -41,6 +44,66 @@ import type { LocationData } from "@/features/map/types";
 
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : "";
+
+async function sendAppointmentTradeNotification({
+  targetUserId,
+  title,
+  body,
+  link,
+  image,
+  tag,
+}: {
+  targetUserId: number;
+  title: string;
+  body: string;
+  link: string;
+  image?: string;
+  tag: string;
+}) {
+  const pref = await db.notificationPreferences.findUnique({
+    where: { userId: targetUserId },
+  });
+
+  if (!pref || isNotificationTypeEnabled(pref, "TRADE")) {
+    const notification = await db.notification.create({
+      data: {
+        userId: targetUserId,
+        title,
+        body,
+        type: "TRADE",
+        link,
+        image,
+        isPushSent: false,
+      },
+    });
+
+    await supabase.channel(`user-${targetUserId}-notifications`).send({
+      type: "broadcast",
+      event: "notification",
+      payload: { ...notification },
+    });
+
+    if (canSendPushForType(pref, "TRADE")) {
+      const pushRes = await sendPushNotification({
+        targetUserId,
+        title: notification.title,
+        message: notification.body,
+        url: notification.link ?? undefined,
+        type: "TRADE",
+        image: notification.image ?? undefined,
+        tag,
+        renotify: true,
+      });
+
+      if (pushRes.success && (pushRes.data?.sent ?? 0) > 0) {
+        await db.notification.update({
+          where: { id: notification.id },
+          data: { isPushSent: true, sentAt: new Date() },
+        });
+      }
+    }
+  }
+}
 
 /**
  * 약속 제안하기
@@ -79,7 +142,13 @@ export async function proposeAppointment(
     include: {
       users: { select: { id: true } },
       product: {
-        select: { id: true, purchase_userId: true, reservation_userId: true },
+        select: {
+          id: true,
+          title: true,
+          purchase_userId: true,
+          reservation_userId: true,
+          images: { take: 1, select: { url: true } },
+        },
       },
     },
   });
@@ -200,6 +269,24 @@ export async function proposeAppointment(
       event: "message",
       payload: chatMessage,
     });
+
+    try {
+      await sendAppointmentTradeNotification({
+        targetUserId: receiverId,
+        title: "거래 약속이 제안되었습니다",
+        body: `'${room.product.title}' 상품의 거래 약속 제안을 확인해주세요.`,
+        link: `/chats/${chatRoomId}`,
+        image: room.product.images?.[0]?.url
+          ? `${room.product.images[0].url}/public`
+          : undefined,
+        tag: `bp-trade-appointment-${chatRoomId}`,
+      });
+    } catch (notificationError) {
+      console.warn(
+        "[Appointment] Proposal notification failed:",
+        notificationError
+      );
+    }
 
     return { success: true, data: chatMessage };
   } catch (error: unknown) {
@@ -388,53 +475,22 @@ export async function acceptAppointment(
 
     // 6. 알림 전송 (상대방에게)
     const targetNotiId = userId === buyerId ? sellerId : buyerId;
-    const pref = await db.notificationPreferences.findUnique({
-      where: { userId: targetNotiId },
-    });
-
-    if (!pref || isNotificationTypeEnabled(pref, "TRADE")) {
-      const productTitle = product.title;
-      const imageUrl = product.images?.[0]?.url
-        ? `${product.images[0].url}/public`
-        : undefined;
-
-      const notification = await db.notification.create({
-        data: {
-          userId: targetNotiId,
-          title: "상품이 예약되었습니다",
-          body: `'${productTitle}' 상품의 거래 약속이 확정되었습니다.`,
-          type: "TRADE",
-          link: `/products/view/${product.id}`,
-          image: imageUrl,
-          isPushSent: false,
-        },
+    try {
+      await sendAppointmentTradeNotification({
+        targetUserId: targetNotiId,
+        title: "상품이 예약되었습니다",
+        body: `'${product.title}' 상품의 거래 약속이 확정되었습니다.`,
+        link: `/products/view/${product.id}`,
+        image: product.images?.[0]?.url
+          ? `${product.images[0].url}/public`
+          : undefined,
+        tag: `bp-trade-${product.id}`,
       });
-
-      await supabase.channel(`user-${targetNotiId}-notifications`).send({
-        type: "broadcast",
-        event: "notification",
-        payload: { ...notification },
-      });
-
-      if (canSendPushForType(pref, "TRADE")) {
-        const pushRes = await sendPushNotification({
-          targetUserId: targetNotiId,
-          title: notification.title,
-          message: notification.body,
-          url: notification.link ?? undefined,
-          type: "TRADE",
-          image: notification.image ?? undefined,
-          tag: `bp-trade-${product.id}`,
-          renotify: true,
-        });
-
-        if (pushRes.success && (pushRes.data?.sent ?? 0) > 0) {
-          await db.notification.update({
-            where: { id: notification.id },
-            data: { isPushSent: true, sentAt: new Date() },
-          });
-        }
-      }
+    } catch (notificationError) {
+      console.warn(
+        "[Appointment] Acceptance notification failed:",
+        notificationError
+      );
     }
 
     return {
@@ -474,6 +530,19 @@ export async function cancelAppointment(
 ): Promise<ServiceResult> {
   const apt = await db.appointment.findUnique({
     where: { id: appointmentId },
+    include: {
+      chatRoom: {
+        include: {
+          product: {
+            select: {
+              id: true,
+              title: true,
+              images: { take: 1, select: { url: true } },
+            },
+          },
+        },
+      },
+    },
   });
 
   if (!apt) return { success: false, error: "약속 정보를 찾을 수 없습니다." };
@@ -547,6 +616,35 @@ export async function cancelAppointment(
       event: "message",
       payload: mapToChatMessage(sysMsg),
     });
+
+    try {
+      const targetUserId =
+        nextStatus === "REJECTED" ? apt.proposerId : apt.receiverId;
+      const title =
+        nextStatus === "REJECTED"
+          ? "거래 약속이 거절되었습니다"
+          : "거래 약속이 취소되었습니다";
+      const body =
+        nextStatus === "REJECTED"
+          ? `'${apt.chatRoom.product.title}' 상품의 거래 약속 제안이 거절되었습니다.`
+          : `'${apt.chatRoom.product.title}' 상품의 거래 약속 제안이 취소되었습니다.`;
+
+      await sendAppointmentTradeNotification({
+        targetUserId,
+        title,
+        body,
+        link: `/chats/${apt.chatRoomId}`,
+        image: apt.chatRoom.product.images?.[0]?.url
+          ? `${apt.chatRoom.product.images[0].url}/public`
+          : undefined,
+        tag: `bp-trade-appointment-${apt.chatRoomId}`,
+      });
+    } catch (notificationError) {
+      console.warn(
+        "[Appointment] Cancel/reject notification failed:",
+        notificationError
+      );
+    }
 
     return { success: true };
   } catch (error: unknown) {

--- a/features/chat/service/message.ts
+++ b/features/chat/service/message.ts
@@ -29,6 +29,8 @@
  * 2026.04.03  임도헌   Modified  채팅방 조회 실패 문구를 찾을 수 없음과 권한 없음 문법으로 분리
  * 2026.04.04  임도헌   Modified  첫 메시지 전송 시 사용자 채널 rooms_refresh로 채팅방 목록 실시간 반영 지원
  * 2026.04.14  임도헌   Modified  채팅 목록 성능 점검 대응으로 메시지/읽음/삭제 변화마다 사용자 목록 refresh 브로드캐스트를 보강
+ * 2026.06.17  임도헌   Modified  삭제된 채팅 메시지의 기존 알림 preview를 placeholder로 정리
+ * 2026.06.21  임도헌   Modified  인앱 알림 더보기와 맞도록 새 메시지 알림 본문 사전 축약 제거
  */
 
 import "server-only";
@@ -95,6 +97,84 @@ async function broadcastChatRoomListRefreshByRoomId(chatRoomId: string) {
   if (!room) return;
 
   await broadcastChatRoomListRefresh(room.users.map((user) => user.id));
+}
+
+function buildChatNotificationBody({
+  username,
+  payload,
+  image,
+}: {
+  username: string;
+  payload: string | null;
+  image: string | null;
+}) {
+  if (image && !payload) {
+    return `${username}님이 사진을 보냈습니다.`;
+  }
+
+  const messageText = (payload ?? "").trim();
+
+  if (!messageText) {
+    return `${username}님이 메시지를 보냈습니다.`;
+  }
+
+  return `${username}님이 메시지를 보냈습니다: ${messageText}`;
+}
+
+async function redactDeletedMessageNotification({
+  chatRoomId,
+  senderId,
+  senderName,
+  payload,
+  image,
+  messageCreatedAt,
+}: {
+  chatRoomId: string;
+  senderId: number;
+  senderName: string;
+  payload: string | null;
+  image: string | null;
+  messageCreatedAt: Date;
+}) {
+  try {
+    const room = await db.productChatRoom.findUnique({
+      where: { id: chatRoomId },
+      select: {
+        users: {
+          where: { id: { not: senderId } },
+          select: { id: true },
+        },
+      },
+    });
+
+    const receiverIds = room?.users.map((user) => user.id) ?? [];
+    if (receiverIds.length === 0) return;
+
+    const originalBody = buildChatNotificationBody({
+      username: senderName,
+      payload,
+      image,
+    });
+
+    await db.notification.updateMany({
+      where: {
+        userId: { in: receiverIds },
+        type: "CHAT",
+        link: `/chats/${chatRoomId}`,
+        body: originalBody,
+        created_at: {
+          gte: new Date(messageCreatedAt.getTime() - 5_000),
+          lte: new Date(messageCreatedAt.getTime() + 2 * 60_000),
+        },
+      },
+      data: {
+        title: "삭제된 메시지",
+        body: `${senderName}님이 보낸 메시지가 삭제되었습니다.`,
+      },
+    });
+  } catch (error) {
+    console.error("[redactDeletedMessageNotification] Error:", error);
+  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -304,14 +384,11 @@ export async function createMessage(
 
       // 알림 전송 조건 체크
       if (isNotificationTypeEnabled(prefs, "CHAT")) {
-        // 알림 메시지 구성
-        let bodyText = "";
-        if (image && !payload) {
-          bodyText = `${message.user.username}님이 사진을 보냈습니다.`;
-        } else {
-          const preview = (payload ?? "").trim().slice(0, 20) + "...";
-          bodyText = `${message.user.username}님이 메시지를 보냈습니다: ${preview}`;
-        }
+        const bodyText = buildChatNotificationBody({
+          username: message.user.username,
+          payload: payload ?? null,
+          image: image ?? null,
+        });
 
         const senderAvatarUrl = message.user.avatar
           ? `${message.user.avatar}/avatar`
@@ -515,6 +592,15 @@ export async function deleteMessage(
     const chatMessage = mapToChatMessage(deletedMessage);
     const wasUnread = !existing.isRead;
 
+    await redactDeletedMessageNotification({
+      chatRoomId: roomId,
+      senderId: userId,
+      senderName: existing.user.username,
+      payload: existing.payload,
+      image: existing.image,
+      messageCreatedAt: existing.created_at,
+    });
+
     await supabase.channel(`room-${roomId}`).send({
       type: "broadcast",
       event: CHAT_EVENT.MESSAGE_DELETED,
@@ -647,4 +733,3 @@ export async function toggleMessageReaction(
     return { success: false, error: "메시지 반응 처리에 실패했습니다." };
   }
 }
-

--- a/features/map/components/LocationPicker.tsx
+++ b/features/map/components/LocationPicker.tsx
@@ -21,6 +21,7 @@
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.10  임도헌   Modified  map 타이포 정책에 맞춰 안내 힌트와 선택 위치 라벨 크기/weight를 400·500·700 기준으로 정리
  * 2026.05.16  임도헌   Modified  카카오 장소 검색 결과 타입을 명시해 any 제거
+ * 2026.06.18  임도헌   Modified  도 단위 카카오 주소를 시/군 중심 지역 계층으로 정규화
  */
 
 import { useState, useEffect } from "react";
@@ -38,6 +39,10 @@ import type {
   KakaoPlaceSearchResult,
   LocationData,
 } from "@/features/map/types";
+import {
+  formatNormalizedRegion,
+  normalizeKakaoRegion,
+} from "@/features/map/utils/normalizeRegion";
 
 interface LocationPickerProps {
   onSelect: (data: LocationData) => void;
@@ -100,17 +105,20 @@ export default function LocationPicker({
       if (status === window.kakao.maps.services.Status.OK) {
         const addr = result[0].address;
 
-        // 세종시 등 region2 부재 케이스 보정
-        const region2Safe = addr.region_2depth_name || addr.region_1depth_name;
+        const region = normalizeKakaoRegion({
+          region1: addr.region_1depth_name,
+          region2: addr.region_2depth_name,
+          region3: addr.region_3depth_name,
+        });
 
         const info: LocationData = {
           latitude: coords.lat,
           longitude: coords.lng,
           locationName:
             placeName || addr.region_3depth_name || addr.address_name,
-          region1: addr.region_1depth_name,
-          region2: region2Safe,
-          region3: addr.region_3depth_name,
+          region1: region.region1,
+          region2: region.region2,
+          region3: region.region3,
         };
         setMarker(coords);
         setSelectedInfo(info);
@@ -286,8 +294,7 @@ export default function LocationPicker({
                       {selectedInfo.locationName}
                     </p>
                     <p className="mt-0 text-xs text-muted dark:text-slate-300/90">
-                      {selectedInfo.region1} {selectedInfo.region2}{" "}
-                      {selectedInfo.region3}
+                      {formatNormalizedRegion(selectedInfo)}
                     </p>
                   </div>
                 </div>

--- a/features/map/types.ts
+++ b/features/map/types.ts
@@ -8,15 +8,16 @@
  * 2026.02.14  임도헌   Created
  * 2026.04.02  임도헌   Modified  위치 타입 필드 설명 정리
  * 2026.05.16  임도헌   Modified  카카오 장소 검색 결과 타입 추가
+ * 2026.06.18  임도헌   Modified  카카오 1depth/도 단위 정규화 정책에 맞춰 지역 필드 설명 보강
  */
 
 export interface LocationData {
   latitude: number; // 위도 (y)
   longitude: number; // 경도 (x)
   locationName: string; // 장소명 (사용자가 검색하거나 클릭한 지점의 이름/주소)
-  region1: string; // 시/도 (Prisma 저장용)
-  region2: string; // 구/군 (Prisma 저장용)
-  region3: string; // 동/읍/면 (Prisma 저장용)
+  region1: string; // 지역 필터 1차 단위(카카오 1depth 또는 도 단위의 시/군)
+  region2: string; // 지역 필터 2차 단위(구/군, 없으면 region1)
+  region3: string; // 지역 필터 3차 단위(동/읍/면)
   // 유저 동네 범위 (선택 사항)
   regionRange?: "DONG" | "GU" | "CITY" | "ALL";
 }

--- a/features/map/utils/normalizeRegion.test.ts
+++ b/features/map/utils/normalizeRegion.test.ts
@@ -1,0 +1,82 @@
+/**
+ * File Name : features/map/utils/normalizeRegion.test.ts
+ * Description : 카카오 행정구역 정규화 유틸 회귀 테스트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.18  임도헌   Created   도 단위/광역시 주소 정규화와 표시 문자열 테스트 추가
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  formatNormalizedRegion,
+  normalizeKakaoRegion,
+} from "./normalizeRegion";
+
+describe("normalizeKakaoRegion", () => {
+  test("도 단위 주소는 시/군을 1차 지역으로 올린다", () => {
+    expect(
+      normalizeKakaoRegion({
+        region1: "경기",
+        region2: "수원시 영통구",
+        region3: "매탄동",
+      })
+    ).toEqual({
+      region1: "수원시",
+      region2: "영통구",
+      region3: "매탄동",
+    });
+  });
+
+  test("구가 없는 시/동 구조는 동 단위 필터가 가능하게 저장한다", () => {
+    expect(
+      normalizeKakaoRegion({
+        region1: "경남",
+        region2: "거제시",
+        region3: "고현동",
+      })
+    ).toEqual({
+      region1: "거제시",
+      region2: "거제시",
+      region3: "고현동",
+    });
+  });
+
+  test("특별시/광역시 주소는 카카오 1depth 값을 그대로 유지한다", () => {
+    expect(
+      normalizeKakaoRegion({
+        region1: "서울",
+        region2: "마포구",
+        region3: "합정동",
+      })
+    ).toEqual({
+      region1: "서울",
+      region2: "마포구",
+      region3: "합정동",
+    });
+
+    expect(
+      normalizeKakaoRegion({
+        region1: "대전",
+        region2: "유성구",
+        region3: "봉명동",
+      })
+    ).toEqual({
+      region1: "대전",
+      region2: "유성구",
+      region3: "봉명동",
+    });
+  });
+
+  test("표시 문자열은 중복 지역 단위를 숨긴다", () => {
+    expect(
+      formatNormalizedRegion({
+        region1: "거제시",
+        region2: "거제시",
+        region3: "고현동",
+      })
+    ).toBe("거제시 고현동");
+  });
+});

--- a/features/map/utils/normalizeRegion.ts
+++ b/features/map/utils/normalizeRegion.ts
@@ -1,0 +1,112 @@
+/**
+ * File Name : features/map/utils/normalizeRegion.ts
+ * Description : 카카오 행정구역 응답을 BoardPort 지역 필터 계층으로 정규화
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.18  임도헌   Created   특별시/광역시는 카카오 1depth를 유지하고 도 단위 주소는 시/군 중심으로 변환
+ */
+
+interface KakaoRegionInput {
+  region1?: string | null;
+  region2?: string | null;
+  region3?: string | null;
+}
+
+export interface NormalizedRegion {
+  region1: string;
+  region2: string;
+  region3: string;
+}
+
+const PROVINCE_REGIONS = new Set([
+  "경기",
+  "경기도",
+  "강원",
+  "강원도",
+  "충북",
+  "충청북도",
+  "충남",
+  "충청남도",
+  "전북",
+  "전라북도",
+  "전남",
+  "전라남도",
+  "경북",
+  "경상북도",
+  "경남",
+  "경상남도",
+  "제주",
+  "제주도",
+  "제주특별자치도",
+]);
+
+function splitRegion(value?: string | null) {
+  return value?.split(/\s+/).filter(Boolean) ?? [];
+}
+
+function isProvinceRegion(region1?: string | null) {
+  if (!region1) return false;
+  return PROVINCE_REGIONS.has(region1) || region1.endsWith("도");
+}
+
+export function normalizeKakaoRegion({
+  region1,
+  region2,
+  region3,
+}: KakaoRegionInput): NormalizedRegion {
+  const fallbackRegion1 = region1 ?? "";
+  const fallbackRegion2 = region2 || fallbackRegion1;
+  const fallbackRegion3 = region3 ?? "";
+
+  if (!isProvinceRegion(region1)) {
+    // 서울/부산/대전 등 특별시·광역시는 카카오 1depth 값을 그대로 필터 기준으로 사용한다.
+    return {
+      region1: fallbackRegion1,
+      region2: fallbackRegion2,
+      region3: fallbackRegion3,
+    };
+  }
+
+  const parts = [...splitRegion(region2), ...splitRegion(region3)];
+  const cityIndex = parts.findIndex(
+    (part) => part.endsWith("시") || part.endsWith("군")
+  );
+
+  if (cityIndex < 0) {
+    return {
+      region1: fallbackRegion1,
+      region2: fallbackRegion2,
+      region3: fallbackRegion3,
+    };
+  }
+
+  const cityName = parts[cityIndex];
+  const [, ...rest] = parts.slice(cityIndex);
+
+  if (rest.length === 1 && !rest[0].endsWith("구")) {
+    // 거제시 고현동처럼 구가 없는 시/군은 기존 세종시 처리와 맞춰 region2를 region1로 둔다.
+    return {
+      region1: cityName,
+      region2: cityName,
+      region3: rest[0],
+    };
+  }
+
+  return {
+    region1: cityName,
+    region2: rest[0] ?? cityName,
+    region3: rest[1] ?? "",
+  };
+}
+
+export function formatNormalizedRegion(region: KakaoRegionInput) {
+  return [
+    region.region1,
+    region.region2 && region.region2 !== region.region1 ? region.region2 : null,
+    region.region3,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/features/notification/components/NotificationListContainer.tsx
+++ b/features/notification/components/NotificationListContainer.tsx
@@ -35,11 +35,13 @@
  * 2026.05.25  임도헌   Modified  허용된 이미지 출처만 렌더링해 오래된 알림 이미지 URL 예외 방어
  * 2026.05.25  임도헌   Modified  알림 상세 이동을 먼저 수행하고 읽음 처리는 후속 동기화로 분리
  * 2026.05.25  임도헌   Modified  알림 이미지/삭제 콘텐츠 렌더링 판단을 테스트 가능한 유틸로 분리
+ * 2026.06.19  임도헌   Modified  모바일 긴 알림 본문 더보기와 알림센터 자기 링크 버튼 숨김 처리 추가
+ * 2026.06.21  임도헌   Modified  모바일 알림 제목/본문 펼침 기준을 실제 clamp overflow 측정으로 보정
  */
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -93,6 +95,133 @@ const KeywordAlertModal = dynamic(
   { ssr: false }
 );
 
+interface NotificationTextBlockProps {
+  notification: NotificationItem;
+  isLinkedNotification: boolean;
+  isExpanded: boolean;
+  onOpen: (notification: NotificationItem) => void;
+  onMarkAsRead: (id: number) => void;
+  onToggleExpanded: (id: number) => void;
+}
+
+function NotificationTextBlock({
+  notification,
+  isLinkedNotification,
+  isExpanded,
+  onOpen,
+  onMarkAsRead,
+  onToggleExpanded,
+}: NotificationTextBlockProps) {
+  const titleRef = useRef<HTMLButtonElement>(null);
+  const bodyRef = useRef<HTMLParagraphElement>(null);
+  const [canExpand, setCanExpand] = useState(false);
+
+  useEffect(() => {
+    if (isExpanded) return;
+
+    const measureOverflow = () => {
+      const title = titleRef.current;
+      const body = bodyRef.current;
+      const titleOverflow =
+        title !== null && title.scrollHeight > title.clientHeight + 1;
+      const bodyOverflow =
+        body !== null && body.scrollHeight > body.clientHeight + 1;
+      setCanExpand(titleOverflow || bodyOverflow);
+    };
+
+    measureOverflow();
+    const rafId = window.requestAnimationFrame(measureOverflow);
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measureOverflow);
+      return () => {
+        window.cancelAnimationFrame(rafId);
+        window.removeEventListener("resize", measureOverflow);
+      };
+    }
+
+    const observer = new ResizeObserver(measureOverflow);
+    if (titleRef.current) observer.observe(titleRef.current);
+    if (bodyRef.current) observer.observe(bodyRef.current);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      observer.disconnect();
+    };
+  }, [isExpanded, notification.body, notification.title]);
+
+  return (
+    <>
+      {isLinkedNotification ? (
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 sm:gap-3">
+          <button
+            ref={titleRef}
+            type="button"
+            onClick={() => onOpen(notification)}
+            className={cn(
+              "focus-ring-soft min-w-0 flex-1 rounded-md px-1 py-0.5 text-left text-[15px] font-bold leading-snug transition-colors sm:text-base",
+              isExpanded
+                ? "line-clamp-none sm:line-clamp-1"
+                : "line-clamp-2 sm:line-clamp-1",
+              notification.isRead
+                ? "text-slate-600 dark:text-slate-300"
+                : "text-primary hover:text-brand dark:hover:text-brand-light"
+            )}
+          >
+            {notification.title}
+          </button>
+          {/* 링크형 알림은 별도 CTA를 노출해 이동 동작 인지성 보강 */}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => onOpen(notification)}
+              className="focus-ring-soft inline-flex shrink-0 items-center gap-1 rounded-full border border-border-strong px-2.5 py-1 text-xs font-medium text-slate-600 transition-colors hover:border-border-strong hover:bg-surface-dim hover:text-primary dark:text-slate-200"
+            >
+              보기
+              <ArrowUpRightIcon className="size-3.5" />
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          ref={titleRef}
+          type="button"
+          onClick={() => onMarkAsRead(notification.id)}
+          className={cn(
+            "focus-ring-soft rounded-md px-1 py-0.5 text-left text-[15px] font-bold leading-snug transition-colors sm:text-base",
+            isExpanded
+              ? "line-clamp-none sm:line-clamp-1"
+              : "line-clamp-2 sm:line-clamp-1",
+            notification.isRead
+              ? "text-slate-600 dark:text-slate-300"
+              : "text-primary hover:text-brand dark:hover:text-brand-light"
+          )}
+        >
+          {notification.title}
+        </button>
+      )}
+      <p
+        ref={bodyRef}
+        className={cn(
+          "mt-0.5 text-sm leading-snug text-slate-600 dark:text-slate-300",
+          isExpanded ? "line-clamp-none sm:line-clamp-2" : "line-clamp-2"
+        )}
+      >
+        {notification.body}
+      </p>
+      {canExpand && (
+        <button
+          type="button"
+          onClick={() => onToggleExpanded(notification.id)}
+          className="focus-ring-soft mt-1 inline-flex rounded px-1 py-0.5 text-xs font-bold text-brand transition-colors hover:text-brand-dark sm:hidden dark:text-brand-light"
+        >
+          {isExpanded ? "접기" : "더보기"}
+        </button>
+      )}
+    </>
+  );
+}
+
 /**
  * 알림함 목록 및 읽음 처리 컨테이너 컴포넌트
  *
@@ -116,6 +245,9 @@ export default function NotificationListContainer({
   const [failedImageIds, setFailedImageIds] = useState<Set<number>>(
     () => new Set()
   );
+  const [expandedNotificationIds, setExpandedNotificationIds] = useState<
+    Set<number>
+  >(() => new Set());
   const [isKeywordModalOpen, setIsKeywordModalOpen] = useState(false);
   const [isMarkingAll, startMarkingAll] = useTransition();
   const router = useRouter();
@@ -132,6 +264,7 @@ export default function NotificationListContainer({
     // 서버 응답 기준 로컬 목록 재동기화
     setNotifications(data.items);
     setFailedImageIds(new Set());
+    setExpandedNotificationIds(new Set());
   }, [data.items]);
 
   // Zustand 액션 가져오기
@@ -257,6 +390,27 @@ export default function NotificationListContainer({
     const separator = safeHref.includes("?") ? "&" : "?";
     return `${safeHref}${separator}returnTo=${encodeURIComponent(currentHref)}`;
   };
+  const isNotificationCenterLink = (href?: string | null) => {
+    if (!href) return false;
+    const safeHref = sanitizeCallbackUrl(href);
+    return (
+      safeHref === "/profile/notifications/list" ||
+      safeHref.startsWith("/profile/notifications/list?")
+    );
+  };
+  const hasActionableLink = (notification: NotificationItem) =>
+    !!notification.link && !isNotificationCenterLink(notification.link);
+  const toggleBodyExpanded = (id: number) => {
+    setExpandedNotificationIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
   const settingsHref = `/profile/notifications/setting?returnTo=${encodeURIComponent(
     currentHref
   )}`;
@@ -337,6 +491,10 @@ export default function NotificationListContainer({
               const icon = typeIcons[notification.type] || (
                 <BellAlertIcon className="size-5" />
               );
+              const isLinkedNotification = hasActionableLink(notification);
+              const isNotificationExpanded = expandedNotificationIds.has(
+                notification.id
+              );
               const canRenderImage =
                 isRenderableNotificationImage(notification.image) &&
                 !failedImageIds.has(notification.id);
@@ -380,49 +538,14 @@ export default function NotificationListContainer({
                   </div>
 
                   <div className="flex-1 min-w-0">
-                    {notification.link ? (
-                      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 sm:gap-3">
-                        <button
-                          type="button"
-                          onClick={() => handleOpenNotification(notification)}
-                          className={cn(
-                            "focus-ring-soft min-w-0 flex-1 rounded-md px-1 py-0.5 text-left font-bold line-clamp-1 transition-colors",
-                            notification.isRead
-                              ? "text-slate-600 dark:text-slate-300"
-                              : "text-primary hover:text-brand dark:hover:text-brand-light"
-                          )}
-                        >
-                          {notification.title}
-                        </button>
-                        {/* 링크형 알림은 별도 CTA를 노출해 이동 동작 인지성 보강 */}
-                        <div className="flex justify-end">
-                          <button
-                            type="button"
-                            onClick={() => handleOpenNotification(notification)}
-                            className="focus-ring-soft inline-flex shrink-0 items-center gap-1 rounded-full border border-border-strong px-2.5 py-1 text-xs font-medium text-slate-600 transition-colors hover:border-border-strong hover:bg-surface-dim hover:text-primary dark:text-slate-200"
-                          >
-                            보기
-                            <ArrowUpRightIcon className="size-3.5" />
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => handleMarkAsRead(notification.id)}
-                        className={cn(
-                          "focus-ring-soft rounded-md px-1 py-0.5 text-left font-bold line-clamp-1 transition-colors",
-                          notification.isRead
-                            ? "text-slate-600 dark:text-slate-300"
-                            : "text-primary hover:text-brand dark:hover:text-brand-light"
-                        )}
-                      >
-                        {notification.title}
-                      </button>
-                    )}
-                    <p className="mt-0.5 line-clamp-2 text-sm leading-snug text-slate-600 dark:text-slate-300">
-                      {notification.body}
-                    </p>
+                    <NotificationTextBlock
+                      notification={notification}
+                      isLinkedNotification={isLinkedNotification}
+                      isExpanded={isNotificationExpanded}
+                      onOpen={handleOpenNotification}
+                      onMarkAsRead={handleMarkAsRead}
+                      onToggleExpanded={toggleBodyExpanded}
+                    />
                     {shouldShowUnavailableCopy(notification) && (
                       <p className="mt-1 text-xs leading-snug text-slate-500 dark:text-slate-400">
                         연결된 콘텐츠가 삭제되어 이동할 수 없습니다.

--- a/features/notification/components/NotificationSettingsClient.tsx
+++ b/features/notification/components/NotificationSettingsClient.tsx
@@ -24,6 +24,7 @@
  * 2026.04.10  임도헌   Modified  notification 타이포 정책에 맞춰 상태 배너 강조 문구 weight를 500 기준으로 정리
  * 2026.04.18  임도헌   Modified  체크박스/시간 입력 폼을 서버 렌더링으로 분리해 초기 설정 페이지 하이드레이션 비용 축소
  * 2026.04.20  임도헌   Modified  알림 설정 체크박스와 행 포커스를 공용 문법에 맞춰 정리
+ * 2026.06.21  임도헌   Modified  댓글/약속/다시보기 알림 추가에 맞춰 알림 종류 설명 문구 보강
  */
 
 import {
@@ -92,7 +93,8 @@ export default function NotificationSettingsClient({
       <section className="space-y-2">
         <h2 className="px-1 text-sm font-bold text-primary">알림 종류</h2>
         <p className="px-1 text-xs leading-relaxed text-muted">
-          필요한 알림만 켜 두세요. 키워드는 아래에서 관리할 수 있습니다.
+          받고 싶은 알림만 켜 두세요. 댓글·거래·방송 활동 알림은
+          종류별 설정을 따릅니다.
         </p>
         <div className="panel divide-y divide-border overflow-hidden">
           {rows.map((row) => (
@@ -179,7 +181,7 @@ const rows = [
     name: "trade",
     label: "거래 알림",
     icon: <ArrowsRightLeftIcon className="size-5" />,
-    description: "예약, 판매 완료 등 거래 상태 변경",
+    description: "약속 제안, 예약/취소, 판매 완료",
   },
   {
     name: "review",
@@ -197,7 +199,7 @@ const rows = [
     name: "stream",
     label: "방송 알림",
     icon: <PlayCircleIcon className="size-5" />,
-    description: "팔로우한 선원의 방송 시작",
+    description: "방송 시작, 다시보기 댓글",
   },
   {
     name: "keyword",
@@ -209,6 +211,6 @@ const rows = [
     name: "system",
     label: "시스템 알림",
     icon: <BellAlertIcon className="size-5" />,
-    description: "공지사항 및 서비스 안내",
+    description: "게시글 댓글, 관리자 안내, 서비스 공지",
   },
 ] as const;

--- a/features/notification/service/notification.ts
+++ b/features/notification/service/notification.ts
@@ -15,6 +15,7 @@
  * 2026.04.26  임도헌   Modified  읽음 처리 실패 문구를 알림 센터 UI 액션 라벨과 같은 표현으로 정리
  * 2026.05.16  임도헌   Modified  미읽음 알림 카운트 조회를 service 계층으로 분리
  * 2026.05.24  임도헌   Modified  삭제된 콘텐츠를 가리키는 오래된 알림 링크/이미지 응답 정규화 추가
+ * 2026.06.19  임도헌   Modified  관리자 조치 인앱 알림은 명시 링크가 있을 때만 보기 링크를 저장하도록 정리
  */
 
 import "server-only";
@@ -268,7 +269,7 @@ export async function sendAdminActionNotification({
         title: notiTitle,
         body: notiBody,
         type: "SYSTEM",
-        link: link ?? "/profile/notifications/list",
+        link: link ?? null,
         isPushSent: false,
       },
     });

--- a/features/post/components/PostEmptyState.tsx
+++ b/features/post/components/PostEmptyState.tsx
@@ -16,6 +16,7 @@
  * 2026.03.28  임도헌   Modified  장문 검색어가 빈 상태 카드에서 넘치지 않도록 제품과 동일한 검색 empty state 문법으로 통일
  * 2026.03.28  임도헌   Modified  검색어를 제목 대신 보조 문구로 다시 노출해 제품 empty state와 검색 피드백 문법을 통일
  * 2026.03.30  임도헌   Modified  게시글 카테고리 plain 라벨 정리에 맞춰 empty state 기본 문구를 일반 게시글 기준으로 조정
+ * 2026.06.15  임도헌   Modified  검색어+카테고리 0건 상태를 순수 검색 0건과 구분해 안내
  */
 "use client";
 
@@ -47,15 +48,26 @@ export default function PostEmptyState({
   let subMessage = "첫 번째 게시글을 작성해보세요!";
   let keywordHint: string | null = null;
   const isNarrowRange = currentRange === "DONG" || currentRange === "GU";
+  const categoryLabel = category
+    ? POST_CATEGORY[category as PostCategoryType]
+    : null;
+  const hasKeywordWithCategory = Boolean(keyword && categoryLabel);
+  const keywordOnlyHref = keyword
+    ? `/posts?keyword=${encodeURIComponent(keyword)}`
+    : "/posts";
 
-  if (keyword) {
+  if (hasKeywordWithCategory) {
+    message = "조건에 맞는 게시글이 없습니다.";
+    subMessage = "검색어는 유지하고 카테고리를 넓혀보세요.";
+    keywordHint = `'${keyword}' 검색 결과 중 ${categoryLabel} 카테고리에 맞는 글을 찾지 못했어요.`;
+  } else if (keyword) {
     message = "검색 결과가 없습니다.";
     subMessage = isNarrowRange
       ? "다른 키워드로 검색하거나, 동네 범위를 넓혀 다시 확인해보세요."
       : "다른 키워드로 검색해보세요.";
     keywordHint = `'${keyword}'에 대한 결과를 찾지 못했어요.`;
-  } else if (category) {
-    message = `'${POST_CATEGORY[category as PostCategoryType]}'에 게시글이 없습니다.`;
+  } else if (categoryLabel) {
+    message = `'${categoryLabel}'에 게시글이 없습니다.`;
     subMessage = isNarrowRange
       ? "이 카테고리의 글이 근처엔 아직 없습니다. 동네 범위를 넓혀보세요."
       : "이 카테고리의 첫 글을 작성해보세요!";
@@ -79,6 +91,14 @@ export default function PostEmptyState({
         </div>
 
         <div className="state-actions justify-center">
+          {hasKeywordWithCategory && (
+            <Link
+              href={keywordOnlyHref}
+              className="btn-secondary inline-flex min-h-[44px] items-center justify-center px-6 text-sm"
+            >
+              카테고리 풀고 보기
+            </Link>
+          )}
           <Link
             href="/posts/add"
             className="btn-primary inline-flex min-h-[44px] items-center justify-center gap-2 px-6 text-sm shadow-sm"

--- a/features/post/components/PostLikeButton.tsx
+++ b/features/post/components/PostLikeButton.tsx
@@ -25,6 +25,8 @@
  * 2026.05.12  임도헌   Modified  다른 상세 화면과 맞춰 시각 레이블은 하트와 숫자만 남기고 접근성 이름은 aria-label로 분리
  * 2026.05.18  임도헌   Modified  상세 좋아요 변경 시 게시글 목록 캐시의 isLiked와 좋아요 수를 함께 낙관 업데이트
  * 2026.05.26  임도헌   Modified  initialData 기반 likeStatus query에 local queryFn을 부여해 refetch 경고 방지
+ * 2026.06.17  임도헌   Modified  낙관 반영 직후 좋아요 버튼이 흐려 보이지 않도록 pending opacity 제거
+ * 2026.06.17  임도헌   Modified  계정 전환 시 이전 사용자의 좋아요 캐시가 재사용되지 않도록 viewer scope 추가
  */
 "use client";
 
@@ -46,6 +48,7 @@ interface PostLikeButtonProps {
   postId: number;
   isLiked: boolean;
   likeCount: number;
+  viewerId?: number | null;
 }
 
 /**
@@ -55,6 +58,7 @@ interface PostLikeButtonProps {
  * - `initialData`를 통한 초기 렌더링 깜빡임 방지 및 상태 하이드레이션 적용
  * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 피드백 제공
  * - 상세 좋아요 변경 시 목록 카드의 좋아요 수와 isLiked도 함께 갱신해 뒤로가기 후 하트 색상 정합성 유지
+ * - 좋아요 상태 query key에 viewer scope를 포함해 계정 전환/재로그인 후 stale 상태 노출 방지
  * - `onError` 발생 시 `previous` 스냅샷을 활용한 이전 상태 복구(Rollback) 로직 포함
  * - `onSettled` 단계에서는 실제 queryFn이 있는 목록 쿼리만 무효화해 상세 initialData 캐시 refetch 경고를 방지
  */
@@ -62,9 +66,10 @@ export default function PostLikeButton({
   postId,
   isLiked: initialIsLiked,
   likeCount: initialLikeCount,
+  viewerId = null,
 }: PostLikeButtonProps) {
   const queryClient = useQueryClient();
-  const queryKey = queryKeys.posts.likeStatus(postId);
+  const queryKey = queryKeys.posts.likeStatus(postId, viewerId);
   const initialLikeStatus = {
     isLiked: initialIsLiked,
     likeCount: initialLikeCount,
@@ -162,9 +167,10 @@ export default function PostLikeButton({
       disabled={isPending}
       className={cn(
         "focus-ring-soft -ml-1.5 flex items-center gap-1.5 rounded-lg p-1.5 transition-colors hover:bg-surface-dim",
-        "disabled:opacity-60 disabled:cursor-not-allowed",
+        "disabled:cursor-not-allowed",
         data.isLiked ? "text-rose-500" : "text-muted hover:text-rose-500"
       )}
+      aria-busy={isPending}
       aria-pressed={data.isLiked}
       aria-label={likeButtonLabel}
     >

--- a/features/post/components/PostList.tsx
+++ b/features/post/components/PostList.tsx
@@ -107,7 +107,7 @@ export default function PostList({
           <button
             onClick={() => setViewMode("list")}
             className={cn(
-              "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+              "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] sm:min-h-[44px] sm:min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
               viewMode === "list"
                 ? "bg-surface-dim text-brand shadow-sm ring-1 ring-border-subtle dark:text-brand-light"
                 : "text-muted hover:bg-surface-dim hover:text-primary"
@@ -119,7 +119,7 @@ export default function PostList({
           <button
             onClick={() => setViewMode("grid")}
             className={cn(
-              "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+              "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] sm:min-h-[44px] sm:min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
               viewMode === "grid"
                 ? "bg-surface-dim text-brand shadow-sm ring-1 ring-border-subtle dark:text-brand-light"
                 : "text-muted hover:bg-surface-dim hover:text-primary"

--- a/features/post/components/PostLocationSection.tsx
+++ b/features/post/components/PostLocationSection.tsx
@@ -6,10 +6,13 @@
  * History
  * Date        Author   Status    Description
  * 2026.04.21  임도헌   Created   PostForm의 위치 선택/변경 UI를 별도 섹션으로 분리
+ * 2026.06.18  임도헌   Modified  정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
+ * 2026.06.18  임도헌   Modified  게시글 관련 장소 문구로 도메인 표현 정리
  */
 
 import { MapPinIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import type { LocationData } from "@/features/map/types";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 
 interface PostLocationSectionProps {
   location: LocationData | null;
@@ -22,7 +25,7 @@ interface PostLocationSectionProps {
  * 게시글 위치 태그 섹션
  *
  * [역할]
- * - 모임 장소/후기 위치처럼 게시글에 연결되는 보조 위치 정보를 표시하고 수정/삭제 액션을 제공
+ * - 모임 장소/후기 위치처럼 게시글에 연결되는 선택 장소 정보를 표시하고 수정/삭제 액션을 제공
  * - 선택된 위치가 있을 때와 없을 때의 UI를 한곳에서 관리해 `PostForm` 본문 길이를 줄인다
  */
 export default function PostLocationSection({
@@ -35,9 +38,9 @@ export default function PostLocationSection({
     <div className="flex flex-col gap-2 pt-2">
       <label className="flex items-center gap-1 text-sm font-medium text-primary">
         <MapPinIcon className="size-4" />
-        장소 태그{" "}
+        게시글 관련 장소{" "}
         <span className="font-normal text-muted">
-          (모임 장소, 후기 위치 등)
+          (선택)
         </span>
       </label>
 
@@ -52,7 +55,7 @@ export default function PostLocationSection({
                 {location.locationName}
               </p>
               <p className="text-xs text-muted">
-                {location.region1} {location.region2} {location.region3}
+                {formatNormalizedRegion(location)}
               </p>
             </div>
           </div>
@@ -83,7 +86,7 @@ export default function PostLocationSection({
           disabled={isUploading}
         >
           <MapPinIcon className="size-5" />
-          <span className="text-sm">지도에서 위치 찾기</span>
+          <span className="text-sm">관련 장소 추가하기</span>
         </button>
       )}
     </div>

--- a/features/post/components/postCard/PostCardMeta.tsx
+++ b/features/post/components/postCard/PostCardMeta.tsx
@@ -17,6 +17,8 @@
  * 2026.03.26  임도헌   Modified  리스트 카드 모바일에서는 위치 정보를 분리 노출해 시간 표시와의 충돌을 완화
  * 2026.04.10  임도헌   Modified  post 타이포 정책에 맞춰 카드 메타 숫자/위치/시간 라벨을 text-xs 기준으로 통일
  * 2026.05.18  임도헌   Modified  좋아요 하트 강조 색상을 총 좋아요 수가 아닌 현재 사용자 좋아요 여부 기준으로 보정
+ * 2026.06.18  임도헌   Modified  명시 장소가 있는 게시글만 카드 위치 정보를 표시
+ * 2026.06.21  임도헌   Modified  명시 장소가 없으면 feedRegion 기준 작성 동네를 카드 메타에 표시
  */
 "use client";
 
@@ -29,6 +31,7 @@ import {
 import TimeAgo from "@/components/ui/TimeAgo";
 import { cn } from "@/lib/utils";
 import type { ViewMode } from "@/features/product/types";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 
 interface PostCardMetaProps {
   views: number;
@@ -36,18 +39,24 @@ interface PostCardMetaProps {
   isLiked?: boolean;
   comments: number;
   createdAt: string;
+  locationName?: string | null;
+  region1?: string | null;
   region2?: string | null;
   region3?: string | null;
+  feedRegion1?: string | null;
+  feedRegion2?: string | null;
+  feedRegion3?: string | null;
   viewMode?: ViewMode;
 }
 
 /**
- * 게시글의 통계 정보(좋아요, 댓글, 조회수, 장소)와 작성 시간을 표시
+ * 게시글의 통계 정보(좋아요, 댓글, 조회수, 관련 장소/작성 동네)와 작성 시간을 표시
  *
  * [레이아웃 최적화]
  * 1. 좌측 통계와 우측 시간/장소를 양 끝으로 배치 (justify-between)
  * 2. 그리드 모드에서는 공간 확보를 위해 장소 정보 숨김
  * 3. 위치 텍스트가 길어질 경우 말줄임(...) 처리 (min-w-0 flex-1)
+ * 4. 명시 장소가 없으면 feedRegion을 작성 동네 메타로 사용
  */
 export default function PostCardMeta({
   views,
@@ -55,13 +64,31 @@ export default function PostCardMeta({
   isLiked = false,
   comments,
   createdAt,
+  locationName,
+  region1,
   region2,
   region3,
+  feedRegion1,
+  feedRegion2,
+  feedRegion3,
   viewMode = "list",
 }: PostCardMetaProps) {
   const isGrid = viewMode === "grid";
-  // 동 단위까지만 표시 (예: "서초구 방배동")
-  const locationText = [region2, region3].filter(Boolean).join(" ");
+  // 명시 장소는 관련 장소로, 없을 때의 feedRegion은 전국 피드에서 출처를 보여주는 작성 동네로 표시한다.
+  const explicitLocationText = locationName
+    ? formatNormalizedRegion({ region1, region2, region3 })
+    : "";
+  const feedRegionText = formatNormalizedRegion({
+    region1: feedRegion1,
+    region2: feedRegion2,
+    region3: feedRegion3,
+  });
+  const locationText = explicitLocationText || feedRegionText;
+  const locationTitle = explicitLocationText
+    ? `관련 장소: ${explicitLocationText}`
+    : feedRegionText
+      ? `작성 동네: ${feedRegionText}`
+      : undefined;
   const showLocationInGrid = isGrid && !!locationText;
 
   const stats = (
@@ -92,7 +119,7 @@ export default function PostCardMeta({
         {showLocationInGrid && (
           <div
             className="flex min-w-0 items-center gap-1 text-xs"
-            title={locationText}
+            title={locationTitle}
           >
             <MapPinIcon className="size-3 shrink-0" />
             <span className="truncate">{locationText}</span>
@@ -115,7 +142,7 @@ export default function PostCardMeta({
       {locationText && (
         <div
           className="flex min-w-0 items-center gap-1 text-xs text-muted sm:hidden"
-          title={locationText}
+          title={locationTitle}
         >
           <MapPinIcon className="size-3 shrink-0" />
           <span className="truncate">{locationText}</span>
@@ -130,7 +157,7 @@ export default function PostCardMeta({
             <>
               <div
                 className="hidden min-w-0 items-center gap-0.5 sm:flex"
-                title={locationText}
+                title={locationTitle}
               >
                 <MapPinIcon className="size-3 shrink-0" />
                 <span className="truncate max-w-[120px] md:max-w-[180px]">

--- a/features/post/components/postCard/index.tsx
+++ b/features/post/components/postCard/index.tsx
@@ -25,6 +25,8 @@
  * 2026.04.20  임도헌   Modified  게시글 카드 포커스가 브라우저 기본 outline 대신 keyboard-only inset 링으로 보이도록 조정
  * 2026.05.03  임도헌   Modified  게시글 목록 카드에 연결 보드게임 요약 배지 표시
  * 2026.05.18  임도헌   Modified  게시글 카드 좋아요 하트 색상을 현재 사용자 좋아요 여부 기준으로 전달
+ * 2026.06.18  임도헌   Modified  명시 장소가 있는 게시글만 카드 위치를 표시하도록 locationName 전달
+ * 2026.06.21  임도헌   Modified  장소 미지정 게시글도 feedRegion 작성 동네를 목록 메타에 노출
  * ===============================================================================================
  * PostCard (게시글 카드) 컴포넌트를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * 각 컴포넌트는 게시글 정보를 보여주는 카드에서 특정 부분의 렌더링을 담당:
@@ -132,8 +134,13 @@ export default function PostCard({
             isLiked={Boolean(post.isLiked)}
             comments={post._count.comments}
             createdAt={post.created_at.toString()}
+            locationName={post.locationName}
+            region1={post.region1}
             region2={post.region2}
             region3={post.region3}
+            feedRegion1={post.feedRegion1}
+            feedRegion2={post.feedRegion2}
+            feedRegion3={post.feedRegion3}
             viewMode={viewMode}
           />
         </div>

--- a/features/post/components/postsDetail/PostDetailLocationSection.tsx
+++ b/features/post/components/postsDetail/PostDetailLocationSection.tsx
@@ -11,6 +11,8 @@
  * 2026.04.14  임도헌   Modified  자동 로드 정책에 맞춰 미리보기 카드를 정보 중심의 간소한 로딩 셸로 정리
  * 2026.04.26  임도헌   Modified  지도 열기 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  * 2026.04.26  임도헌   Modified  위치 섹션 제목 아이콘을 위치 카드 아이콘과 같은 다크모드 톤으로 정리
+ * 2026.06.18  임도헌   Modified  정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
+ * 2026.06.18  임도헌   Modified  게시글 관련 장소 문구로 도메인 표현 정리
  */
 "use client";
 
@@ -20,6 +22,7 @@ import {
   ArrowTopRightOnSquareIcon,
   MapPinIcon,
 } from "@heroicons/react/24/outline";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 
 const loadStaticMap = () => import("@/features/map/components/StaticMap");
 
@@ -148,7 +151,7 @@ export default function PostDetailLocationSection({
 
   if (!hasLocationData) return null;
 
-  const regionString = [region1, region2, region3].filter(Boolean).join(" ");
+  const regionString = formatNormalizedRegion({ region1, region2, region3 });
   const mapLink = `https://map.kakao.com/link/map/${encodeURIComponent(
     locationName
   )},${latitude},${longitude}`;
@@ -160,7 +163,7 @@ export default function PostDetailLocationSection({
     >
       <h2 className="mb-4 flex items-center gap-2 text-sm font-bold text-primary">
         <MapPinIcon className="size-4 text-brand dark:text-brand-light" />
-        모임 및 거래 희망 장소
+        게시글 관련 장소
       </h2>
 
       {shouldLoadMap ? (

--- a/features/post/components/postsDetail/PostDetailMeta.tsx
+++ b/features/post/components/postsDetail/PostDetailMeta.tsx
@@ -11,14 +11,21 @@
  * 2026.05.18  임도헌   Modified  상세 메타에 댓글 수 표시 및 post stats 캐시 연동
  * 2026.05.18  임도헌   Modified  상세 통계 아이콘을 목록 카드와 같은 solid 문법으로 통일
  * 2026.05.26  임도헌   Modified  initialData 기반 stats query에 local queryFn을 부여해 refetch 경고 방지
+ * 2026.06.17  임도헌   Modified  좋아요 상태 캐시 분리를 위해 viewerId 전달
+ * 2026.06.21  임도헌   Modified  관련 장소 또는 작성 동네 메타를 상세 화면에 표시
  */
 "use client";
 
 import PostLikeButton from "@/features/post/components/PostLikeButton";
-import { ChatBubbleLeftIcon, EyeIcon } from "@heroicons/react/24/solid";
+import {
+  ChatBubbleLeftIcon,
+  EyeIcon,
+  MapPinIcon,
+} from "@heroicons/react/24/solid";
 import TimeAgo from "@/components/ui/TimeAgo";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 
 interface PostDetailMetaProps {
   postId: number;
@@ -27,12 +34,20 @@ interface PostDetailMetaProps {
   views: number;
   commentCount: number;
   createdAt: string;
+  viewerId?: number | null;
+  locationName?: string | null;
+  region1?: string | null;
+  region2?: string | null;
+  region3?: string | null;
+  feedRegion1?: string | null;
+  feedRegion2?: string | null;
+  feedRegion3?: string | null;
 }
 
 /**
  * 게시글 하단의 메타 정보 영역
  * - 좌측: 좋아요 버튼 (PostLikeButton)
- * - 우측: 조회수, 댓글 수, 작성 시간 (TimeAgo)
+ * - 우측: 관련 장소/작성 동네, 조회수, 댓글 수, 작성 시간 (TimeAgo)
  * - 댓글 수는 댓글 작성/삭제 mutation이 갱신하는 post stats 캐시 기준으로 표시
  */
 export default function PostDetailMeta({
@@ -42,6 +57,14 @@ export default function PostDetailMeta({
   views,
   commentCount,
   createdAt,
+  viewerId = null,
+  locationName,
+  region1,
+  region2,
+  region3,
+  feedRegion1,
+  feedRegion2,
+  feedRegion3,
 }: PostDetailMetaProps) {
   const queryClient = useQueryClient();
   const statsQueryKey = queryKeys.posts.stats(postId);
@@ -55,22 +78,50 @@ export default function PostDetailMeta({
     staleTime: Infinity,
     enabled: false,
   });
+  const explicitLocationText = locationName
+    ? formatNormalizedRegion({ region1, region2, region3 })
+    : "";
+  const feedRegionText = formatNormalizedRegion({
+    region1: feedRegion1,
+    region2: feedRegion2,
+    region3: feedRegion3,
+  });
+  const locationText = explicitLocationText || feedRegionText;
+  const locationLabel = explicitLocationText ? "관련 장소" : "작성 동네";
 
   return (
-    <div className="flex items-center justify-between">
-      <PostLikeButton isLiked={isLiked} likeCount={likeCount} postId={postId} />
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <PostLikeButton
+        isLiked={isLiked}
+        likeCount={likeCount}
+        postId={postId}
+        viewerId={viewerId}
+      />
 
-      <div className="flex items-center gap-3 text-xs text-muted">
-        <div className="flex items-center gap-1">
-          <EyeIcon className="size-4" />
-          <span>{views.toLocaleString()}</span>
+      <div className="flex flex-col gap-2 text-xs text-muted sm:items-end">
+        {locationText && (
+          <div
+            className="flex max-w-full items-center gap-1"
+            title={`${locationLabel}: ${locationText}`}
+          >
+            <MapPinIcon className="size-4 shrink-0" />
+            <span className="shrink-0 font-medium">{locationLabel}</span>
+            <span className="truncate">{locationText}</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1">
+            <EyeIcon className="size-4" />
+            <span>{views.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <ChatBubbleLeftIcon className="size-4" />
+            <span>{stats.commentCount.toLocaleString()}</span>
+          </div>
+          <span className="text-border">|</span>
+          <TimeAgo date={createdAt} />
         </div>
-        <div className="flex items-center gap-1">
-          <ChatBubbleLeftIcon className="size-4" />
-          <span>{stats.commentCount.toLocaleString()}</span>
-        </div>
-        <span className="text-border">|</span>
-        <TimeAgo date={createdAt} />
       </div>
     </div>
   );

--- a/features/post/components/postsDetail/index.tsx
+++ b/features/post/components/postsDetail/index.tsx
@@ -34,6 +34,8 @@
  * 2026.05.03  임도헌   Modified  게시글 상세에 연결된 보드게임 카탈로그 칩 노출
  * 2026.05.04  임도헌   Modified  게시글 상세의 연결 보드게임을 도감 이동 카드로 강조
  * 2026.05.18  임도헌   Modified  상세 메타에 댓글 수를 표시하도록 PostDetailMeta에 commentCount 전달
+ * 2026.06.17  임도헌   Modified  게시글 좋아요 상태 캐시 분리를 위해 viewerId를 메타로 전달
+ * 2026.06.21  임도헌   Modified  상세 메타에 관련 장소 또는 작성 동네 정보를 전달
  * ===============================================================================================
  * PostDetail (게시글 상세) 페이지를 구성하는 UI 요소 모음
  *
@@ -71,6 +73,7 @@ interface PostDetailProps {
   views: number;
   likeCount: number;
   isLiked: boolean;
+  viewerId?: number | null;
   returnTo?: string;
   hasExplicitReturnTo?: boolean;
 }
@@ -92,6 +95,7 @@ export default function PostDetail({
   views,
   likeCount,
   isLiked,
+  viewerId = null,
   returnTo,
   hasExplicitReturnTo = false,
 }: PostDetailProps) {
@@ -165,6 +169,14 @@ export default function PostDetail({
             views={views}
             commentCount={post._count.comments}
             createdAt={post.created_at?.toString() ?? ""}
+            viewerId={viewerId}
+            locationName={post.locationName ?? null}
+            region1={post.region1 ?? null}
+            region2={post.region2 ?? null}
+            region3={post.region3 ?? null}
+            feedRegion1={post.feedRegion1 ?? null}
+            feedRegion2={post.feedRegion2 ?? null}
+            feedRegion3={post.feedRegion3 ?? null}
           />
         </div>
 

--- a/features/post/hooks/usePostPagination.ts
+++ b/features/post/hooks/usePostPagination.ts
@@ -21,6 +21,7 @@
  * 2026.03.14  임도헌   Modified  첫 페이지 totalCount를 노출해 무한스크롤 중에도 총 게시글 수를 고정 표시
  * 2026.04.17  임도헌   Modified  Suspense 무한스크롤 훅의 캐시 분리/반환 책임이 주석에서 바로 드러나도록 설명 보강
  * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
+ * 2026.06.18  임도헌   Modified  게시글 피드 지역 스코프를 queryKeyExtra로 분리한다는 설명으로 최신화
  */
 "use client";
 
@@ -99,7 +100,7 @@ async function fetchPostsPage(url: string): Promise<PostsPage> {
  *
  * [기능]
  * - `searchParams`를 queryKey에 반영해 게시판/카테고리/검색어 조합별 캐시를 분리
- * - `queryKeyExtra`로 같은 검색 조건 안에서도 currentRange 같은 보조 범위를 추가 분리
+ * - `queryKeyExtra`로 같은 검색 조건 안에서도 피드 지역/범위 같은 보조 스코프를 추가 분리
  * - `useSuspenseInfiniteQuery`와 게시글 목록 Route Handler를 연결해 Client queryFn의 Server Action 직접 호출을 피하고 다음 페이지를 커서 기반으로 조회
  * - 평탄화된 posts 배열과 첫 페이지 totalCount를 함께 반환해 목록/헤더가 같은 데이터를 공유하도록 구성
  *

--- a/features/post/selects.ts
+++ b/features/post/selects.ts
@@ -8,6 +8,7 @@
  * 2026.04.02  임도헌   Created   constants.ts에서 게시글 목록/상세 조회용 Prisma select 분리
  * 2026.05.03  임도헌   Modified  게시글 목록 카드에 연결 보드게임 칩을 표시할 수 있도록 보드게임 locale select 추가
  * 2026.05.08  임도헌   Modified  보드게임 relation select를 features/boardgame/selects.ts 공용 상수로 교체
+ * 2026.06.18  임도헌   Modified  동네 피드 노출 기준 feedRegion 필드 조회 추가
  */
 
 import { Prisma } from "@/generated/prisma/client";
@@ -67,6 +68,9 @@ export const POST_SELECT = {
   region1: true,
   region2: true,
   region3: true,
+  feedRegion1: true,
+  feedRegion2: true,
+  feedRegion3: true,
   _count: {
     select: {
       comments: true,

--- a/features/post/service/comment.ts
+++ b/features/post/service/comment.ts
@@ -18,15 +18,22 @@
  * 2026.03.04  임도헌   Modified  unstable_cache 래퍼 제거 및 단일 조회 함수(getPostCommentsList)로 통합
  * 2026.03.05  임도헌   Modified  주석 최신화
  * 2026.03.07  임도헌   Modified  댓글 삭제에도 정지 유저 가드 적용 및 실패 문구 구체화
+ * 2026.06.21  임도헌   Modified  게시글 댓글 작성 시 작성자에게 인앱/푸시 알림 전송 추가
  */
 import "server-only";
 import db from "@/lib/db";
+import { supabase } from "@/lib/supabase";
 import { badgeChecks } from "@/features/user/service/badge";
 import {
   getBlockedUserIds,
   checkBlockRelation,
 } from "@/features/user/service/block";
 import { validateUserStatus } from "@/features/user/service/admin";
+import {
+  canSendPushForType,
+  isNotificationTypeEnabled,
+} from "@/features/notification/utils/policy";
+import { sendPushNotification } from "@/features/notification/service/sender";
 import { Prisma } from "@/generated/prisma/client";
 import type { PostComment } from "@/features/post/types";
 import type { ServiceResult } from "@/lib/types";
@@ -92,6 +99,94 @@ export async function getPostCommentsList(
 /*                                Write Logic                                 */
 /* -------------------------------------------------------------------------- */
 
+function normalizeNotificationText(text: string) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+async function notifyPostOwnerOnComment({
+  postId,
+  postTitle,
+  ownerId,
+  commenterId,
+  commenterName,
+  commenterAvatar,
+  payload,
+}: {
+  postId: number;
+  postTitle: string;
+  ownerId: number;
+  commenterId: number;
+  commenterName: string;
+  commenterAvatar: string | null;
+  payload: string;
+}) {
+  if (ownerId === commenterId) return;
+
+  try {
+    const prefs = await db.notificationPreferences.findUnique({
+      where: { userId: ownerId },
+    });
+
+    if (!isNotificationTypeEnabled(prefs, "SYSTEM")) return;
+
+    const title = "게시글에 새 댓글이 달렸습니다";
+    const body = `${commenterName}님이 '${postTitle}' 글에 댓글을 남겼습니다: ${normalizeNotificationText(
+      payload
+    )}`;
+    const link = `/posts/${postId}`;
+    const image = commenterAvatar ? `${commenterAvatar}/avatar` : undefined;
+
+    const notification = await db.notification.create({
+      data: {
+        userId: ownerId,
+        title,
+        body,
+        type: "SYSTEM",
+        link,
+        image,
+        isPushSent: false,
+      },
+    });
+
+    await supabase.channel(`user-${ownerId}-notifications`).send({
+      type: "broadcast",
+      event: "notification",
+      payload: {
+        id: notification.id,
+        userId: ownerId,
+        title: notification.title,
+        body: notification.body,
+        link: notification.link,
+        type: notification.type,
+        image: notification.image,
+        created_at: notification.created_at,
+      },
+    });
+
+    if (canSendPushForType(prefs, "SYSTEM")) {
+      const pushRes = await sendPushNotification({
+        targetUserId: ownerId,
+        title,
+        message: body,
+        url: link,
+        type: "SYSTEM",
+        image,
+        tag: `post-comment-${postId}`,
+        renotify: true,
+      });
+
+      if (pushRes.success && (pushRes.data?.sent ?? 0) > 0) {
+        await db.notification.update({
+          where: { id: notification.id },
+          data: { isPushSent: true, sentAt: new Date() },
+        });
+      }
+    }
+  } catch (error) {
+    console.warn("[PostComment] Notification failed:", error);
+  }
+}
+
 /**
  * 게시글 댓글 생성 로직
  *
@@ -119,7 +214,7 @@ export async function createComment(
     // 양방향 차단 관계가 있으면 댓글 상호작용 자체를 막음
     const post = await db.post.findUnique({
       where: { id: postId },
-      select: { userId: true },
+      select: { userId: true, title: true },
     });
     if (!post) return { success: false, error: "게시글을 찾을 수 없습니다." };
 
@@ -138,12 +233,26 @@ export async function createComment(
         postId,
         userId,
       },
+      select: {
+        id: true,
+        payload: true,
+        user: { select: { username: true, avatar: true } },
+      },
     });
 
     // 댓글 작성 관련 뱃지 체크
     await Promise.allSettled([
       badgeChecks.onCommentCreate(userId),
       badgeChecks.onEventParticipation(userId),
+      notifyPostOwnerOnComment({
+        postId,
+        postTitle: post.title,
+        ownerId: post.userId,
+        commenterId: userId,
+        commenterName: comment.user.username,
+        commenterAvatar: comment.user.avatar,
+        payload: comment.payload,
+      }),
     ]);
 
     return { success: true, data: { id: comment.id } };

--- a/features/post/service/post.ts
+++ b/features/post/service/post.ts
@@ -42,6 +42,7 @@
  * 2026.05.16  임도헌   Modified  수정 액션의 기존 첨부 동영상 확인 쿼리를 service 헬퍼로 분리
  * 2026.05.18  임도헌   Modified  게시글 목록 카드 하트 색상을 현재 사용자 좋아요 여부 기준으로 표시하도록 isLiked 매핑 추가
  * 2026.05.23  임도헌   Modified  삭제된 게시글 알림 링크/이미지 정리 및 삭제 cursor 목록 페이지네이션 실패 방어
+ * 2026.06.18  임도헌   Modified  게시글 장소 지역과 동네 피드 노출 지역(feedRegion)을 분리
  */
 import "server-only";
 
@@ -72,6 +73,36 @@ const TAKE = POSTS_PAGE_TAKE;
 type PostListRow = Prisma.PostGetPayload<{
   select: typeof POST_SELECT;
 }>;
+
+type RegionSource = {
+  region1?: string | null;
+  region2?: string | null;
+  region3?: string | null;
+};
+
+type FeedRegionWhere = Partial<
+  Record<"feedRegion1" | "feedRegion2" | "feedRegion3", string>
+>;
+
+function toFeedRegionPayload(source: RegionSource | null | undefined) {
+  return {
+    feedRegion1: source?.region1 ?? null,
+    feedRegion2: source?.region2 ?? null,
+    feedRegion3: source?.region3 ?? null,
+  };
+}
+
+function buildPostFeedRegionWhere(user: RegionSource & {
+  regionRange: Parameters<typeof buildRegionWhere>[0]["regionRange"];
+}): FeedRegionWhere {
+  const regionWhere = buildRegionWhere(user);
+
+  return {
+    ...(regionWhere.region1 ? { feedRegion1: regionWhere.region1 } : {}),
+    ...(regionWhere.region2 ? { feedRegion2: regionWhere.region2 } : {}),
+    ...(regionWhere.region3 ? { feedRegion3: regionWhere.region3 } : {}),
+  };
+}
 
 /**
  * 사용자가 소유한 게시글에 연결된 동영상 존재 여부 확인
@@ -401,8 +432,8 @@ async function syncPostBlocksFromDraft(
  *
  * [데이터 가공 전략]
  * - 커뮤니티 특성에 따라 지역 필터 적용 여부가 달라짐
- * - 지역성 카테고리 (CREW, FREE) : 유저의 DB 설정(RegionRange)에 따라 지역 필터를 적용
- * - 정보성 카테고리 (LOG, MAP, RECOMMEND, COMPASS) : 지역 필터 없이 전국(ALL) 단위로 조회
+ * - 사용자의 DB 설정(RegionRange)에 따라 feedRegion 기준 지역 필터 적용
+ * - feedRegion은 명시 장소가 있으면 해당 장소, 없으면 작성자 동네를 기준으로 저장
  *  - 정지 유저(bannedAt) 콘텐츠 은닉 필터 포함
  *
  * @param {PostSearchParams | undefined} params - 검색 조건
@@ -422,7 +453,7 @@ async function buildWhere(
     select: { region1: true, region2: true, region3: true, regionRange: true },
   });
 
-  const regionCondition = user ? buildRegionWhere(user) : {};
+  const regionCondition = user ? buildPostFeedRegionWhere(user) : {};
 
   return {
     AND: [
@@ -611,6 +642,11 @@ export async function createPost(
     const status = await validateUserStatus(userId);
     if (!status.success) return status;
 
+    const authorRegion = await db.user.findUnique({
+      where: { id: userId },
+      select: { region1: true, region2: true, region3: true },
+    });
+    const feedRegion = toFeedRegionPayload(data.location ?? authorRegion);
     const nextTags = Array.from(new Set(data.tags));
     // 보드게임 연결은 게시글 분류/태그와 독립적인 선택 관계라 join table에만 저장
     const boardGameIds = Array.from(new Set(data.boardGameIds ?? []));
@@ -631,6 +667,7 @@ export async function createPost(
             region2: data.location.region2,
             region3: data.location.region3,
           }),
+          ...feedRegion,
         },
       });
 
@@ -743,6 +780,10 @@ export async function updatePost(
     if (existing.userId !== userId)
       return { success: false, error: "권한이 없습니다." };
 
+    const authorRegion = await db.user.findUnique({
+      where: { id: userId },
+      select: { region1: true, region2: true, region3: true },
+    });
     const prevTags = new Set(existing.tags.map((tag) => tag.name));
     const nextTags = Array.from(new Set(data.tags));
     // 수정 폼의 현재 보드게임 선택값을 전체 교체 기준으로 정규화
@@ -760,6 +801,7 @@ export async function updatePost(
           region1: data.location.region1,
           region2: data.location.region2,
           region3: data.location.region3,
+          ...toFeedRegionPayload(data.location),
         }
       : {
           latitude: null,
@@ -768,6 +810,7 @@ export async function updatePost(
           region1: null,
           region2: null,
           region3: null,
+          ...toFeedRegionPayload(authorRegion),
         };
 
     // 수정 트랜잭션 실행

--- a/features/post/types.ts
+++ b/features/post/types.ts
@@ -22,6 +22,7 @@
  * 2026.05.03  임도헌   Modified  보드게임 카탈로그 연결 DTO 및 상세 타입 추가
  * 2026.05.03  임도헌   Modified  게시글 목록 카드에서 연결 보드게임 요약을 표시할 수 있도록 타입 설명 보강
  * 2026.05.18  임도헌   Modified  게시글 목록 카드 하트 색상 기준 분리를 위한 isLiked 필드 추가
+ * 2026.06.18  임도헌   Modified  동네 피드 노출 기준 feedRegion 필드 추가
  */
 
 import { LocationData } from "@/features/map/types";
@@ -182,6 +183,9 @@ export interface PostDetail extends BasePost {
   region1?: string | null;
   region2?: string | null;
   region3?: string | null;
+  feedRegion1?: string | null;
+  feedRegion2?: string | null;
+  feedRegion3?: string | null;
   board_games?: Array<{
     boardGame: BoardGameRelationOption;
   }>;

--- a/features/product/components/MyLikesList.tsx
+++ b/features/product/components/MyLikesList.tsx
@@ -13,6 +13,7 @@
  * 2026.04.17  임도헌   Modified  찜 목록의 무한 스크롤/빠른 해제/상단 카드 우선 로드 책임 설명 보강
  * 2026.04.17  임도헌   Modified  Lighthouse 대응: 첫 카드만 priority 적용하고 빈 상태 heading/order 정리
  * 2026.04.24  임도헌   Modified  찜 목록 제품 상세 진입 시 현재 목록 경로를 returnTo로 전달
+ * 2026.06.17  임도헌   Modified  빠른 찜 해제 버튼의 좋아요 캐시 분리를 위해 viewerId 전달
  */
 "use client";
 
@@ -100,6 +101,7 @@ export default function MyLikesList({ userId }: { userId: number }) {
             isPriority={index === 0}
             showQuickUnlike
             returnTo={returnTo}
+            viewerId={userId}
           />
         ))}
       </div>

--- a/features/product/components/MySalesProductItem.tsx
+++ b/features/product/components/MySalesProductItem.tsx
@@ -51,6 +51,9 @@
  * 2026.05.03  임도헌   Modified  프로필 판매 카드에 연결 보드게임 배지 표시 추가
  * 2026.05.05  임도헌   Modified  판매 내역 카드 helper와 상태/리뷰 핸들러 JSDoc 보강
  * 2026.05.18  임도헌   Modified  판매 완료 탭의 시간 표기를 등록일이 아닌 판매 완료 시점 기준으로 보정
+ * 2026.06.18  임도헌   Modified  공용 거래 상태 배지로 예약/판매완료 색상 기준 통일
+ * 2026.06.18  임도헌   Modified  판매 내역 하단 액션의 주요/일반/위험 톤 분리
+ * 2026.06.21  임도헌   Modified  판매 내역 위험 액션을 공용 danger 토큰 기준으로 통일해 다크모드 대비 보정
  */
 
 "use client";
@@ -90,6 +93,7 @@ import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import { toProductImagePublicUrl } from "@/features/product/utils/image";
 import { removeRecentViewedProduct } from "@/features/product/utils/recentViewed";
 import ProductCardBoardGameBadge from "@/features/product/components/productCard/ProductCardBoardGameBadge";
+import ProductTradeStatusBadge from "@/features/product/components/ProductTradeStatusBadge";
 import type {
   MySalesListItem,
   ProductStatus,
@@ -143,24 +147,19 @@ type ProductStatusActionResult = {
 
 /**
  * 판매 탭 상태의 카드 상단 pill 표시
+ * 예약/판매완료는 공개 상품 카드와 같은 공용 거래 상태 배지를 사용한다.
  *
  * @param props - 현재 판매 상태 tab
  * @returns 상태 pill 또는 null
  */
 function StatusPill({ tab }: { tab?: ProductStatus }) {
   if (!tab) return null;
-  const styles = {
-    selling: "bg-brand text-white",
-    reserved: "bg-accent text-accent-foreground",
-    sold: "bg-neutral-500 text-white",
-  };
+  if (tab !== "selling") {
+    return <ProductTradeStatusBadge status={tab} className="px-2" />;
+  }
+
   return (
-    <span
-      className={cn(
-        "rounded px-2 py-0.5 text-xs font-bold shadow-sm",
-        styles[tab]
-      )}
-    >
+    <span className="rounded bg-brand px-2 py-0.5 text-xs font-bold text-white shadow-sm">
       {PRODUCT_STATUS_LABEL[tab]}
     </span>
   );
@@ -177,6 +176,29 @@ function Chip({ children }: { children: React.ReactNode }) {
     <span className="inline-flex items-center rounded-lg border border-border bg-surface-dim px-2.5 py-1 text-xs font-medium leading-none text-primary shadow-sm">
       {children}
     </span>
+  );
+}
+
+type SalesActionTone = "primary" | "neutral" | "danger";
+
+const salesActionToneClass: Record<SalesActionTone, string> = {
+  primary:
+    "text-brand hover:bg-brand/5 dark:text-primary dark:hover:bg-brand-light/10",
+  neutral: "text-muted hover:bg-surface-dim hover:text-primary",
+  danger:
+    "text-danger hover:bg-danger/5 hover:text-danger dark:hover:bg-danger/10",
+};
+
+function getSalesActionClass(
+  tone: SalesActionTone,
+  isGrid: boolean,
+  extraClass?: string
+) {
+  return cn(
+    "focus-ring-strong-inset font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+    salesActionToneClass[tone],
+    isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm",
+    extraClass
   );
 }
 
@@ -701,10 +723,7 @@ export default function MySalesProductItem({
             <button
               onClick={() => toggleModal("reservation", true)}
               disabled={opLoading}
-              className={cn(
-                "focus-ring-strong-inset font-medium text-brand dark:text-brand-light hover:bg-brand/5 dark:hover:bg-brand-light/10 transition-colors disabled:opacity-50",
-                isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
-              )}
+              className={getSalesActionClass("primary", isGrid)}
             >
               예약자 선택
             </button>
@@ -715,20 +734,14 @@ export default function MySalesProductItem({
             <button
               onClick={handleUpdateToSelling}
               disabled={opLoading}
-              className={cn(
-                "focus-ring-strong-inset font-medium text-muted hover:text-primary hover:bg-surface-dim transition-colors",
-                isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
-              )}
+              className={getSalesActionClass("danger", isGrid)}
             >
               예약 취소
             </button>
             <button
               onClick={handleUpdateToSold}
               disabled={opLoading}
-              className={cn(
-                "focus-ring-strong-inset font-medium text-brand dark:text-brand-light hover:bg-brand/5 dark:hover:bg-brand-light/10 transition-colors",
-                isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
-              )}
+              className={getSalesActionClass("primary", isGrid)}
             >
               판매 완료
             </button>
@@ -739,10 +752,7 @@ export default function MySalesProductItem({
             {sellerReviews.length > 0 ? (
               <button
                 onClick={() => toggleModal("reviewSeller", true)}
-                className={cn(
-                  "focus-ring-strong-inset font-medium text-primary hover:bg-surface-dim transition-colors",
-                  isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
-                )}
+                className={getSalesActionClass("neutral", isGrid)}
               >
                 내 리뷰 보기
               </button>
@@ -750,10 +760,7 @@ export default function MySalesProductItem({
               <button
                 onClick={() => toggleModal("reviewCreate", true)}
                 disabled={reviewLoading}
-                className={cn(
-                  "focus-ring-strong-inset font-medium text-brand dark:text-brand-light hover:bg-brand/5 dark:hover:bg-brand-light/10 transition-colors disabled:opacity-50",
-                  isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
-                )}
+                className={getSalesActionClass("primary", isGrid)}
               >
                 {reviewLoading ? "처리 중..." : "리뷰 작성"}
               </button>
@@ -761,32 +768,26 @@ export default function MySalesProductItem({
             <button
               onClick={handleUpdateToSelling}
               disabled={opLoading}
-              className={cn(
-                "focus-ring-strong-inset font-medium text-muted hover:text-primary hover:bg-surface-dim transition-colors",
-                isSoldGrid
-                  ? "border-r border-border-subtle py-2.5 text-xs"
-                  : isGrid
-                    ? "py-2.5 text-xs"
-                    : "py-3 text-xs sm:text-sm"
+              className={getSalesActionClass(
+                "danger",
+                isGrid,
+                isSoldGrid ? "border-r border-border-subtle" : undefined
               )}
             >
               {isGrid ? "판매 중으로" : "판매 중으로 변경"}
             </button>
             <button
               onClick={() => toggleModal("reviewBuyer", true)}
-              className={cn(
-                "focus-ring-strong-inset font-medium text-muted hover:text-primary hover:bg-surface-dim transition-colors",
-                isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
-              )}
+              className={getSalesActionClass("neutral", isGrid)}
             >
               구매자 리뷰
             </button>
             <button
               onClick={handleToggleHidden}
               disabled={opLoading}
-              className={cn(
-                "focus-ring-strong-inset font-medium text-muted hover:text-primary hover:bg-surface-dim transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-                isGrid ? "py-2.5 text-xs" : "py-3 text-xs sm:text-sm"
+              className={getSalesActionClass(
+                product.hidden_at ? "neutral" : "danger",
+                isGrid
               )}
             >
               {product.hidden_at ? "숨김 해제" : "숨기기"}

--- a/features/product/components/MySalesProductList.tsx
+++ b/features/product/components/MySalesProductList.tsx
@@ -30,6 +30,7 @@
  * 2026.04.19  임도헌   Modified  판매 탭 active 대비와 라이트/다크 선택 상태를 현재 UI 기준으로 재정리
  * 2026.05.16  임도헌   Modified  판매 탭 캐시 이동 payload와 무한스크롤 캐시 shape 타입 정리
  * 2026.05.30  임도헌   Modified  판매 내역 뷰 토글을 제품 목록 토글 톤과 통일
+ * 2026.06.21  임도헌   Modified  판매 내역 뷰 토글 모바일 크기를 목록 공통 36px 기준으로 정렬
  */
 
 "use client";
@@ -255,7 +256,7 @@ export default function MySalesProductList({
             onClick={() => setViewMode("list")}
             aria-label="리스트 보기"
             className={cn(
-              "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+              "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow] sm:min-h-[44px] sm:min-w-[44px]",
               viewMode === "list"
                 ? "bg-surface-dim text-brand shadow-sm ring-1 ring-border-subtle dark:text-brand-light"
                 : "text-muted hover:bg-surface-dim hover:text-primary"
@@ -267,7 +268,7 @@ export default function MySalesProductList({
             onClick={() => setViewMode("grid")}
             aria-label="그리드 보기"
             className={cn(
-              "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+              "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow] sm:min-h-[44px] sm:min-w-[44px]",
               viewMode === "grid"
                 ? "bg-surface-dim text-brand shadow-sm ring-1 ring-border-subtle dark:text-brand-light"
                 : "text-muted hover:bg-surface-dim hover:text-primary"

--- a/features/product/components/ProductCardSkeleton.tsx
+++ b/features/product/components/ProductCardSkeleton.tsx
@@ -12,6 +12,7 @@
  * 2026.05.09  임도헌   Modified  보드게임 배지와 taxonomy가 추가된 상품 카드 정보 구조 반영
  * 2026.06.01  임도헌   Modified  상품 카드 하단 메타 정렬 변경에 맞춰 grid 스켈레톤 여백 정리
  * 2026.06.04  임도헌   Modified  데모 상품 리스트 카드 높이에 맞춰 스켈레톤 밀도 보정
+ * 2026.06.21  임도헌   Modified  리스트 카드 이미지 폭 변경에 맞춰 스켈레톤 썸네일 폭 정렬
  */
 "use client";
 
@@ -54,7 +55,7 @@ export default function ProductCardSkeleton({
           "shrink-0 overflow-hidden bg-surface-dim",
           isGrid
             ? "aspect-[3/2] w-full sm:aspect-[4/3]"
-            : "w-24 self-stretch sm:w-36"
+            : "w-28 self-stretch sm:w-36"
         )}
       >
         <Skeleton className="h-full w-full" />
@@ -78,10 +79,7 @@ export default function ProductCardSkeleton({
         </div>
 
         <div
-          className={cn(
-            "flex flex-col",
-            isGrid ? "mt-auto gap-1.5" : "gap-2"
-          )}
+          className={cn("flex flex-col", isGrid ? "mt-auto gap-1.5" : "gap-2")}
         >
           <div className="flex min-w-0 items-center gap-1.5">
             <Skeleton className="h-6 w-20 rounded-full" />

--- a/features/product/components/ProductDesktopHeader.tsx
+++ b/features/product/components/ProductDesktopHeader.tsx
@@ -19,6 +19,8 @@
  * 2026.04.17  임도헌   Modified  데스크톱 제품 헤더의 상품 검색 버튼 스타일을 정리
  * 2026.04.20  임도헌   Modified  다크 모드에서도 상품 검색 트리거 포커스 톤이 다른 헤더 액션과 일관되도록 공용 포커스 유틸을 적용
  * 2026.04.20  임도헌   Modified  앱 셸(sm) 기준과 데스크톱 헤더 노출 기준을 맞춰 640~767px 구간 레이아웃 mismatch 정리
+ * 2026.06.14  임도헌   Modified  긴 필터 요약을 말줄임 대신 가로 스크롤로 확인할 수 있게 조정
+ * 2026.06.15  임도헌   Modified  검색어만 적용된 상태도 요약 X 버튼으로 바로 해제할 수 있게 조정
  */
 "use client";
 
@@ -87,8 +89,10 @@ export default function ProductDesktopHeader({
     setIsSearchOpen,
     handleSearch,
     filterSummary,
+    hasActiveKeyword,
     hasActiveFilters,
     resetFilterParams,
+    clearKeyword,
     localSearchHistory,
     removeHistory,
     clearHistory,
@@ -98,6 +102,11 @@ export default function ProductDesktopHeader({
     keyword,
     searchHistory,
   });
+  const showSummaryReset = hasActiveFilters || hasActiveKeyword;
+  const handleSummaryReset = hasActiveFilters ? resetFilterParams : clearKeyword;
+  const summaryResetLabel = hasActiveFilters
+    ? "필터 초기화 (검색어 유지)"
+    : "검색어 초기화";
 
   return (
     <>
@@ -144,14 +153,16 @@ export default function ProductDesktopHeader({
 
             <div className="min-w-0 flex-1">
               <div className="flex items-center rounded-2xl border border-border-subtle bg-surface px-4 py-2.5">
-                <p className="min-w-0 flex-1 truncate text-sm font-medium text-muted/90">
-                  {filterSummary}
-                </p>
-                {hasActiveFilters && (
+                <div className="min-w-0 flex-1 overflow-x-auto scrollbar-hide">
+                  <p className="w-max whitespace-nowrap text-sm font-medium text-muted/90">
+                    {filterSummary}
+                  </p>
+                </div>
+                {showSummaryReset && (
                   <button
                     type="button"
-                    onClick={resetFilterParams}
-                    aria-label="필터 초기화 (검색어 유지)"
+                    onClick={handleSummaryReset}
+                    aria-label={summaryResetLabel}
                     className="focus-ring-soft ml-2 shrink-0 rounded-full p-0.5 text-muted transition-colors hover:bg-surface-dim hover:text-primary"
                   >
                     <XMarkIcon className="size-4" />

--- a/features/product/components/ProductEmptyState.tsx
+++ b/features/product/components/ProductEmptyState.tsx
@@ -19,6 +19,8 @@
  * 2026.03.25  임도헌   Modified  검색 결과 없음 상태에서 키워드 알림 카드를 메인 empty state보다 더 보조적으로 보이게 polish
  * 2026.03.28  임도헌   Modified  제품 검색 결과 없음 상태에서 검색어를 제목 대신 보조 문구로 다시 노출해 게시글과 피드백 문법을 통일
  * 2026.04.28  임도헌   Modified  상품 검색 결과 없음 상태에서 보드게임 도감 탐색 진입점 추가
+ * 2026.06.15  임도헌   Modified  상세조건 0건 상태를 순수 검색 0건과 구분해 안내
+ * 2026.06.16  임도헌   Modified  키워드가 있는 조건 0건 상태에서도 키워드 알림 CTA를 유지
  */
 "use client";
 
@@ -29,6 +31,7 @@ import type { RegionRange } from "@/generated/prisma/enums";
 
 interface ProductEmptyStateProps {
   hasSearchParams: boolean;
+  hasRefinementParams?: boolean;
   keyword?: string;
   alertId?: number;
   currentRange: RegionRange;
@@ -37,27 +40,49 @@ interface ProductEmptyStateProps {
 /**
  * 제품 목록이 비어있을 때 표시되는 UI
  *
- * - 검색어(keyword)가 있다면 `KeywordAlertButton`을 제공하여 키워드 등록 유도
+ * - 키워드 검색 결과가 없다면 상세 조건 유무와 관계없이 `KeywordAlertButton`을 제공하여 키워드 등록 유도
  * - 검색 결과가 없을 때 같은 검색어로 보드게임 도감을 탐색할 수 있는 보조 동선 제공
  * - 유저가 현재 탐색 중인 지역 범위(`currentRange`)를 버튼에 전달하여 의도에 맞는 범위 등록 지원
  *
  * @param hasSearchParams - 검색 필터 적용 여부
+ * @param hasRefinementParams - 키워드를 제외한 상세 조건 적용 여부
  * @param keyword - 현재 검색 중인 키워드
  * @param alertId - 해당 키워드의 알림 등록 ID (등록 상태 확인용)
  * @param currentRange - 현재 탐색 중인 지역 필터 범위
  */
 export default function ProductEmptyState({
   hasSearchParams,
+  hasRefinementParams = false,
   keyword,
   alertId,
   currentRange,
 }: ProductEmptyStateProps) {
   // 범위가 동/구로 좁을 때 안내가 필요한지 판별
   const isNarrowRange = currentRange === "DONG" || currentRange === "GU";
+  const hasActiveRefinements = hasSearchParams && hasRefinementParams;
   const keywordHint =
     hasSearchParams && keyword
-      ? `'${keyword}'에 대한 결과를 찾지 못했어요.`
+      ? hasRefinementParams
+        ? `'${keyword}' 검색 결과 중 현재 조건에 맞는 상품을 찾지 못했어요.`
+        : `'${keyword}'에 대한 결과를 찾지 못했어요.`
       : null;
+  const resetRefinementHref = keyword
+    ? `/products?keyword=${encodeURIComponent(keyword)}`
+    : "/products";
+  const title = hasSearchParams
+    ? hasActiveRefinements
+      ? "조건에 맞는 상품이 없습니다."
+      : "검색 결과가 없습니다."
+    : "등록된 제품이 없습니다.";
+  const description = hasSearchParams
+    ? hasActiveRefinements
+      ? keyword
+        ? "검색어는 유지하고 분류나 상세 필터를 조금 넓혀보세요."
+        : "분류나 상세 필터를 조금 넓혀보세요."
+      : isNarrowRange
+        ? "다른 검색어로 다시 시도하거나, 동네 범위를 넓혀보세요."
+        : "다른 검색어로 다시 시도해보세요."
+    : "첫 번째 상품을 등록해 항구를 채워보세요.";
 
   return (
     <div className="state-screen">
@@ -67,18 +92,8 @@ export default function ProductEmptyState({
         </div>
 
         <div>
-          <p className="state-title">
-            {hasSearchParams
-              ? "검색 결과가 없습니다."
-              : "등록된 제품이 없습니다."}
-          </p>
-          <p className="state-description">
-            {hasSearchParams
-              ? isNarrowRange
-                ? "다른 검색어로 다시 시도하거나, 동네 범위를 넓혀보세요."
-                : "다른 검색어로 다시 시도해보세요."
-              : "첫 번째 상품을 등록해 항구를 채워보세요."}
-          </p>
+          <p className="state-title">{title}</p>
+          <p className="state-description">{description}</p>
           {keywordHint && (
             <p className="mt-2 break-all text-xs font-medium leading-5 text-muted/90 line-clamp-2 sm:line-clamp-3">
               {keywordHint}
@@ -97,7 +112,18 @@ export default function ProductEmptyState({
           </div>
         )}
 
-        {/* 키워드 검색 중이지만 결과가 없을 때 -> 알림 등록 유도 */}
+        {hasActiveRefinements && (
+          <div className="state-actions justify-center">
+            <Link
+              href={resetRefinementHref}
+              className="btn-secondary inline-flex min-h-[44px] items-center justify-center px-6 text-sm"
+            >
+              {keyword ? "필터 풀고 보기" : "조건 풀고 보기"}
+            </Link>
+          </div>
+        )}
+
+        {/* 키워드가 있는 0건 상태에서는 상세 조건 유무와 관계없이 알림 등록 유도 */}
         {keyword && (
           <div className="mt-7 flex flex-col items-center gap-2 rounded-xl border border-dashed border-border-subtle bg-surface-dim/20 p-4 dark:bg-white/5">
             <p className="text-xs font-medium text-muted/90">

--- a/features/product/components/ProductForm.tsx
+++ b/features/product/components/ProductForm.tsx
@@ -51,6 +51,7 @@
  * 2026.05.05  임도헌   Modified  상품 폼 복귀/위치/검증 핸들러 JSDoc 보강
  * 2026.05.16  임도헌   Modified  제품 폼 값 타입명을 PascalCase 기준으로 정리
  * 2026.05.30  임도헌   Modified  모바일 상품 폼의 필드 높이와 섹션 간격을 압축해 작성 밀도 조정
+ * 2026.06.18  임도헌   Modified  거래 기준 지역 필수화에 맞춰 위치 검증/에러 이동 UX 보강
  */
 
 /**
@@ -527,6 +528,7 @@ export default function ProductForm({
   const [isMapOpen, setIsMapOpen] = useState(false);
   const location = watch("location");
   const imageSectionRef = useRef<HTMLDivElement | null>(null);
+  const locationSectionRef = useRef<HTMLDivElement | null>(null);
 
   /**
    * 이미지 업로드 섹션 열기와 포커스/스크롤 이동
@@ -547,7 +549,8 @@ export default function ProductForm({
    * @param data - 선택한 위치 데이터
    */
   const handleLocationSelect = (data: LocationData) => {
-    setValue("location", data, { shouldDirty: true });
+    setValue("location", data, { shouldDirty: true, shouldValidate: true });
+    clearErrors("location");
     setIsMapOpen(false);
   };
 
@@ -555,7 +558,7 @@ export default function ProductForm({
    * 상품 거래 위치 초기화
    */
   const handleRemoveLocation = () => {
-    setValue("location", null, { shouldDirty: true });
+    setValue("location", null, { shouldDirty: true, shouldValidate: true });
   };
 
   /**
@@ -727,6 +730,15 @@ export default function ProductForm({
   const onInvalid = (formErrors: typeof errors) => {
     if (formErrors.photos) {
       focusImageSection();
+      return;
+    }
+
+    if (formErrors.location) {
+      locationSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "nearest",
+      });
       return;
     }
     focusFirstFieldError<ProductFormValues>(formErrors, setFocus);
@@ -1027,11 +1039,14 @@ export default function ProductForm({
         resetSignal={resetSignal}
       />
 
-      <ProductLocationSection
-        location={location ?? null}
-        onOpenMap={() => setIsMapOpen(true)}
-        onRemoveLocation={handleRemoveLocation}
-      />
+      <div ref={locationSectionRef}>
+        <ProductLocationSection
+          location={location ?? null}
+          onOpenMap={() => setIsMapOpen(true)}
+          onRemoveLocation={handleRemoveLocation}
+          errorMessage={errors.location?.message}
+        />
+      </div>
 
       <ProductFormActions
         mode={mode}

--- a/features/product/components/ProductLikeButton.tsx
+++ b/features/product/components/ProductLikeButton.tsx
@@ -25,6 +25,9 @@
  * 2026.05.16  임도헌   Modified  제품 목록/찜 목록 캐시 갱신 shape 타입 정리
  * 2026.05.18  임도헌   Modified  목록 카드 하트 색상 보정을 위해 낙관 업데이트에 isLiked 상태 반영
  * 2026.05.26  임도헌   Modified  initialData 기반 likeStatus query에 local queryFn을 부여해 refetch 경고 방지
+ * 2026.06.17  임도헌   Modified  좋아요 낙관 반영 직전 목록/찜 목록 fetch 취소 및 pending opacity 제거
+ * 2026.06.17  임도헌   Modified  계정 전환 시 이전 사용자의 좋아요 캐시가 재사용되지 않도록 viewer scope 추가
+ * 2026.06.18  임도헌   Modified  다크모드에서 빠른 찜 해제 버튼의 중립 배경/경계 대비 보강
  */
 "use client";
 
@@ -48,6 +51,7 @@ interface ProductLikeButtonProps {
   isLiked: boolean;
   likeCount: number;
   productId: number;
+  viewerId?: number | null;
   variant?: "stack" | "quick-remove";
   className?: string;
 }
@@ -69,6 +73,8 @@ type ProductLikeCacheItem = {
  * - `useMutation`의 `onMutate` 단계를 활용한 낙관적 업데이트(Optimistic Update)로 즉각적인 UI 상태 반전 및 피드백 제공
  * - 목록 카드 하트 색상이 현재 사용자 좋아요 여부를 의미하도록 list cache의 `isLiked`를 함께 갱신
  * - 좋아요 취소 시 찜한 목록(`LIKED` scope) 쿼리 캐시에 접근하여 해당 아이템을 목록에서 즉각 제거 처리
+ * - 진행 중인 목록/찜 목록 fetch가 낙관 업데이트를 덮어쓰지 않도록 변경 직전 관련 쿼리 취소
+ * - 좋아요 상태 query key에 viewer scope를 포함해 계정 전환/재로그인 후 stale 상태 노출 방지
  * - API 요청 에러 발생 시 `onError`에서 캡처된 이전 상태 스냅샷(`previous`)으로 안전한 롤백(Rollback) 처리
  * - `onSettled` 시점에는 실제 queryFn이 있는 목록/찜 목록만 무효화해 상세 initialData 캐시 refetch 경고를 방지
  */
@@ -76,11 +82,12 @@ export default function ProductLikeButton({
   isLiked: initialIsLiked,
   likeCount: initialLikeCount,
   productId,
+  viewerId = null,
   variant = "stack",
   className = "",
 }: ProductLikeButtonProps) {
   const queryClient = useQueryClient();
-  const queryKey = queryKeys.products.likeStatus(productId);
+  const queryKey = queryKeys.products.likeStatus(productId, viewerId);
   const initialLikeStatus = {
     isLiked: initialIsLiked,
     likeCount: initialLikeCount,
@@ -104,7 +111,13 @@ export default function ProductLikeButton({
       else await likeProduct(productId);
     },
     onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey }),
+        queryClient.cancelQueries({ queryKey: queryKeys.products.lists() }),
+        queryClient.cancelQueries({
+          predicate: (query) => isLikedScopeKey(query.queryKey),
+        }),
+      ]);
 
       const previousLikeStatus = queryClient.getQueryData(queryKey);
       const listQueries = queryClient.getQueriesData({
@@ -117,10 +130,11 @@ export default function ProductLikeButton({
       const nextLikeCount = data.isLiked
         ? Math.max(0, data.likeCount - 1)
         : data.likeCount + 1;
+      const nextIsLiked = !data.isLiked;
 
       // 1) 상세 버튼 상태 즉시 반영
       queryClient.setQueryData(queryKey, {
-        isLiked: !data.isLiked,
+        isLiked: nextIsLiked,
         likeCount: nextLikeCount,
       });
 
@@ -137,7 +151,7 @@ export default function ProductLikeButton({
                 product.id === productId
                   ? {
                       ...product,
-                      isLiked: !data.isLiked,
+                      isLiked: nextIsLiked,
                       _count: {
                         ...product._count,
                         product_likes: nextLikeCount,
@@ -243,16 +257,18 @@ export default function ProductLikeButton({
       type="button"
       onClick={() => mutate()}
       className={cn(
-            variant === "quick-remove"
+        variant === "quick-remove"
           ? [
               "inline-flex h-7 items-center justify-center gap-1 rounded-full border border-border-subtle bg-surface/92 px-2 text-muted shadow-sm transition-[background-color,color,border-color,box-shadow] motion-safe:transition-transform sm:h-8 sm:gap-1.5 sm:px-3",
+              "dark:border-border-strong dark:bg-surface-dim dark:text-primary dark:shadow-[0_0_0_1px_rgba(148,163,184,0.08)]",
               "hover:-translate-y-0.5 hover:bg-surface-dim hover:text-primary active:scale-95",
+              "dark:hover:border-border-strong dark:hover:bg-surface-hover dark:hover:text-primary",
               "focus-ring-soft",
-              "disabled:opacity-50 disabled:cursor-not-allowed",
+              "disabled:cursor-not-allowed",
             ]
           : [
               "flex flex-col items-center justify-center p-2 rounded-xl transition-colors active:scale-95",
-              "hover:bg-surface-dim disabled:opacity-50 disabled:cursor-not-allowed",
+              "hover:bg-surface-dim disabled:cursor-not-allowed",
             ],
         variant === "quick-remove"
           ? "text-muted"
@@ -262,6 +278,8 @@ export default function ProductLikeButton({
         className
       )}
       disabled={isPending}
+      aria-busy={isPending}
+      aria-pressed={data.isLiked}
       aria-label={
         variant === "quick-remove"
           ? data.isLiked

--- a/features/product/components/ProductList.tsx
+++ b/features/product/components/ProductList.tsx
@@ -40,12 +40,7 @@
 
 "use client";
 
-import {
-  ReactNode,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { ReactNode, useMemo, useRef, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { usePageVisibility } from "@/hooks/usePageVisibility";
@@ -135,7 +130,7 @@ export default function ProductList({
             onClick={() => setViewMode("list")}
             aria-label="리스트 보기"
             className={cn(
-              "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+              "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] sm:min-h-[44px] sm:min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
               viewMode === "list"
                 ? "bg-surface-dim text-brand shadow-sm ring-1 ring-border-subtle dark:text-brand-light"
                 : "text-muted hover:bg-surface-dim hover:text-primary"
@@ -147,7 +142,7 @@ export default function ProductList({
             onClick={() => setViewMode("grid")}
             aria-label="그리드 보기"
             className={cn(
-              "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+              "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] sm:min-h-[44px] sm:min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
               viewMode === "grid"
                 ? "bg-surface-dim text-brand shadow-sm ring-1 ring-border-subtle dark:text-brand-light"
                 : "text-muted hover:bg-surface-dim hover:text-primary"

--- a/features/product/components/ProductListSkeleton.tsx
+++ b/features/product/components/ProductListSkeleton.tsx
@@ -10,6 +10,7 @@
  * 2026.04.17  임도헌   Modified  목록/라우트 로딩에서 재사용되는 스켈레톤 책임이 주석에서 바로 드러나도록 설명 보강
  * 2026.05.09  임도헌   Modified  보드게임 도감/알림 액션이 포함된 상품 목록 헤더 구조 반영
  * 2026.06.01  임도헌   Modified  모바일 목록 툴바 압축 밀도에 맞춰 뷰 토글 스켈레톤 크기 조정
+ * 2026.06.21  임도헌   Modified  실제 뷰 토글 버튼 크기(모바일 36px, sm 이상 44px)에 맞춰 스켈레톤 정렬
  */
 "use client";
 
@@ -44,9 +45,9 @@ export default function ProductListSkeleton({
             <div className="h-8 w-24 rounded-full bg-surface-dim" />
             <div className="h-8 w-9 rounded-full bg-surface-dim sm:w-28" />
           </div>
-          <div className="flex rounded-2xl border border-border-subtle bg-surface p-1">
-            <div className="size-10 rounded-xl bg-surface-dim" />
-            <div className="size-10 rounded-xl bg-surface-dim" />
+          <div className="flex rounded-xl border border-border-subtle bg-surface p-1">
+            <div className="size-9 rounded-lg bg-surface-dim sm:size-11" />
+            <div className="size-9 rounded-lg bg-surface-dim sm:size-11" />
           </div>
         </div>
       ) : null}

--- a/features/product/components/ProductLocationSection.tsx
+++ b/features/product/components/ProductLocationSection.tsx
@@ -6,35 +6,43 @@
  * History
  * Date        Author   Status    Description
  * 2026.04.21  임도헌   Created   ProductForm의 직거래 장소 선택/변경 UI를 별도 섹션으로 분리
+ * 2026.06.18  임도헌   Modified  정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
+ * 2026.06.18  임도헌   Modified  상품 거래 기준 지역을 필수 입력 UI로 정리
  */
 
 import { MapPinIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import type { LocationData } from "@/features/map/types";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 
 interface ProductLocationSectionProps {
   location: LocationData | null;
   onOpenMap: () => void;
   onRemoveLocation: () => void;
+  errorMessage?: string;
 }
 
 /**
- * 직거래 희망 장소 섹션
+ * 거래 기준 지역 섹션
  *
  * [역할]
  * - 선택된 장소 요약, 변경/삭제 액션, 빈 상태 CTA를 한곳에서 관리
- * - 거래 위치는 선택 사항이므로 필수 입력과 구분되는 보조 섹션으로 렌더링
+ * - 상품 노출 지역과 거래 기준 위치로 사용되는 필수 입력을 렌더링
  */
 export default function ProductLocationSection({
   location,
   onOpenMap,
   onRemoveLocation,
+  errorMessage,
 }: ProductLocationSectionProps) {
   return (
     <div className="flex flex-col gap-2 pt-2">
       <label className="flex items-center gap-1 text-sm font-medium text-primary">
         <MapPinIcon className="size-4" />
-        직거래 희망 장소 <span className="font-normal text-muted">(선택)</span>
+        거래 기준 지역 <span className="text-danger">*</span>
       </label>
+      <p className="text-xs leading-snug text-muted">
+        상품이 노출될 동네와 거래 기준 위치로 사용됩니다.
+      </p>
 
       {location ? (
         <div className="flex items-center justify-between gap-3 rounded-xl border border-brand/30 bg-surface p-3 shadow-sm">
@@ -47,7 +55,7 @@ export default function ProductLocationSection({
                 {location.locationName}
               </p>
               <p className="truncate text-xs text-muted">
-                {location.region1} {location.region2} {location.region3}
+                {formatNormalizedRegion(location)}
               </p>
             </div>
           </div>
@@ -73,11 +81,15 @@ export default function ProductLocationSection({
         <button
           type="button"
           onClick={onOpenMap}
-          className="focus-ring-soft flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-surface-dim/30 text-muted transition-colors hover:border-brand/30 hover:bg-surface-dim hover:text-primary"
+          className="focus-ring-soft flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-surface-dim/30 text-muted transition-colors hover:border-brand/30 hover:bg-surface-dim hover:text-primary aria-[invalid=true]:border-danger/60 aria-[invalid=true]:bg-danger/5 aria-[invalid=true]:text-danger"
+          aria-invalid={!!errorMessage}
         >
           <MapPinIcon className="size-5" />
-          <span className="text-sm">거래 장소 추가하기</span>
+          <span className="text-sm">거래 기준 지역 선택하기</span>
         </button>
+      )}
+      {errorMessage && (
+        <p className="text-xs font-medium text-danger">{errorMessage}</p>
       )}
     </div>
   );

--- a/features/product/components/ProductMobileHeader.tsx
+++ b/features/product/components/ProductMobileHeader.tsx
@@ -21,6 +21,8 @@
  * 2026.04.13  임도헌   Modified  모바일/데스크톱 헤더와 중복되던 검색/필터 상태 로직을 공통 훅으로 정리
  * 2026.04.17  임도헌   Modified  모바일 제품 헤더의 상품 검색 버튼 스타일을 정리
  * 2026.05.30  임도헌   Modified  모바일 제품 필터 헤더의 상하 여백을 압축해 목록 가시 영역 확보
+ * 2026.06.14  임도헌   Modified  긴 필터 요약을 말줄임 대신 가로 스크롤로 확인할 수 있게 조정
+ * 2026.06.15  임도헌   Modified  검색어만 적용된 상태도 요약 X 버튼으로 바로 해제할 수 있게 조정
  */
 "use client";
 
@@ -94,8 +96,10 @@ export default function ProductMobileHeader({
     setIsSearchOpen,
     handleSearch,
     filterSummary,
+    hasActiveKeyword,
     hasActiveFilters,
     resetFilterParams,
+    clearKeyword,
     localSearchHistory,
     removeHistory,
     clearHistory,
@@ -105,6 +109,11 @@ export default function ProductMobileHeader({
     keyword,
     searchHistory,
   });
+  const showSummaryReset = hasActiveFilters || hasActiveKeyword;
+  const handleSummaryReset = hasActiveFilters ? resetFilterParams : clearKeyword;
+  const summaryResetLabel = hasActiveFilters
+    ? "필터 초기화 (검색어 유지)"
+    : "검색어 초기화";
 
   return (
     <>
@@ -158,14 +167,16 @@ export default function ProductMobileHeader({
 
           <div className="relative min-w-0 flex-1">
             <div className="flex items-center rounded-xl border border-border-subtle bg-background px-3 py-1.5">
-              <p className="min-w-0 flex-1 truncate text-xs font-medium text-muted/90">
-                {filterSummary}
-              </p>
-              {hasActiveFilters && (
+              <div className="min-w-0 flex-1 overflow-x-auto scrollbar-hide">
+                <p className="w-max whitespace-nowrap text-xs font-medium text-muted/90">
+                  {filterSummary}
+                </p>
+              </div>
+              {showSummaryReset && (
                 <button
                   type="button"
-                  onClick={resetFilterParams}
-                  aria-label="필터 초기화 (검색어 유지)"
+                  onClick={handleSummaryReset}
+                  aria-label={summaryResetLabel}
                   className="focus-ring-soft ml-1.5 shrink-0 rounded-full p-0.5 text-muted transition-colors hover:bg-surface hover:text-primary"
                 >
                   <XMarkIcon className="size-3.5" />

--- a/features/product/components/ProductTradeStatusBadge.tsx
+++ b/features/product/components/ProductTradeStatusBadge.tsx
@@ -1,0 +1,55 @@
+/**
+ * File Name : features/product/components/ProductTradeStatusBadge.tsx
+ * Description : 제품 거래 상태 공용 배지 (예약/판매완료)
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.18  임도헌   Created   예약/판매완료 상태 표시 색상과 라벨을 공용화
+ */
+
+import { PRODUCT_STATUS_LABEL } from "@/features/product/constants";
+import type { ProductStatus } from "@/features/product/types";
+import { cn } from "@/lib/utils";
+
+type TradeStatus = Exclude<ProductStatus, "selling">;
+
+interface ProductTradeStatusBadgeProps {
+  status: TradeStatus;
+  variant?: "soft" | "solid";
+  className?: string;
+}
+
+const softStyles: Record<TradeStatus, string> = {
+  reserved:
+    "border border-green-500/20 bg-green-500/15 text-green-700 dark:border-green-400/25 dark:bg-green-400/15 dark:text-green-100",
+  sold: "border border-border bg-surface-dim text-muted",
+};
+
+const solidStyles: Record<TradeStatus, string> = {
+  reserved: "bg-green-600/90 text-white",
+  sold: "bg-neutral-600/90 text-white",
+};
+
+/**
+ * 예약/판매완료처럼 기본 판매 중 상태와 구분이 필요한 거래 상태만 표시한다.
+ * - soft: 카드 본문, 상세 헤더, 판매 내역용
+ * - solid: 이미지 오버레이용
+ */
+export default function ProductTradeStatusBadge({
+  status,
+  variant = "soft",
+  className,
+}: ProductTradeStatusBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center whitespace-nowrap rounded px-1.5 py-0.5 text-xs font-bold shadow-sm",
+        variant === "solid" ? solidStyles[status] : softStyles[status],
+        className
+      )}
+    >
+      {PRODUCT_STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/features/product/components/productCard/index.tsx
+++ b/features/product/components/productCard/index.tsx
@@ -55,6 +55,7 @@
  * 2026.05.20  임도헌   Modified  끌어올린 상품은 등록일 대신 refreshed_at 기준 노출 시점을 표시
  * 2026.06.01  임도헌   Modified  그리드 카드의 태그/메타 묶음을 하단 정렬해 카드별 공백 차이 완화
  * 2026.06.04  임도헌   Modified  데모 상품 밀도 대응을 위해 리스트 카드 높이와 썸네일 정렬 보정
+ * 2026.06.17  임도헌   Modified  찜 목록 빠른 해제 버튼에 viewerId 전달
  * ===============================================================================================
  * ProductCard (구 ListProduct) 컴포넌트를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * 각 컴포넌트는 제품 정보를 보여주는 카드에서 특정 부분의 렌더링을 담당
@@ -95,6 +96,7 @@ export default function ProductCard({
   isPriority,
   returnTo = "/products",
   showQuickUnlike = false,
+  viewerId = null,
 }: ProductCardProps) {
   const likedAt = "liked_at" in product ? product.liked_at : undefined;
   const {
@@ -134,7 +136,7 @@ export default function ProductCard({
         "relative shrink-0 overflow-hidden bg-surface-dim",
         isGrid
           ? "aspect-[3/2] w-full border-b border-border sm:aspect-[4/3]"
-          : "w-24 self-stretch sm:w-36"
+          : "w-28 self-stretch sm:w-36"
       )}
     >
       <ProductCardThumbnail
@@ -263,6 +265,7 @@ export default function ProductCard({
             productId={id}
             isLiked={true}
             likeCount={_count.product_likes}
+            viewerId={viewerId}
             variant="quick-remove"
           />
         </div>
@@ -275,6 +278,7 @@ export default function ProductCard({
               productId={id}
               isLiked={true}
               likeCount={_count.product_likes}
+              viewerId={viewerId}
               variant="quick-remove"
             />
           </div>

--- a/features/product/components/productDetail/ProductDetailActions.tsx
+++ b/features/product/components/productDetail/ProductDetailActions.tsx
@@ -15,6 +15,7 @@
  * 2026.04.06  임도헌   Modified  수정/삭제를 상단 owner 메뉴로 이동하고 하단 액션바는 UP 중심으로 정리
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 상세 액션바 타이포 무게를 정리
  * 2026.04.20  임도헌   Modified  owner용 UP 버튼 포커스가 배경에 묻히지 않도록 inset 강조 기준으로 조정
+ * 2026.06.17  임도헌   Modified  좋아요 상태 캐시 분리를 위해 viewerId 전달
  */
 "use client";
 
@@ -32,6 +33,7 @@ interface ProductDetailActionsProps {
   isLiked: boolean;
   likeCount: number;
   isOwner: boolean;
+  viewerId?: number | null;
   bumpCount?: number;
 }
 
@@ -46,6 +48,7 @@ export default function ProductDetailActions({
   isLiked,
   likeCount,
   isOwner,
+  viewerId = null,
   bumpCount = 0,
 }: ProductDetailActionsProps) {
   const [isPending, startTransition] = useTransition();
@@ -77,6 +80,7 @@ export default function ProductDetailActions({
             productId={productId}
             isLiked={isLiked}
             likeCount={likeCount}
+            viewerId={viewerId}
           />
         </div>
 

--- a/features/product/components/productDetail/ProductDetailHeader.tsx
+++ b/features/product/components/productDetail/ProductDetailHeader.tsx
@@ -16,6 +16,7 @@
  * 2026.04.09  임도헌   Modified  판매완료 숨김 상태를 owner 전용 배지로 표시
  * 2026.04.10  임도헌   Modified  Pretendard subset 3-weight 정책에 맞춰 상세 헤더 배지 타이포를 정리
  * 2026.04.14  임도헌   Modified  서버 컨테이너 전환에 맞춰 무상태 헤더 컴포넌트로 정리
+ * 2026.06.18  임도헌   Modified  예약/판매완료 거래 상태 배지를 상세 헤더에 표시
  */
 
 import { formatToWon } from "@/lib/utils";
@@ -26,6 +27,7 @@ import {
   ArrowUpIcon,
   PuzzlePieceIcon,
 } from "@heroicons/react/24/outline";
+import ProductTradeStatusBadge from "@/features/product/components/ProductTradeStatusBadge";
 
 interface ProductDetailHeaderProps {
   title: string;
@@ -33,10 +35,12 @@ interface ProductDetailHeaderProps {
   game_type: string;
   bumpCount?: number;
   showHiddenBadge?: boolean;
+  reservationUserId?: number | null;
+  purchaseUserId?: number | null;
 }
 
 /**
- * 제품의 핵심 정보(타입, 제목, 가격)를 표시
+ * 제품의 핵심 정보(타입, 거래 상태, 제목, 가격)를 표시
  * 게임 타입 배지를 클릭하면 해당 타입 필터 검색으로 이동
  */
 export default function ProductDetailHeader({
@@ -45,7 +49,15 @@ export default function ProductDetailHeader({
   game_type,
   bumpCount = 0,
   showHiddenBadge = false,
+  reservationUserId = null,
+  purchaseUserId = null,
 }: ProductDetailHeaderProps) {
+  const tradeStatus = purchaseUserId
+    ? "sold"
+    : reservationUserId
+      ? "reserved"
+      : null;
+
   return (
     <div className="flex flex-col gap-3">
       {/* 게임 타입 뱃지 */}
@@ -68,6 +80,13 @@ export default function ProductDetailHeader({
           <span className="inline-flex items-center rounded-full border border-border bg-surface-dim px-2 py-1 text-xs font-medium text-muted shadow-sm sm:px-2.5">
             숨김
           </span>
+        )}
+        {/* 판매 중은 기본 상태라 생략하고, 예약/판매완료만 명시한다. */}
+        {tradeStatus && (
+          <ProductTradeStatusBadge
+            status={tradeStatus}
+            className="rounded-full px-2 py-1 sm:px-2.5"
+          />
         )}
       </div>
 

--- a/features/product/components/productDetail/ProductDetailLocationSection.tsx
+++ b/features/product/components/productDetail/ProductDetailLocationSection.tsx
@@ -11,6 +11,7 @@
  * 2026.04.14  임도헌   Modified  지도 섹션의 지연 준비 전략과 사용자 흐름이 드러나도록 함수 상단 JSDoc 설명을 보강
  * 2026.04.14  임도헌   Modified  자동 로드 정책에 맞춰 미리보기 카드를 정보 중심의 간소한 로딩 셸로 정리
  * 2026.04.26  임도헌   Modified  지도 열기 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
+ * 2026.06.18  임도헌   Modified  정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
  */
 
 "use client";
@@ -21,6 +22,7 @@ import {
   ArrowTopRightOnSquareIcon,
   MapPinIcon,
 } from "@heroicons/react/24/outline";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 
 const loadStaticMap = () => import("@/features/map/components/StaticMap");
 
@@ -153,7 +155,7 @@ export default function ProductDetailLocationSection({
     return null;
   }
 
-  const regionString = [region1, region2, region3].filter(Boolean).join(" ");
+  const regionString = formatNormalizedRegion({ region1, region2, region3 });
   const mapLink = `https://map.kakao.com/link/map/${encodeURIComponent(
     locationName
   )},${latitude},${longitude}`;

--- a/features/product/components/productDetail/ProductDetailTags.tsx
+++ b/features/product/components/productDetail/ProductDetailTags.tsx
@@ -10,10 +10,19 @@
  * 2026.01.17  임도헌   Moved     components/product -> features/product/components
  * 2026.01.25  임도헌   Modified  주석 및 컴포넌트 구조 설명 보강
  * 2026.03.14  임도헌   Modified  태그 이모지(🏷️)를 # prefix로 교체해 렌더링 일관성 확보
+ * 2026.06.14  임도헌   Modified  상세 태그 검색 이동 시 최근 검색어 저장과 캐시 갱신을 보강
  */
 
+"use client";
+
 import Link from "next/link";
+import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
+import { queryKeys } from "@/lib/queryKeys";
+import { createSearchHistory } from "@/features/product/actions/history";
+import { SEARCH_HISTORY_MAX_ITEMS } from "@/features/search/constants";
+import { normalizeSearchKeyword } from "@/features/search/utils/keyword";
+import type { SearchHistoryItem } from "@/features/search/types";
 import type { ProductTag } from "@/features/product/types";
 
 interface ProductDetailTagsProps {
@@ -25,14 +34,37 @@ interface ProductDetailTagsProps {
  * 클릭 시 해당 태그로 검색 결과 이동
  */
 export default function ProductDetailTags({ tags }: ProductDetailTagsProps) {
+  const queryClient = useQueryClient();
+
   if (!tags || tags.length === 0) return null;
+
+  const handleTagSearch = (keyword: string) => {
+    const normalized = normalizeSearchKeyword(keyword);
+    if (!normalized) return;
+
+    queryClient.setQueryData(
+      queryKeys.search.history(),
+      (old: SearchHistoryItem[] = []) => {
+        const filtered = old.filter((item) => item.keyword !== normalized);
+        return [
+          { keyword: normalized, created_at: new Date() },
+          ...filtered,
+        ].slice(0, SEARCH_HISTORY_MAX_ITEMS);
+      }
+    );
+
+    void createSearchHistory(normalized);
+  };
 
   return (
     <div className="flex flex-wrap gap-2">
-      {tags.map((tag, index) => (
+      {tags.map((tag) => (
         <Link
-          key={index}
+          key={tag.name}
           href={`/products?keyword=${encodeURIComponent(tag.name)}`}
+          onClick={() => {
+            handleTagSearch(tag.name);
+          }}
           className={cn(
             "focus-ring-soft inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-[background-color,color,border-color,box-shadow] motion-safe:transition-transform",
             "bg-badge text-badge-text",

--- a/features/product/components/productDetail/index.tsx
+++ b/features/product/components/productDetail/index.tsx
@@ -19,6 +19,7 @@
  * 2026.04.14  임도헌   Modified  서버 컨테이너 책임과 섹션 조합 흐름이 드러나도록 함수 상단 JSDoc 설명을 보강
  * 2026.05.03  임도헌   Modified  상품 상세에 연결된 보드게임 카탈로그 칩 노출
  * 2026.05.06  임도헌   Modified  게시글/방송 상세와 동일한 도감 이동 카드 표시로 통일
+ * 2026.06.18  임도헌   Modified  예약/판매완료 거래 상태를 상세 헤더에 전달
  * ===============================================================================================
  * ProductDetail 페이지를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * 각 컴포넌트는 제품 상세 정보의 특정 섹션을 담당
@@ -51,6 +52,7 @@ interface ProductDetailProps {
   isOwner: boolean;
   likeCount: number;
   isLiked: boolean;
+  viewerId?: number | null;
   isModalContext?: boolean;
 }
 
@@ -66,6 +68,7 @@ export default function ProductDetailContainer({
   isOwner,
   likeCount,
   isLiked,
+  viewerId = null,
   isModalContext = false,
 }: ProductDetailProps) {
   return (
@@ -93,6 +96,8 @@ export default function ProductDetailContainer({
             game_type={product.game_type}
             bumpCount={product.bump_count}
             showHiddenBadge={isOwner && !!product.hidden_at}
+            reservationUserId={product.reservation_userId}
+            purchaseUserId={product.purchase_userId}
           />
 
           <p className="text-base text-primary whitespace-pre-wrap leading-relaxed">
@@ -134,6 +139,7 @@ export default function ProductDetailContainer({
           isLiked={isLiked}
           likeCount={likeCount}
           isOwner={isOwner}
+          viewerId={viewerId}
           bumpCount={product.bump_count}
         />
       </div>

--- a/features/product/hooks/useProductHeaderState.ts
+++ b/features/product/hooks/useProductHeaderState.ts
@@ -9,6 +9,8 @@
  * Date        Author   Status    Description
  * 2026.04.13  임도헌   Created   모바일/데스크톱 제품 헤더에서 중복되던 검색/필터 상태 로직을 공통 훅으로 분리
  * 2026.04.17  임도헌   Modified  공통 헤더 훅의 검색/필터/최근 검색어 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.06.15  임도헌   Modified  검색어 초기화 시 빈 키워드가 최근 검색어에 저장되지 않도록 방어
+ * 2026.06.15  임도헌   Modified  제품 요약 영역에서 검색어만 남은 상태도 즉시 초기화할 수 있게 핸들러 제공
  */
 
 import { useState } from "react";
@@ -60,8 +62,16 @@ export function useProductHeaderState({
 
   // 검색 확정 시 최근 검색어 저장, URL keyword 갱신 후 모달 닫기
   const handleSearch = (nextKeyword: string) => {
-    addHistory(nextKeyword);
-    updateKeyword(nextKeyword);
+    const trimmed = nextKeyword.trim();
+    if (trimmed) {
+      addHistory(trimmed);
+    }
+    updateKeyword(trimmed);
+    setIsSearchOpen(false);
+  };
+
+  const clearKeyword = () => {
+    updateKeyword("");
     setIsSearchOpen(false);
   };
 
@@ -70,8 +80,10 @@ export function useProductHeaderState({
     setIsSearchOpen,
     handleSearch,
     filterSummary,
+    hasActiveKeyword: Boolean(keyword?.trim()),
     hasActiveFilters: activeFilterCount > 0,
     resetFilterParams,
+    clearKeyword,
     localSearchHistory,
     removeHistory,
     clearHistory,

--- a/features/product/schemas.test.ts
+++ b/features/product/schemas.test.ts
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.25  임도헌   Created   상품 등록/수정 입력 검증 회귀 테스트 추가
+ * 2026.06.18  임도헌   Modified  거래 기준 지역 필수화 검증 추가
  */
 
 import { describe, expect, test } from "vitest";
@@ -27,7 +28,14 @@ const validProductInput = {
   categoryId: 1,
   boardGameIds: [],
   tags: [],
-  location: null,
+  location: {
+    latitude: 37.5665,
+    longitude: 126.978,
+    locationName: "서울시청",
+    region1: "서울",
+    region2: "중구",
+    region3: "태평로1가",
+  },
 };
 
 describe("productFormSchema", () => {
@@ -62,6 +70,20 @@ describe("productFormSchema", () => {
     if (!result.success) {
       expect(result.error.flatten().fieldErrors.max_players).toContain(
         "최대 인원은 최소 인원 이상이어야 합니다."
+      );
+    }
+  });
+
+  test("거래 기준 지역이 없으면 실패한다", () => {
+    const result = productFormSchema.safeParse({
+      ...validProductInput,
+      location: null,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.location).toContain(
+        "거래 기준 지역을 선택해주세요."
       );
     }
   });

--- a/features/product/schemas.ts
+++ b/features/product/schemas.ts
@@ -22,6 +22,7 @@
  * 2026.03.12  임도헌   Modified  이미지 애니메이션 메타 저장용 photosAnimated 필드 추가
  * 2026.05.03  임도헌   Modified  보드게임 카탈로그 연결 id 검증 필드 추가
  * 2026.05.16  임도헌   Modified  폼 값 타입명을 PascalCase 기준으로 정리
+ * 2026.06.18  임도헌   Modified  상품 노출/거래 기준 지역으로 location 선택을 필수화
  */
 
 import { z } from "zod";
@@ -92,7 +93,7 @@ export const productFormSchema = z.object({
     .array(z.string())
     .max(5, "태그는 최대 5개까지 입력 가능합니다.")
     .default([]),
-  // 위치 정보는 선택 사항이며, 수정 시 삭제(null)될 수 있으므로 nullable() 처리 필수
+  // 상품은 거래 지역이 핵심 정보라 location을 제출 시 필수로 검증한다.
   location: z
     .object({
       latitude: z.number(),
@@ -102,8 +103,15 @@ export const productFormSchema = z.object({
       region2: z.string(),
       region3: z.string(),
     })
-    .optional()
-    .nullable(),
+    .nullable()
+    .superRefine((location, ctx) => {
+      if (location !== null) return;
+
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "거래 기준 지역을 선택해주세요.",
+      });
+    }),
 }).refine((data) => data.max_players >= data.min_players, {
   message: "최대 인원은 최소 인원 이상이어야 합니다.",
   path: ["max_players"],

--- a/features/product/service/create.ts
+++ b/features/product/service/create.ts
@@ -19,6 +19,7 @@
  * 2026.04.04  임도헌   Modified  상품 생성 트랜잭션/후처리 단계의 인라인 주석 보강
  * 2026.05.03  임도헌   Modified  상품 생성 시 보드게임 카탈로그 연결 저장 추가
  * 2026.05.03  임도헌   Modified  상품-보드게임 연결 저장 정책 주석 보강
+ * 2026.06.18  임도헌   Modified  거래 기준 지역 필수 정책에 맞춰 위치 저장/알림 지역을 필수값으로 정리
  */
 import "server-only";
 
@@ -49,12 +50,19 @@ export const createProduct = async (
   if (!status.success) return status;
 
   try {
+    if (!data.location) {
+      return {
+        success: false,
+        error: "거래 기준 지역을 선택해주세요.",
+      };
+    }
+
     // 태그 저장/카운트 정산용 고유 태그 목록 구성
     const uniqueTags = Array.from(new Set(data.tags));
     // 선택된 보드게임은 중복 제거 후 join table 연결 대상으로만 사용
     const boardGameIds = Array.from(new Set(data.boardGameIds ?? []));
 
-    // 상품 본문/위치/카테고리/태그 연결용 create payload 구성
+    // 상품 본문/거래 기준 지역/카테고리/태그 연결용 create payload 구성
     const productData: Prisma.ProductCreateInput = {
       title: data.title,
       description: data.description,
@@ -66,15 +74,12 @@ export const createProduct = async (
       condition: data.condition,
       completeness: data.completeness,
       has_manual: data.has_manual,
-      // 위치 정보 매핑 (data.location이 있으면 분해, 없으면 undefined)
-      ...(data.location && {
-        latitude: data.location.latitude,
-        longitude: data.location.longitude,
-        locationName: data.location.locationName,
-        region1: data.location.region1,
-        region2: data.location.region2,
-        region3: data.location.region3,
-      }),
+      latitude: data.location.latitude,
+      longitude: data.location.longitude,
+      locationName: data.location.locationName,
+      region1: data.location.region1,
+      region2: data.location.region2,
+      region3: data.location.region3,
       category: { connect: { id: data.categoryId } },
       user: { connect: { id: userId } },
       search_tags: {
@@ -132,9 +137,9 @@ export const createProduct = async (
         title: product.title,
         tags: uniqueTags,
         sellerId: userId,
-        region1: data.location?.region1,
-        region2: data.location?.region2,
-        region3: data.location?.region3,
+        region1: data.location.region1,
+        region2: data.location.region2,
+        region3: data.location.region3,
       });
     } catch (err) {
       console.error("[createProduct] Keyword alert failed:", err);

--- a/features/product/service/detail.ts
+++ b/features/product/service/detail.ts
@@ -24,6 +24,7 @@
  * 2026.04.14  임도헌   Modified  상세/모달 공통 서버 로더를 추가해 좋아요/차단 상태 조회 중복을 통합
  * 2026.05.03  임도헌   Modified  제품 상세에 연결된 보드게임 카탈로그 정보 포함
  * 2026.05.08  임도헌   Modified  제품 상세 보드게임 relation select를 공용 상수로 교체
+ * 2026.06.18  임도헌   Modified  상세 캐시와 별도로 거래/숨김 상태를 최신 조회하도록 보강
  */
 import "server-only";
 
@@ -106,19 +107,28 @@ export const getCachedProduct = (id: number) => {
 
 /**
  * 상세 페이지/모달에서 공통으로 쓰는 상세 조회 모델.
- * 공통 본문은 캐시된 상세 데이터를 재사용하고, 개인화된 좋아요/차단 상태만 별도 조회
+ * 공통 본문은 캐시된 상세 데이터를 재사용하고, 자주 바뀌는 거래/숨김 상태와
+ * 개인화된 좋아요/차단 상태만 별도 조회
  */
 export async function getProductDetailViewData(
   id: number,
   userId: number | null
 ) {
-  // 공통 본문 캐시 재사용, 사용자별 상태만 개별 조회
-  const [product, likeStatus] = await Promise.all([
+  // 공통 본문 캐시는 유지하되, 채팅 약속 수락처럼 상태만 바뀌는 경로는 최신 DB 값을 덮어쓴다.
+  const [product, likeStatus, liveState] = await Promise.all([
     getCachedProduct(id),
     getProductLikeStatus(id, userId),
+    db.product.findUnique({
+      where: { id },
+      select: {
+        reservation_userId: true,
+        purchase_userId: true,
+        hidden_at: true,
+      },
+    }),
   ]);
 
-  if (!product) {
+  if (!product || !liveState) {
     return {
       product: null,
       likeStatus,
@@ -127,14 +137,21 @@ export async function getProductDetailViewData(
     };
   }
 
-  const isOwner = userId === product.userId;
+  const productWithLiveState = {
+    ...product,
+    reservation_userId: liveState.reservation_userId,
+    purchase_userId: liveState.purchase_userId,
+    hidden_at: liveState.hidden_at,
+  };
+
+  const isOwner = userId === productWithLiveState.userId;
   // 상품 소유자 확인 이후에만 차단 관계 계산, 불필요한 조회 감소
   const isBlocked = userId
-    ? await checkBlockRelation(userId, product.userId)
+    ? await checkBlockRelation(userId, productWithLiveState.userId)
     : false;
 
   return {
-    product,
+    product: productWithLiveState,
     likeStatus,
     isOwner,
     isBlocked,

--- a/features/product/service/update.ts
+++ b/features/product/service/update.ts
@@ -24,6 +24,7 @@
  * 2026.04.04  임도헌   Modified  제품 수정 트랜잭션/가격 인하 후처리 단계의 인라인 주석 보강
  * 2026.05.03  임도헌   Modified  상품 수정 시 보드게임 카탈로그 연결 교체 저장 추가
  * 2026.05.03  임도헌   Modified  상품-보드게임 연결 교체 정책 주석 보강
+ * 2026.06.18  임도헌   Modified  거래 기준 지역 필수 정책에 맞춰 위치 삭제 저장 경로 제거
  */
 import "server-only";
 
@@ -219,24 +220,22 @@ export async function updateProduct(
       return { success: false, error: "수정 권한이 없습니다." };
     }
 
-    // 위치 삭제까지 포함한 위치 필드 payload 구성
-    const locationUpdate = data.location
-      ? {
-          latitude: data.location.latitude,
-          longitude: data.location.longitude,
-          locationName: data.location.locationName,
-          region1: data.location.region1,
-          region2: data.location.region2,
-          region3: data.location.region3,
-        }
-      : {
-          latitude: null,
-          longitude: null,
-          locationName: null,
-          region1: null,
-          region2: null,
-          region3: null,
-        };
+    if (!data.location) {
+      return {
+        success: false,
+        error: "거래 기준 지역을 선택해주세요.",
+      };
+    }
+
+    // 거래 기준 지역은 상품 노출/거래 문맥의 필수값이므로 항상 현재 선택값으로 갱신
+    const locationUpdate = {
+      latitude: data.location.latitude,
+      longitude: data.location.longitude,
+      locationName: data.location.locationName,
+      region1: data.location.region1,
+      region2: data.location.region2,
+      region3: data.location.region3,
+    };
 
     // 가격/태그 변경 diff 계산
     const isPriceDropped = data.price < existing.price;

--- a/features/product/types.ts
+++ b/features/product/types.ts
@@ -27,6 +27,8 @@
  * 2026.05.03  임도헌   Modified  상품 목록 카드에서 연결 보드게임 요약을 표시할 수 있도록 목록 타입 확장
  * 2026.05.18  임도헌   Modified  상품 목록 카드 하트 색상 기준 분리를 위한 isLiked 필드 추가
  * 2026.05.08  임도헌   Modified  프로필/마이페이지 제품 목록 조회 범위 타입을 product types로 이동
+ * 2026.06.17  임도헌   Modified  찜 목록 빠른 해제의 좋아요 캐시 분리를 위한 ProductCard viewerId prop 추가
+ * 2026.06.18  임도헌   Modified  상품 거래 기준 지역 필수화에 맞춰 ProductDTO location을 필수값으로 정리
  */
 
 import {
@@ -81,7 +83,7 @@ export interface ProductDTO {
   completeness: (typeof COMPLETENESS_TYPES)[number];
   has_manual: boolean;
   categoryId: number;
-  location?: LocationData | null;
+  location: LocationData;
   boardGameIds?: number[];
 }
 
@@ -371,6 +373,7 @@ export interface ProductCardProps {
   isPriority: boolean;
   returnTo?: string;
   showQuickUnlike?: boolean;
+  viewerId?: number | null;
 }
 
 // =============================================================================

--- a/features/report/components/ReportModal.tsx
+++ b/features/report/components/ReportModal.tsx
@@ -16,17 +16,28 @@
  * 2026.04.06  임도헌   Modified  모바일 키보드가 열려도 textarea와 CTA가 안전하게 보이도록 시트형 배치와 내부 스크롤 구조 적용
  * 2026.04.10  임도헌   Modified  신고 사유 선택 라벨 weight를 Pretendard subset 3-weight 정책에 맞춰 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.06.19  임도헌   Modified  X 닫기와 중복되는 푸터 취소 버튼을 제거해 신고 제출 CTA 중심으로 정리
+ * 2026.06.19  임도헌   Modified  모바일 신고 UI를 공용 BottomSheet로 분기해 차단/신고 모달 문법 통일
  */
 
-import { useState, useTransition, useEffect, useId, useRef } from "react";
+import {
+  useState,
+  useTransition,
+  useEffect,
+  useId,
+  useRef,
+  useCallback,
+} from "react";
 import { createPortal } from "react-dom";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import BottomSheet from "@/components/global/BottomSheet";
 import { lockBodyScroll, unlockBodyScroll } from "@/lib/bodyScrollLock";
 import { cn } from "@/lib/utils";
 import { submitReportAction } from "@/features/report/actions/create";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import {
   REPORT_REASON_LABELS,
   REPORT_ERRORS,
@@ -65,6 +76,7 @@ export default function ReportModal({
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const titleId = useId();
   const descriptionId = useId();
+  const isMobile = useIsMobile();
   const [reason, setReason] = useState<ReportReason | "">("");
   const [description, setDescription] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -80,22 +92,27 @@ export default function ReportModal({
     setMounted(true);
   }, []);
 
+  const handleRequestClose = useCallback(() => {
+    if (!isPending) onClose();
+  }, [isPending, onClose]);
+
   // 모달 닫힐 때 상태 초기화
   useEffect(() => {
     if (!isOpen) {
       setReason("");
       setDescription("");
-    } else {
-      // 열렸을 때 배경 스크롤 방지
+    } else if (!isMobile) {
+      // 데스크톱 모달은 직접 관리하고, 모바일 스크롤/포커스는 공용 BottomSheet가 담당
       lockBodyScroll();
       return () => {
         unlockBodyScroll();
       };
     }
-  }, [isOpen]);
+  }, [isMobile, isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
+    if (isMobile) return;
 
     previousFocusRef.current =
       document.activeElement instanceof HTMLElement
@@ -108,7 +125,7 @@ export default function ReportModal({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        if (!isPending) onClose();
+        handleRequestClose();
         return;
       }
 
@@ -142,7 +159,7 @@ export default function ReportModal({
       document.removeEventListener("keydown", handleKeyDown);
       previousFocusRef.current?.focus();
     };
-  }, [isOpen, isPending, onClose]);
+  }, [handleRequestClose, isMobile, isOpen]);
 
   if (!isOpen || !mounted) return null;
 
@@ -175,13 +192,84 @@ export default function ReportModal({
     });
   };
 
+  const reportForm = (
+    <div className="flex flex-col gap-6">
+      <div>
+        <label className="text-sm font-bold text-primary mb-3 block">
+          신고 사유
+        </label>
+        <div className="space-y-2 max-h-[40vh] overflow-y-auto scrollbar-hide">
+          {(Object.keys(REPORT_REASON_LABELS) as ReportReason[]).map((r) => (
+            <label
+              key={r}
+              className={cn(
+                "flex items-center gap-3 p-3.5 rounded-2xl border cursor-pointer transition-[background-color,color,border-color,box-shadow]",
+                reason === r
+                  ? "bg-brand/5 border-brand/50 text-brand dark:bg-brand-light/10 dark:border-brand-light/50 dark:text-brand-light"
+                  : "bg-surface border-border text-muted hover:bg-surface-dim"
+              )}
+            >
+              <input
+                type="radio"
+                name="report_reason"
+                value={r}
+                checked={reason === r}
+                onChange={(e) => setReason(e.target.value as ReportReason)}
+                className="size-4 shrink-0 accent-brand dark:accent-brand-light"
+                disabled={isPending}
+              />
+              <span className="text-sm font-medium">
+                {REPORT_REASON_LABELS[r]}
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label className="text-sm font-bold text-primary mb-2 block">
+          상세 설명 <span className="font-normal text-muted text-xs">(선택)</span>
+        </label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="내용을 입력하세요..."
+          className="input-primary min-h-[100px] p-4 text-sm bg-surface-dim border-none resize-none"
+          maxLength={500}
+          disabled={isPending}
+        />
+      </div>
+    </div>
+  );
+
+  const submitButton = (
+    <button
+      onClick={handleSubmit}
+      className="btn-primary h-11 px-8"
+      disabled={isPending || !reason}
+    >
+      {isPending ? "접수 중..." : "신고하기"}
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open
+        title="신고하기"
+        onClose={handleRequestClose}
+        contentClassName="px-4 py-5"
+        footer={<div className="flex justify-end">{submitButton}</div>}
+      >
+        {reportForm}
+      </BottomSheet>
+    );
+  }
+
   const modalContent = (
     <div className="fixed inset-0 z-[150] flex items-end justify-center bg-black/60 px-4 pt-6 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-sm sm:items-center sm:p-4">
       {/* 배경 클릭 시 닫기 */}
-      <div
-        className="absolute inset-0"
-        onClick={() => !isPending && onClose()}
-      />
+      <div className="absolute inset-0" onClick={handleRequestClose} />
 
       <div
         className="relative flex max-h-[calc(100dvh-1rem)] w-full max-w-sm flex-col overflow-hidden rounded-t-3xl border border-border-subtle bg-surface shadow-2xl sm:max-h-[calc(100dvh-2rem)] sm:rounded-3xl"
@@ -202,7 +290,7 @@ export default function ReportModal({
             신고하기
           </h2>
           <button
-            onClick={() => !isPending && onClose()}
+            onClick={handleRequestClose}
             disabled={isPending}
             ref={closeButtonRef}
             aria-label="신고 모달 닫기"
@@ -213,75 +301,13 @@ export default function ReportModal({
         </div>
 
         {/* 본문 */}
-        <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-6">
-          <div>
-            <label className="text-sm font-bold text-primary mb-3 block">
-              신고 사유
-            </label>
-            <div className="space-y-2 max-h-[40vh] overflow-y-auto scrollbar-hide">
-              {(Object.keys(REPORT_REASON_LABELS) as ReportReason[]).map(
-                (r) => (
-                  <label
-                    key={r}
-                    className={cn(
-                      "flex items-center gap-3 p-3.5 rounded-2xl border cursor-pointer transition-[background-color,color,border-color,box-shadow]",
-                      reason === r
-                        ? "bg-brand/5 border-brand/50 text-brand dark:bg-brand-light/10 dark:border-brand-light/50 dark:text-brand-light"
-                        : "bg-surface border-border text-muted hover:bg-surface-dim"
-                    )}
-                  >
-                    <input
-                      type="radio"
-                      name="report_reason"
-                      value={r}
-                      checked={reason === r}
-                      onChange={(e) =>
-                        setReason(e.target.value as ReportReason)
-                      }
-                      className="size-4 shrink-0 accent-brand dark:accent-brand-light"
-                      disabled={isPending}
-                    />
-                    <span className="text-sm font-medium">
-                      {REPORT_REASON_LABELS[r]}
-                    </span>
-                  </label>
-                )
-              )}
-            </div>
-          </div>
-
-          <div>
-            <label className="text-sm font-bold text-primary mb-2 block">
-              상세 설명{" "}
-              <span className="font-normal text-muted text-xs">(선택)</span>
-            </label>
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="내용을 입력하세요..."
-              className="input-primary min-h-[100px] p-4 text-sm bg-surface-dim border-none resize-none"
-              maxLength={500}
-              disabled={isPending}
-            />
-          </div>
+        <div className="flex-1 overflow-y-auto p-6">
+          {reportForm}
         </div>
 
         {/* 하단 액션 */}
-        <div className="shrink-0 p-4 border-t border-border-subtle bg-surface flex justify-end gap-3">
-          <button
-            onClick={onClose}
-            className="btn-secondary-modal h-11 px-6 text-sm font-medium"
-            disabled={isPending}
-          >
-            취소
-          </button>
-          <button
-            onClick={handleSubmit}
-            className="btn-primary h-11 px-8"
-            disabled={isPending || !reason}
-          >
-            {isPending ? "접수 중..." : "신고하기"}
-          </button>
+        <div className="shrink-0 p-4 border-t border-border-subtle bg-surface flex justify-end">
+          {submitButton}
         </div>
       </div>
     </div>

--- a/features/report/components/admin/AdminActionModal.tsx
+++ b/features/report/components/admin/AdminActionModal.tsx
@@ -15,9 +15,13 @@
  * 2026.04.26  임도헌   Modified  관리자 액션 모달에 dialog 의미와 설명/입력 라벨 연결, ESC 닫기 흐름을 보강
  * 2026.04.26  임도헌   Modified  primary 확인 버튼의 다크모드 색조를 공용 CTA 톤과 맞춰 정리
  * 2026.04.28  임도헌   Modified  모바일 관리자 액션을 공용 BottomSheet로 분기해 작은 화면의 입력/버튼 잘림을 완화
+ * 2026.06.19  임도헌   Modified  데스크톱 X 닫기를 추가하고 푸터 취소 버튼을 제거해 실제 관리자 액션만 남김
+ * 2026.06.19  임도헌   Modified  데스크톱 관리자 액션 모달을 포털로 렌더링해 관리자 셸의 레이아웃 문맥에서 분리
  */
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import BottomSheet from "@/components/global/BottomSheet";
 import { cn } from "@/lib/utils";
 import Select from "@/components/ui/Select";
@@ -80,6 +84,15 @@ export default function AdminActionModal({
   const [isPending, startTransition] = useTransition();
   const dialogRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
+  const [mounted, setMounted] = useState(false);
+
+  const handleRequestClose = useCallback(() => {
+    if (!isPending) onClose();
+  }, [isPending, onClose]);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // 모달 종료 시 입력 상태 초기화
   // 같은 모달을 여러 대상에 재사용하므로 닫힐 때 사유와 기간을 기본값으로 초기화
@@ -95,7 +108,7 @@ export default function AdminActionModal({
 
     const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !isPending) onClose();
+      if (event.key === "Escape") handleRequestClose();
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -103,9 +116,9 @@ export default function AdminActionModal({
       window.clearTimeout(timer);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isMobile, isPending, onClose, open]);
+  }, [handleRequestClose, isMobile, open]);
 
-  if (!open) return null;
+  if (!open || !mounted) return null;
 
   const handleConfirm = () => {
     if (reason.trim().length < minReasonLength) return;
@@ -179,14 +192,6 @@ export default function AdminActionModal({
 
   const footer = (
     <div className="flex flex-col justify-end gap-3 sm:flex-row">
-      <button
-        onClick={onClose}
-        disabled={isPending}
-        className="btn-secondary-modal flex-1 px-4 text-sm font-medium sm:flex-none"
-      >
-        취소
-      </button>
-
       {secondaryLabel && onSecondaryAction && (
         <button
           onClick={handleSecondary}
@@ -201,7 +206,7 @@ export default function AdminActionModal({
         onClick={handleConfirm}
         disabled={isPending || reason.trim().length < minReasonLength}
         className={cn(
-          "focus-ring-strong flex items-center justify-center gap-2 rounded-xl px-6 py-2.5 text-sm font-bold shadow-sm transition-[background-color,color,border-color,box-shadow,opacity] disabled:opacity-50",
+          "focus-ring-strong flex min-h-10 flex-1 items-center justify-center gap-2 rounded-xl px-6 py-2.5 text-sm font-bold shadow-sm transition-[background-color,color,border-color,box-shadow,opacity] disabled:opacity-50 sm:flex-none",
           variantClasses[confirmVariant]
         )}
       >
@@ -219,7 +224,7 @@ export default function AdminActionModal({
         open
         title={title}
         description={description}
-        onClose={onClose}
+        onClose={handleRequestClose}
         footer={footer}
         contentClassName="pt-4"
         panelClassName="max-h-[90dvh]"
@@ -229,7 +234,7 @@ export default function AdminActionModal({
     );
   }
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
       <div
         ref={dialogRef}
@@ -241,15 +246,31 @@ export default function AdminActionModal({
         className="flex max-h-[calc(100dvh-2rem)] w-full max-w-md flex-col overflow-hidden rounded-3xl border border-border-subtle bg-surface shadow-2xl"
       >
         <div className="flex-1 overflow-y-auto p-6">
-          <h3 id="admin-action-title" className="text-xl font-bold text-primary">
-            {title}
-          </h3>
-          <p
-            id="admin-action-description"
-            className="text-sm text-muted mt-2 mb-6 leading-relaxed"
-          >
-            {description}
-          </p>
+          <div className="mb-6 flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <h3
+                id="admin-action-title"
+                className="text-xl font-bold text-primary"
+              >
+                {title}
+              </h3>
+              <p
+                id="admin-action-description"
+                className="mt-2 text-sm leading-relaxed text-muted"
+              >
+                {description}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleRequestClose}
+              disabled={isPending}
+              aria-label="관리자 액션 모달 닫기"
+              className="focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
+            >
+              <XMarkIcon className="size-6" />
+            </button>
+          </div>
           {content}
         </div>
 
@@ -257,6 +278,7 @@ export default function AdminActionModal({
           {footer}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/features/report/components/admin/ReportActionDialog.tsx
+++ b/features/report/components/admin/ReportActionDialog.tsx
@@ -21,10 +21,22 @@
  * 2026.04.27  임도헌   Modified  기각 사유 전달과 유저 단독 신고의 콘텐츠 삭제 추천 제외 흐름 보강
  * 2026.04.28  임도헌   Modified  모바일 신고 처리 UI를 공용 BottomSheet로 분기해 작은 화면의 잘림을 완화
  * 2026.04.28  임도헌   Modified  신고 처리 전 실제 조치 대상 유저를 모달에서 확인할 수 있도록 표시 보강
+ * 2026.06.19  임도헌   Modified  데스크톱 X 닫기를 추가하고 푸터 취소/닫기 버튼을 제거해 처리 액션 중심으로 정리
+ * 2026.06.19  임도헌   Modified  신고 처리 오버레이 레이어를 상향해 관리자 상단 영역까지 안정적으로 덮도록 보강
+ * 2026.06.19  임도헌   Modified  데스크톱 신고 처리 모달을 포털로 렌더링해 관리자 셸의 레이아웃 문맥에서 분리
  */
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { createPortal } from "react-dom";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { toast } from "sonner";
 import BottomSheet from "@/components/global/BottomSheet";
 import { updateReportAction } from "@/features/report/actions/admin";
@@ -147,6 +159,15 @@ export default function ReportActionDialog({
   const dialogRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
   const isReadOnly = reportStatus !== "PENDING";
+  const [mounted, setMounted] = useState(false);
+
+  const handleRequestClose = useCallback(() => {
+    if (!isPending) onClose();
+  }, [isPending, onClose]);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -164,7 +185,7 @@ export default function ReportActionDialog({
 
     const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !isPending) onClose();
+      if (event.key === "Escape") handleRequestClose();
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -172,9 +193,9 @@ export default function ReportActionDialog({
       window.clearTimeout(timer);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isMobile, isPending, onClose, open]);
+  }, [handleRequestClose, isMobile, open]);
 
-  if (!open) return null;
+  if (!open || !mounted) return null;
 
   const handleAction = (status: "RESOLVED" | "DISMISSED") => {
     startTransition(async () => {
@@ -297,9 +318,7 @@ export default function ReportActionDialog({
             <div className="mt-3 space-y-3">
               {targetResolvedUserId ? (
                 <div className="rounded-lg border border-border-subtle bg-surface/70 px-3 py-2">
-                  <p className="text-xs font-bold text-muted">
-                    조치 대상 유저
-                  </p>
+                  <p className="text-xs font-bold text-muted">조치 대상 유저</p>
                   <p className="mt-1 text-sm font-bold text-primary">
                     {targetResolvedUsername || "이름 없음"} #
                     {targetResolvedUserId}
@@ -459,33 +478,22 @@ export default function ReportActionDialog({
     </>
   );
 
-  const footer = (
-    <div className="flex gap-3 justify-end">
+  const footer = isReadOnly ? null : (
+    <div className="flex justify-end gap-3">
       <button
-        onClick={onClose}
+        onClick={() => handleAction("DISMISSED")}
         disabled={isPending}
-        className="btn-secondary-modal h-10 px-4 text-sm font-medium"
+        className="focus-ring-soft inline-flex h-10 min-w-20 items-center justify-center rounded-xl border border-rose-300/50 bg-rose-50 px-4 text-sm font-bold text-rose-700 transition-colors hover:bg-rose-100 disabled:opacity-50 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-300 dark:hover:bg-rose-500/15"
       >
-        {isReadOnly ? "닫기" : "취소"}
+        기각
       </button>
-      {!isReadOnly && (
-        <button
-          onClick={() => handleAction("DISMISSED")}
-          disabled={isPending}
-          className="btn-secondary h-10 text-sm border-border text-primary"
-        >
-          기각
-        </button>
-      )}
-      {!isReadOnly && (
-        <button
-          onClick={() => handleAction("RESOLVED")}
-          disabled={isPending}
-          className="btn-primary h-10 text-sm"
-        >
-          {isPending ? "처리 중..." : "조치 완료"}
-        </button>
-      )}
+      <button
+        onClick={() => handleAction("RESOLVED")}
+        disabled={isPending}
+        className="btn-primary h-10 min-w-24 text-sm"
+      >
+        {isPending ? "처리 중..." : "조치 완료"}
+      </button>
     </div>
   );
 
@@ -495,7 +503,7 @@ export default function ReportActionDialog({
         open
         title="신고 처리"
         description={dialogDescription}
-        onClose={onClose}
+        onClose={handleRequestClose}
         footer={footer}
         contentClassName="pt-4"
         panelClassName="max-h-[92dvh]"
@@ -505,8 +513,8 @@ export default function ReportActionDialog({
     );
   }
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm">
       <div
         ref={dialogRef}
         role="dialog"
@@ -517,22 +525,41 @@ export default function ReportActionDialog({
         className="flex max-h-[calc(100dvh-2rem)] w-full max-w-md flex-col overflow-hidden rounded-3xl border border-border-subtle bg-surface shadow-2xl"
       >
         <div className="flex-1 overflow-y-auto p-6">
-          <h3
-            id="report-action-title"
-            className="text-lg font-bold text-primary mb-2"
-          >
-            신고 처리
-          </h3>
-          <p id="report-action-description" className="text-sm text-muted mb-4">
-            {dialogDescription}
-          </p>
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <h3
+                id="report-action-title"
+                className="text-lg font-bold text-primary"
+              >
+                신고 처리
+              </h3>
+              <p
+                id="report-action-description"
+                className="mt-2 text-sm text-muted"
+              >
+                {dialogDescription}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleRequestClose}
+              disabled={isPending}
+              aria-label="신고 처리 모달 닫기"
+              className="focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
+            >
+              <XMarkIcon className="size-6" />
+            </button>
+          </div>
           {content}
         </div>
 
-        <div className="shrink-0 border-t border-border-subtle bg-surface px-6 py-4">
-          {footer}
-        </div>
+        {footer && (
+          <div className="shrink-0 border-t border-border-subtle bg-surface px-6 py-4">
+            {footer}
+          </div>
+        )}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/features/review/service/create.ts
+++ b/features/review/service/create.ts
@@ -24,6 +24,7 @@
  * 2026.03.07  임도헌   Modified  push 성공 판정 기준을 result.data.sent로 정정
  * 2026.03.07  임도헌   Modified  차단 관계에서는 리뷰 작성 불가하도록 가드 추가
  * 2026.04.03  임도헌   Modified  리뷰 생성 helper 주석 보강
+ * 2026.06.21  임도헌   Modified  인앱 알림 더보기와 맞도록 리뷰 알림 본문 사전 축약 제거
  */
 
 import "server-only";
@@ -80,12 +81,8 @@ async function sendPush(params: {
   }
 }
 
-/**
- * 긴 리뷰 본문을 알림용 짧은 미리보기 문자열로 정규화
- */
-function buildPreview(text: string, max = 30) {
-  const plain = text.replace(/\s+/g, " ").trim();
-  return plain.length <= max ? plain : `${plain.slice(0, max)}...`;
+function normalizeNotificationText(text: string) {
+  return text.replace(/\s+/g, " ").trim();
 }
 
 /**
@@ -200,7 +197,7 @@ export async function createReviewService(
           const title = "새로운 리뷰가 작성되었습니다";
           const body = `${review.user.username}님이 ${
             prod.title
-          }에 리뷰를 작성했습니다: "${buildPreview(data.payload)}"`;
+          }에 리뷰를 작성했습니다: "${normalizeNotificationText(data.payload)}"`;
 
           // DB 알림 저장
           const notification = await db.notification.create({

--- a/features/search/components/PopularSearchesBox.tsx
+++ b/features/search/components/PopularSearchesBox.tsx
@@ -15,6 +15,7 @@
  * 2026.04.10  임도헌   Modified  검색 타이포 정책에 맞춰 섹션 헤더 weight를 500 기준으로 정리
  * 2026.04.10  임도헌   Modified  상위 검색 모달 클라이언트 경계 아래에서만 사용되도록 use client 중복 선언을 제거
  * 2026.04.17  임도헌   Modified  인기 검색어 링크 렌더링과 빈 상태 처리 책임이 주석에서 바로 드러나도록 설명 보강
+ * 2026.06.14  임도헌   Modified  인기 검색어 클릭 시 기존 분류/필터 조건을 유지하도록 검색 실행 경로 통일
  */
 
 import Link from "next/link";
@@ -56,9 +57,12 @@ export default function PopularSearchesBox({
         <div className="space-y-1">
           {popularSearches.map((item, index) => (
             <Link
-              key={index}
+              key={item.keyword}
               href={`${basePath}?keyword=${encodeURIComponent(item.keyword)}`}
-              onClick={() => onSearch(item.keyword)}
+              onClick={(e) => {
+                e.preventDefault();
+                onSearch(item.keyword);
+              }}
               className="focus-ring-soft group -mx-2 flex items-start gap-2 rounded-lg p-2 transition-colors hover:bg-surface-dim"
             >
               <span className="mt-0.5 w-5 shrink-0 text-center text-sm font-bold text-brand dark:text-brand-light">

--- a/features/search/components/PostCategoryTabs.tsx
+++ b/features/search/components/PostCategoryTabs.tsx
@@ -30,6 +30,7 @@
  * 2026.04.20  임도헌   Modified  키보드 포커스가 브라우저 기본 outline으로 보이지 않도록 공용 soft 포커스 규칙을 적용
  * 2026.05.03  임도헌   Modified  카테고리 툴팁이 뒤 콘텐츠와 섞이지 않도록 불투명 surface 톤으로 보정
  * 2026.05.05  임도헌   Modified  카테고리 탭 상호작용 핸들러 JSDoc 보강
+ * 2026.06.15  임도헌   Modified  게시글 카테고리 변경 시 검색어를 유지하도록 검색 조합 정책 통일
  */
 
 import { useRef, useState } from "react";
@@ -71,21 +72,42 @@ export default function PostCategoryTabs({
   const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
 
   /**
-   * 게시글 카테고리 변경 시 검색어 초기화와 목록 URL 갱신
+   * 게시글 카테고리 변경 시 기존 검색어를 유지한 채 목록 URL 갱신
    *
    * @param category - 선택한 게시글 카테고리 key, 없으면 전체
    */
   const handleCategoryClick = (category?: string) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.delete("keyword"); // 검색어 초기화
 
     if (category) {
       params.set("category", category);
     } else {
-      params.delete("category"); // 전체 보기
+      params.delete("category"); // 전체 카테고리 보기
     }
 
-    router.push(`/posts?${params.toString()}`);
+    const query = params.toString();
+    router.push(query ? `/posts?${query}` : "/posts");
+  };
+
+  /**
+   * 탭 링크 href 생성
+   *
+   * - 실제 클릭은 handleCategoryClick이 처리하지만, 새 탭 열기/주소 미리보기에서도
+   *   검색어 유지 정책이 드러나도록 현재 쿼리를 반영한다.
+   *
+   * @param category - 선택한 게시글 카테고리 key, 없으면 전체
+   */
+  const createCategoryHref = (category?: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (category) {
+      params.set("category", category);
+    } else {
+      params.delete("category");
+    }
+
+    const query = params.toString();
+    return query ? `/posts?${query}` : "/posts";
   };
 
   const isTouchDevice =
@@ -214,7 +236,7 @@ export default function PostCategoryTabs({
             onTouchEnd={handleTouchEnd}
           >
             <Link
-              href="/posts"
+              href={createCategoryHref()}
               prefetch={false}
               onClick={(e) => {
                 e.preventDefault();
@@ -279,7 +301,7 @@ export default function PostCategoryTabs({
               onTouchEnd={handleTouchEnd} // 모바일 long press 종료
             >
               <Link
-                href={`/posts?category=${key}`}
+                href={createCategoryHref(key)}
                 prefetch={false}
                 onClick={(e) => {
                   e.preventDefault();

--- a/features/search/components/ProductCategoryDropdown.tsx
+++ b/features/search/components/ProductCategoryDropdown.tsx
@@ -27,13 +27,13 @@
  * 2026.04.02  임도헌   Modified  카테고리 옵션/빠른 분류 키 타입을 search 도메인 공용 타입 기준으로 정리
  * 2026.04.10  임도헌   Modified  검색 타이포 정책에 맞춰 분류 라벨 및 섹션 헤더 weight를 500 기준으로 정리
  * 2026.05.16  임도헌   Modified  빠른 분류 선택 시 초기화할 쿼리 키를 search 상수로 분리
+ * 2026.06.14  임도헌   Modified  분류 선택이 기존 검색어/상세 필터를 유지하도록 검색 정책 통일
  */
 "use client";
 
 import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { GAME_TYPE_DISPLAY, GAME_TYPES } from "@/features/product/constants";
-import { SEARCH_QUICK_CATEGORY_RESET_KEYS } from "@/features/search/constants";
 import BottomSheet from "@/components/global/BottomSheet";
 import type {
   ProductQuickCategoryParamKey,
@@ -54,7 +54,7 @@ interface CategoryDropdownProps {
  * 검색바 좌측의 카테고리 빠른 선택 드롭다운
  * - 게임 타입(보드게임/TRPG/카드) 및 대분류 카테고리를 바로 선택하여 이동
  * - `compact`, `tone` props로 헤더 버튼 밀도와 flat 톤을 분기
- * - 빠른 분류 선택 시 기존 검색어/가격/상태 조건은 비우고 분류 축만 남김
+ * - 분류 선택 시 기존 검색어/가격/상태 조건을 유지해 현재 결과를 좁힘
  */
 export default function ProductCategoryDropdown({
   categories,
@@ -68,17 +68,15 @@ export default function ProductCategoryDropdown({
   const isMobile = useIsMobile();
 
   /**
-   * 빠른 분류 전용 쿼리 재구성
-   * - 기존 검색어/가격/상태 조건 초기화
-   * - 선택한 분류 축만 유지
+   * 분류 전용 쿼리 갱신
+   * - keyword와 상세 필터는 유지
+   * - 선택한 분류 파라미터만 교체
    */
   const createQuickCategoryQuery = (
     name: ProductQuickCategoryParamKey,
     value: string
   ) => {
     const params = new URLSearchParams(searchParams.toString());
-    // 세부 검색 조건 초기화
-    SEARCH_QUICK_CATEGORY_RESET_KEYS.forEach((key) => params.delete(key));
     params.set(name, value);
 
     return params.toString();
@@ -194,7 +192,7 @@ export default function ProductCategoryDropdown({
         <BottomSheet
           open={isOpen}
           title="카테고리 선택"
-          description="게임 타입과 장르를 빠르게 선택해 새 탐색을 시작합니다."
+          description="게임 타입과 장르를 현재 검색 조건에 추가합니다."
           onClose={() => setIsOpen(false)}
           contentClassName="pt-4"
         >

--- a/features/search/components/RegionFilterToggle.tsx
+++ b/features/search/components/RegionFilterToggle.tsx
@@ -18,6 +18,7 @@
  * 2026.04.10  임도헌   Modified  검색 타이포 정책에 맞춰 범위 라벨/드롭다운 헤더 weight를 500 기준으로 정리
  * 2026.04.20  임도헌   Modified  제품 헤더 범위 토글과 드롭다운 항목에 공용 포커스 링을 적용해 헤더 포커스 문법을 통일
  * 2026.04.20  임도헌   Modified  모바일에서는 지역 범위 선택을 BottomSheet로 제공해 제품/게시글 헤더의 조작 밀도와 모달 패턴을 통일
+ * 2026.06.18  임도헌   Modified  도 단위 주소 정규화 정책에 맞춰 시/군 단위 표현과 주석 정리
  */
 "use client";
 
@@ -51,15 +52,15 @@ interface Props {
 /**
  * 리스트 페이지용 지역 필터 토글
  *
- * - "내 동네 / 구 단위 / 시 단위 / 전국" 범위를 선택하는 UI를 제공
+ * - "내 동네 / 구 단위 / 시/군 단위 / 전국" 범위를 선택하는 UI를 제공
  * - [Change] URL Query(`?region=...`)를 변경하지 않고, `updateUserLocationAction`을 호출하여
  *   DB의 `User.regionRange` 필드를 직접 업데이트 (SSOT: DB).
  * - 세종시 등 '구/군'이 없는 특수 행정구역의 경우 '구 단위' 옵션을 자동으로 숨김 처리
  * - 낙관적 업데이트(Optimistic UI)를 적용하여 클릭 즉시 UI를 변경하고 백그라운드에서 저장
  * - 저장 성공 시 toast와 `router.refresh()`로 서버 상태 재동기화
  *
- * @param userRegion1 - 시/도
- * @param userRegion2 - 구/군
+ * @param userRegion1 - 지역 필터 1차 단위(카카오 1depth 또는 도 단위의 시/군)
+ * @param userRegion2 - 지역 필터 2차 단위(구/군, 없으면 userRegion1)
  * @param userRegion3 - 동/읍/면
  * @param currentRange - 현재 설정된 범위 (Server Component에서 주입)
  */
@@ -77,7 +78,7 @@ export default function RegionFilterToggle({
   const menuRef = useRef<HTMLDivElement>(null);
 
   // '구' 단위가 유의미한 지역인지 판별
-  // region2가 없거나, region1(시/도)과 region2(구/군)가 같다면 '구 단위' 필터는 불필요함 (예: 세종시)
+  // region2가 없거나 region1과 같다면 '구 단위' 필터는 불필요함 (예: 세종시, 구가 없는 시/군)
   const hasDistinctGu = !!userRegion2 && userRegion2 !== userRegion1;
   const activeItemClass =
     "bg-brand/5 font-medium text-brand dark:bg-brand-light/15 dark:text-brand-light";

--- a/features/search/components/SearchBar.tsx
+++ b/features/search/components/SearchBar.tsx
@@ -25,10 +25,12 @@
  * 2026.04.10  임도헌   Modified  상위 클라이언트 래퍼 아래에서만 사용되도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.17  임도헌   Modified  탭 상단 검색바에 공통 입력 스타일 클래스를 적용
  * 2026.05.16  임도헌   Modified  검색 제출 로딩 표시 시간을 search 상수로 분리
+ * 2026.06.15  임도헌   Modified  검색어가 있을 때 즉시 초기화할 수 있는 clear 버튼 추가
  */
 
 import { useEffect, useState } from "react";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import { cn } from "@/lib/utils";
 import { SEARCH_SUBMIT_PENDING_MS } from "@/features/search/constants";
 
@@ -58,6 +60,7 @@ export default function SearchBar({
 }: SearchBarProps) {
   const [keyword, setKeyword] = useState(value);
   const [isPending, setIsPending] = useState(false);
+  const hasKeyword = keyword.trim().length > 0;
 
   useEffect(() => {
     setKeyword(value);
@@ -68,6 +71,13 @@ export default function SearchBar({
     const trimmed = keyword.trim();
     setIsPending(true);
     onSearch(trimmed);
+    setTimeout(() => setIsPending(false), SEARCH_SUBMIT_PENDING_MS);
+  };
+
+  const handleClear = () => {
+    setKeyword("");
+    setIsPending(true);
+    onSearch("");
     setTimeout(() => setIsPending(false), SEARCH_SUBMIT_PENDING_MS);
   };
 
@@ -90,6 +100,17 @@ export default function SearchBar({
         )}
       />
       <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-[18px] text-muted pointer-events-none" />
+
+      {hasKeyword && !isPending && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="focus-ring-soft absolute right-2 top-1/2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted transition-colors hover:text-danger"
+          aria-label="검색어 지우기"
+        >
+          <XMarkIcon className="size-4" />
+        </button>
+      )}
 
       {isPending && (
         <div className="absolute right-3 top-1/2 -translate-y-1/2">

--- a/features/search/components/SearchHistoryBox.tsx
+++ b/features/search/components/SearchHistoryBox.tsx
@@ -14,6 +14,7 @@
  * 2026.04.02  임도헌   Modified  검색 기록 타입 import를 search 도메인 공용 타입 기준으로 정리
  * 2026.04.10  임도헌   Modified  검색 타이포 정책에 맞춰 섹션 헤더 weight를 500 기준으로 정리
  * 2026.04.10  임도헌   Modified  상위 검색 모달 클라이언트 경계 아래에서만 사용되도록 use client 중복 선언을 제거
+ * 2026.06.14  임도헌   Modified  모바일 최근 검색어 삭제 후 터치 잔상과 삭제 버튼 hover 배경을 정리
  */
 
 import Link from "next/link";
@@ -78,14 +79,17 @@ export default function SearchHistoryBox({
               : "flex-wrap"
           )}
         >
-          {history.map((item, index) => (
+          {history.map((item) => (
             <div
-              key={index}
+              key={item.keyword}
               className="group relative flex items-center shrink-0"
             >
               <Link
                 href={`${basePath}?keyword=${encodeURIComponent(item.keyword)}`}
-                onClick={() => onSearch(item.keyword)}
+                onClick={(e) => {
+                  e.preventDefault();
+                  onSearch(item.keyword);
+                }}
                 className={cn(
                   "focus-ring-soft border border-transparent bg-surface-dim px-3 py-1.5 pr-7 text-sm text-primary transition-colors hover:bg-border rounded-lg",
                   "whitespace-nowrap"
@@ -94,11 +98,13 @@ export default function SearchHistoryBox({
                 {item.keyword}
               </Link>
               <button
+                type="button"
                 onClick={(e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   onRemove(item.keyword);
                 }}
-                className="focus-ring-soft absolute right-1 inline-flex min-h-[28px] min-w-[28px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface hover:text-danger"
+                className="focus-ring-soft absolute right-1 inline-flex min-h-[28px] min-w-[28px] items-center justify-center rounded-full text-muted transition-colors hover:text-danger"
                 aria-label={`${item.keyword} 삭제`}
               >
                 <XMarkIcon className="size-3.5" />

--- a/features/search/constants.ts
+++ b/features/search/constants.ts
@@ -7,6 +7,7 @@
  * Date        Author   Status    Description
  * 2026.04.02  임도헌   Created   검색 기록/필터/롱프레스 정책 상수 분리
  * 2026.05.16  임도헌   Modified  검색 제출 로딩 표시 시간과 빠른 분류 초기화 키 상수 추가
+ * 2026.06.14  임도헌   Modified  분류 선택이 검색 조건을 유지하도록 빠른 분류 초기화 키 제거
  */
 
 import type { SearchFilterKey } from "@/features/search/types";
@@ -28,9 +29,3 @@ export const SEARCH_TAB_TOOLTIP_LONG_PRESS_MS = 600;
 
 /** 검색 제출 후 최소 로딩 표시 시간(ms) */
 export const SEARCH_SUBMIT_PENDING_MS = 500;
-
-/** 제품 빠른 분류 선택 시 초기화할 검색/필터 파라미터 */
-export const SEARCH_QUICK_CATEGORY_RESET_KEYS = [
-  "keyword",
-  ...SEARCH_FILTER_KEYS,
-] as const;

--- a/features/stream/components/EditStreamMetaModal.tsx
+++ b/features/stream/components/EditStreamMetaModal.tsx
@@ -8,6 +8,8 @@
  * 2026.04.07  임도헌   Created   방송 상세 상단 메뉴에서 여는 제목/설명 수정 모달 추가
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.06.01  임도헌   Modified  방송 정보 수정 입력 높이를 모바일 작성형 폼 기준으로 정리
+ * 2026.06.19  임도헌   Modified  X 닫기와 중복되는 푸터 취소 버튼을 제거해 저장 CTA 중심으로 정리
+ * 2026.06.19  임도헌   Modified  모바일 방송 정보 수정 UI를 공용 BottomSheet로 분기해 모달 문법 통일
  */
 
 import { useEffect, useState, useTransition } from "react";
@@ -15,9 +17,11 @@ import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import BottomSheet from "@/components/global/BottomSheet";
 import Input from "@/components/ui/Input";
 import { updateBroadcastMetaAction } from "@/features/stream/actions/update";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 interface EditStreamMetaModalProps {
   open: boolean;
@@ -42,6 +46,7 @@ export default function EditStreamMetaModal({
   onClose,
   onSaved,
 }: EditStreamMetaModalProps) {
+  const isMobile = useIsMobile();
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
   const [title, setTitle] = useState(initialTitle);
@@ -119,6 +124,34 @@ export default function EditStreamMetaModal({
     </div>
   );
 
+  const footer = (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={isPending}
+        className="btn-primary h-10 w-full px-5 text-sm sm:w-auto"
+      >
+        {isPending ? "저장 중..." : "저장"}
+      </button>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open={open}
+        title="방송 정보 수정"
+        description="라이브 중에도 제목과 설명을 바로 업데이트할 수 있습니다."
+        onClose={() => !isPending && onClose()}
+        contentClassName="pt-4"
+        footer={footer}
+      >
+        {content}
+      </BottomSheet>
+    );
+  }
+
   return createPortal(
     <div className="fixed inset-0 z-[140] flex items-end justify-center bg-black/60 px-4 pt-6 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-sm sm:items-center sm:p-4">
       <div
@@ -163,24 +196,7 @@ export default function EditStreamMetaModal({
         <div className="flex-1 overflow-y-auto px-6 py-5">{content}</div>
 
         <div className="shrink-0 border-t border-border-subtle bg-surface px-6 py-4">
-          <div className="flex justify-end gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isPending}
-              className="btn-secondary-modal h-10 px-4 text-sm font-medium"
-            >
-              취소
-            </button>
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={isPending}
-              className="btn-primary h-10 px-5 text-sm"
-            >
-              {isPending ? "저장 중..." : "저장"}
-            </button>
-          </div>
+          {footer}
         </div>
       </div>
     </div>,

--- a/features/stream/components/PrivateAccessModal.tsx
+++ b/features/stream/components/PrivateAccessModal.tsx
@@ -24,6 +24,8 @@
  * 2026.04.07  임도헌   Modified  모바일에서는 BottomSheet를 사용해 비밀번호 입력과 키보드 겹침을 완화
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.05.19  임도헌   Modified  비공개 방송 입장 비밀번호 입력에 current-password autocomplete를 명시해 브라우저 폼 경고 완화
+ * 2026.06.19  임도헌   Modified  데스크톱 X 닫기를 추가하고 푸터 취소 버튼을 제거해 입장 CTA 중심으로 정리
+ * 2026.06.19  임도헌   Modified  데스크톱 비공개 방송 입력과 입장 CTA를 한 줄 배치로 정리
  */
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
@@ -36,7 +38,7 @@ import BottomSheet from "@/components/global/BottomSheet";
 import { lockBodyScroll, unlockBodyScroll } from "@/lib/bodyScrollLock";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { LockClosedIcon } from "@heroicons/react/24/outline";
+import { LockClosedIcon, XMarkIcon } from "@heroicons/react/24/outline";
 
 interface PrivateAccessModalProps {
   open: boolean;
@@ -190,6 +192,34 @@ export default function PrivateAccessModal({
   if (!open) return null;
 
   const formId = "private-access-form";
+  const passwordInput = (
+    <input
+      ref={inputRef}
+      type="password"
+      value={password}
+      onChange={(e) => {
+        setPassword(e.target.value);
+        setError("");
+      }}
+      placeholder="비밀번호 입력"
+      autoComplete="current-password"
+      className={cn(
+        "input-primary h-12 rounded-2xl bg-surface-dim px-4",
+        error && "ring-2 ring-danger/50"
+      )}
+      disabled={isPending}
+    />
+  );
+  const submitButton = (
+    <button
+      type="submit"
+      form={formId}
+      disabled={isPending}
+      className="btn-primary min-h-[48px] w-full px-6 text-sm sm:w-auto sm:min-w-[112px]"
+    >
+      {isPending ? "확인 중..." : "입장하기"}
+    </button>
+  );
 
   const content = (
     <form id={formId} onSubmit={handleSubmit} className="space-y-4">
@@ -197,46 +227,29 @@ export default function PrivateAccessModal({
         <label className="mb-2 block text-sm font-medium text-primary">
           비밀번호
         </label>
-        <input
-          ref={inputRef}
-          type="password"
-          value={password}
-          onChange={(e) => {
-            setPassword(e.target.value);
-            setError("");
-          }}
-          placeholder="비밀번호 입력"
-          autoComplete="current-password"
-          className={cn(
-            "input-primary h-12 rounded-2xl bg-surface-dim px-4",
-            error && "ring-2 ring-danger/50"
-          )}
-          disabled={isPending}
-        />
+        {passwordInput}
         {error && <p className="mt-2 text-xs font-medium text-danger">{error}</p>}
       </div>
     </form>
   );
 
   const footer = (
-    <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-      <button
-        type="button"
-        onClick={close}
-        disabled={isPending}
-        className="btn-secondary-modal min-h-[44px] px-4 text-sm font-medium"
-      >
-        취소
-      </button>
-      <button
-        type="submit"
-        form={formId}
-        disabled={isPending}
-        className="btn-primary min-h-[44px] text-sm"
-      >
-        {isPending ? "확인 중..." : "입장하기"}
-      </button>
+    <div className="flex justify-end">
+      {submitButton}
     </div>
+  );
+
+  const desktopContent = (
+    <form id={formId} onSubmit={handleSubmit} className="space-y-2">
+      <label className="block text-sm font-medium text-primary">
+        비밀번호
+      </label>
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">{passwordInput}</div>
+        {submitButton}
+      </div>
+      {error && <p className="text-xs font-medium text-danger">{error}</p>}
+    </form>
   );
 
   if (isMobile) {
@@ -271,26 +284,33 @@ export default function PrivateAccessModal({
       aria-modal="true"
       onClick={() => !isPending && close()}
     >
-        <div
-          ref={modalRef}
-          className={cn(
-          "mx-2.5 w-full max-w-xl rounded-3xl border border-border-subtle bg-surface px-6 py-7 shadow-2xl sm:mx-4 sm:px-8 sm:py-9"
+      <div
+        ref={modalRef}
+        className={cn(
+          "relative mx-2.5 w-full max-w-xl rounded-3xl border border-border-subtle bg-surface px-6 py-7 shadow-2xl sm:mx-4 sm:px-8 sm:py-9"
         )}
         onClick={(e) => e.stopPropagation()}
       >
-          <div className="mb-5 flex flex-col items-center text-center">
-            <div className="state-icon-wrap mb-4 size-[68px]">
-              <LockClosedIcon className="size-8 text-amber-500" />
+        <button
+          type="button"
+          onClick={close}
+          disabled={isPending}
+          aria-label="비공개 방송 모달 닫기"
+          className="focus-ring-soft absolute right-4 top-4 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
+        >
+          <XMarkIcon className="size-6" />
+        </button>
+        <div className="mb-5 flex flex-col items-center text-center">
+          <div className="state-icon-wrap mb-4 size-[68px]">
+            <LockClosedIcon className="size-8 text-amber-500" />
           </div>
           <h3 className="text-2xl font-bold text-primary">비공개 방송</h3>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              방송 입장을 위해 비밀번호를 입력해주세요.
-            </p>
-          </div>
+          <p className="mt-2 text-sm leading-6 text-muted">
+            방송 입장을 위해 비밀번호를 입력해주세요.
+          </p>
+        </div>
 
-          {content}
-
-          <div className="pt-2">{footer}</div>
+        {desktopContent}
       </div>
     </div>,
     document.body

--- a/features/stream/components/StreamCard.tsx
+++ b/features/stream/components/StreamCard.tsx
@@ -52,6 +52,7 @@
  * 2026.05.15  임도헌   Modified  레일 카드 카테고리 배지가 남는 가로폭을 우선 사용하고 부족할 때만 말줄임되도록 조정
  * 2026.05.15  임도헌   Modified  모바일 터치 환경에서 썸네일 미리보기 버튼으로 라이브 프리뷰를 켤 수 있도록 보강
  * 2026.05.18  임도헌   Modified  다시보기 카드 메타를 좋아요/댓글/조회수 Heroicons 통계 문법으로 통일
+ * 2026.06.22  임도헌   Modified  레일 카드 카테고리 배지가 남은 줄 전체를 차지하지 않도록 폭 계산 조정
  */
 
 "use client";
@@ -483,8 +484,8 @@ export default function StreamCard(props: StreamCardProps) {
             {category && (
               <span
                 className={cn(
-                  "ml-auto flex min-w-0 items-center gap-1 rounded bg-black/60 px-2 py-0.5 text-xs font-medium text-white shadow-sm backdrop-blur-[2px]",
-                  isGridLayout ? "max-w-[46%]" : "flex-1"
+                  "ml-auto inline-flex min-w-0 shrink items-center gap-1 rounded bg-black/60 px-2 py-0.5 text-xs font-medium text-white shadow-sm backdrop-blur-[2px]",
+                  isGridLayout ? "max-w-[46%]" : "max-w-[62%]"
                 )}
               >
                 {category.icon && (

--- a/features/stream/components/StreamDetail/index.tsx
+++ b/features/stream/components/StreamDetail/index.tsx
@@ -42,6 +42,7 @@
  * 2026.05.17  임도헌   Modified  live-status 직접 구독 제거 후 셸에서 내려온 상태 props 기준으로 렌더링
  * 2026.05.28  임도헌   Modified  모바일 플레이어와 정보 패널을 화면 폭에 맞게 정리
  * 2026.05.29  임도헌   Modified  셸 상태 기준으로 모바일 방송 정보 노출, 높이 제한, 스크롤 기준 정리
+ * 2026.06.17  임도헌   Modified  팔로우 CTA가 pending 동안 선반영 상태를 유지하도록 opacity/text 처리 정리
  * ===============================================================================================
  * StreamDetail (방송 상세) 페이지를 구성하는 UI 요소들을 분리해 모아둔 디렉토리
  * - StreamStatusOverlay.tsx: 상태에 따라 플레이어 위에 노출되는 공통 상태 오버레이
@@ -317,27 +318,17 @@ export default function StreamDetail({
                       disabled={isPending}
                       aria-pressed={isFollowing}
                       aria-busy={isPending}
-                      aria-label={
-                        isPending
-                          ? "팔로우 처리 중"
-                          : isFollowing
-                            ? "팔로우 취소"
-                            : "팔로우"
-                      }
+                      aria-label={isFollowing ? "팔로우 취소" : "팔로우"}
                       className={cn(
                         "shrink-0 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors lg:px-3.5",
-                        "disabled:cursor-not-allowed disabled:opacity-60",
+                        "disabled:cursor-not-allowed",
                         isFollowing ? "focus-ring-soft" : "focus-ring-strong",
                         isFollowing
                           ? "border-border-strong bg-surface text-muted hover:border-danger/30 hover:bg-danger/5 hover:text-danger"
                           : "border-transparent bg-brand text-white hover:bg-brand-dark"
                       )}
                     >
-                      {isPending
-                        ? "처리 중..."
-                        : isFollowing
-                          ? "팔로우 취소"
-                          : "팔로우"}
+                      {isFollowing ? "팔로우 취소" : "팔로우"}
                     </button>
                   )}
                 </div>

--- a/features/stream/components/StreamEmptyState.tsx
+++ b/features/stream/components/StreamEmptyState.tsx
@@ -18,9 +18,11 @@
  * 2026.03.28  임도헌   Modified  스트림 모드(라이브/다시보기)에 따라 제목/설명/CTA를 분기하도록 확장
  * 2026.04.16  임도헌   Modified  빈 상태 CTA 링크 자동 prefetch를 끄고 실제 선택 시 이동하도록 정리
  * 2026.05.08  임도헌   Modified  스트림 조회 범위 타입을 StreamScope 공용 타입으로 교체
+ * 2026.06.16  임도헌   Modified  검색어+카테고리/팔로잉 0건 상태를 순수 검색 0건과 구분해 안내
  */
 import Link from "next/link";
 import { VideoCameraIcon } from "@heroicons/react/24/outline";
+import { STREAM_CATEGORY } from "@/features/stream/constants";
 import type { StreamMode, StreamScope } from "@/features/stream/types";
 
 interface Props {
@@ -45,9 +47,30 @@ export default function StreamEmptyState({
   const hasCategory = !!category;
   const isFollowingScope = scope === "following";
   const isRecordingMode = mode === "recordings";
-  const keywordHint = hasKeyword
-    ? `'${keyword}'에 대한 ${isRecordingMode ? "다시보기" : "방송"}를 찾지 못했어요.`
+  const hasKeywordWithRefinement =
+    hasKeyword && (hasCategory || isFollowingScope);
+  const categoryLabel = category
+    ? STREAM_CATEGORY[category as keyof typeof STREAM_CATEGORY]
     : null;
+  const targetLabel = isRecordingMode ? "다시보기" : "방송";
+  const conditionLabel = [
+    categoryLabel ? "카테고리" : null,
+    isFollowingScope ? "팔로잉 범위" : null,
+  ]
+    .filter(Boolean)
+    .join("이나 ");
+  const keywordHint = hasKeyword
+    ? hasKeywordWithRefinement
+      ? `'${keyword}' 검색 결과 중 현재 조건에 맞는 ${targetLabel}를 찾지 못했어요.`
+      : `'${keyword}'에 대한 ${targetLabel}를 찾지 못했어요.`
+    : null;
+  const resetRefinementHref = (() => {
+    const params = new URLSearchParams();
+    if (isRecordingMode) params.set("mode", "recordings");
+    if (keyword) params.set("keyword", keyword);
+
+    return params.toString() ? `/streams?${params.toString()}` : "/streams";
+  })();
 
   let title = isRecordingMode
     ? "등록된 다시보기가 없습니다."
@@ -56,15 +79,20 @@ export default function StreamEmptyState({
     ? "방송이 종료되고 준비가 끝난 다시보기가 여기에 표시됩니다."
     : "새로운 신호를 시작해보세요.";
 
-  if (hasKeyword) {
+  if (hasKeywordWithRefinement) {
+    title = "조건에 맞는 결과가 없습니다.";
+    description = conditionLabel
+      ? `검색어는 유지하고 ${conditionLabel}를 넓혀보세요.`
+      : `검색어는 유지하고 ${targetLabel} 범위를 넓혀보세요.`;
+  } else if (hasKeyword) {
     title = "검색 결과가 없습니다.";
     description = isFollowingScope
-      ? `다른 키워드로 검색하거나, 전체 ${isRecordingMode ? "다시보기" : "방송"}으로 범위를 넓혀보세요.`
-      : `다른 키워드로 ${isRecordingMode ? "다시보기" : "방송"}을 검색해보세요.`;
+      ? `다른 키워드로 검색하거나, 전체 ${targetLabel}으로 범위를 넓혀보세요.`
+      : `다른 키워드로 ${targetLabel}을 검색해보세요.`;
   } else if (hasCategory) {
-    title = `이 카테고리 ${isRecordingMode ? "다시보기" : "방송"}이 없습니다.`;
+    title = `이 카테고리 ${targetLabel}이 없습니다.`;
     description = isFollowingScope
-      ? `팔로잉 중인 ${isRecordingMode ? "다시보기" : "방송"}이 없어 다른 카테고리나 전체 목록을 확인해보세요.`
+      ? `팔로잉 중인 ${targetLabel}이 없어 다른 카테고리나 전체 목록을 확인해보세요.`
       : "다른 카테고리를 확인해보세요.";
   } else if (isFollowingScope) {
     title = isRecordingMode
@@ -102,7 +130,16 @@ export default function StreamEmptyState({
               {isRecordingMode ? "라이브 보러가기" : "방송 시작하기"}
             </Link>
           )}
-          {(hasKeyword || hasCategory) && (
+          {hasKeywordWithRefinement && (
+            <Link
+              href={resetRefinementHref}
+              prefetch={false}
+              className="btn-secondary inline-flex min-h-[44px] items-center justify-center px-6 text-sm"
+            >
+              조건 풀고 보기
+            </Link>
+          )}
+          {(hasKeyword || hasCategory) && !hasKeywordWithRefinement && (
             <Link
               href={isRecordingMode ? "/streams?mode=recordings" : "/streams"}
               prefetch={false}
@@ -111,7 +148,7 @@ export default function StreamEmptyState({
               전체 목록 보기
             </Link>
           )}
-          {isFollowingScope && (
+          {isFollowingScope && !hasKeyword && !hasCategory && (
             <Link
               href={isRecordingMode ? "/streams?mode=recordings" : "/streams"}
               prefetch={false}

--- a/features/stream/components/recording/RecordingTopbar.tsx
+++ b/features/stream/components/recording/RecordingTopbar.tsx
@@ -21,6 +21,7 @@
  * 2026.04.24  임도헌   Modified  녹화 삭제의 back/replace 복귀 조건이 현재 정책 기준으로 드러나도록 주석 보강
  * 2026.04.24  임도헌   Modified  내 프로필 방송국에서 진입한 녹화 삭제도 back + refresh 복귀 대상으로 포함
  * 2026.04.24  임도헌   Modified  navigation refresh helper 기준으로 녹화 삭제 후 back 복귀 플래그 기록 중복을 정리
+ * 2026.06.22  임도헌   Modified  녹화 삭제 후 채널/목록 React Query 캐시에서 삭제 항목을 즉시 제거
  */
 
 "use client";
@@ -28,6 +29,7 @@
 import { useEffect, useRef, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { toggleBlockAction } from "@/features/user/actions/block";
 import {
@@ -48,6 +50,7 @@ import {
   markNavigationRefresh,
   NAVIGATION_REFRESH_SCOPES,
 } from "@/lib/navigationRefreshFlag";
+import { removeRecordingFromListCaches } from "@/features/stream/utils/recordingListCache";
 
 const ReportModal = dynamic(
   () => import("@/features/report/components/ReportModal"),
@@ -72,6 +75,7 @@ function isSafeRecordingReturnTarget(href: string) {
 }
 
 interface RecordingTopbarProps {
+  vodId: number;
   broadcastId: number;
   ownerId: number;
   username: string;
@@ -96,6 +100,7 @@ interface RecordingTopbarProps {
  * - 스크롤 중에도 상단에 고정되어 상세 액션 접근을 유지
  */
 export default function RecordingTopbar({
+  vodId,
   broadcastId,
   ownerId,
   username,
@@ -108,6 +113,7 @@ export default function RecordingTopbar({
   preferHistoryBack = false,
 }: RecordingTopbarProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [menuOpen, setMenuOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
   const [blockConfirmOpen, setBlockConfirmOpen] = useState(false);
@@ -173,6 +179,7 @@ export default function RecordingTopbar({
       }
 
       toast.success("녹화를 삭제했습니다.");
+      removeRecordingFromListCaches(queryClient, vodId);
       setDeleteConfirmOpen(false);
       setMenuOpen(false);
 

--- a/features/stream/components/recording/recordingDetail/RecordingLikeButton.tsx
+++ b/features/stream/components/recording/recordingDetail/RecordingLikeButton.tsx
@@ -16,6 +16,7 @@
  * 2026.05.18  임도헌   Modified  녹화본 상세 좋아요 변경 시 메인/채널 다시보기 목록 캐시 동기화 추가
  * 2026.05.26  임도헌   Modified  initialData 기반 likeStatus query에 local queryFn을 부여하고 목록 캐시만 재검증
  * 2026.06.07  임도헌   Modified  계정 전환 시 이전 사용자의 VOD 좋아요 캐시가 재사용되지 않도록 viewer scope 추가
+ * 2026.06.17  임도헌   Modified  낙관 반영 직후 좋아요 버튼이 흐려 보이지 않도록 pending opacity 제거
  */
 
 "use client";
@@ -134,8 +135,9 @@ export default function RecordingLikeButton({
       className={cn(
         "focus-ring-soft -ml-1.5 flex items-center gap-1.5 rounded-lg p-1.5 transition-colors hover:bg-surface-dim",
         data.isLiked ? "text-rose-500" : "text-muted hover:text-rose-500",
-        isPending && "opacity-70 cursor-not-allowed"
+        isPending && "cursor-not-allowed"
       )}
+      aria-busy={isPending}
       aria-pressed={data.isLiked}
       // 시각 카운트의 접근성 이름 포함을 통한 보조기기/시각 정보 불일치 방지
       aria-label={

--- a/features/stream/service/comment.ts
+++ b/features/stream/service/comment.ts
@@ -13,16 +13,111 @@
  * 2026.03.07  임도헌   Modified  댓글 목록의 정지 유저 은닉 및 삭제 액션 정지 유저 가드 적용
  * 2026.05.13  임도헌   Modified  댓글 목록 페이징에서 마지막 페이지 이후 빈 추가 요청이 생기지 않도록 nextCursor 응답으로 보정
  * 2026.05.16  임도헌   Modified  댓글 목록 where 조건 타입 명시
+ * 2026.06.21  임도헌   Modified  녹화본 댓글 작성 시 방송 주인에게 인앱/푸시 알림 전송 추가
  */
 
 import "server-only";
 import db from "@/lib/db";
+import { supabase } from "@/lib/supabase";
 import type { Prisma } from "@/generated/prisma/client";
 import {
   checkBlockRelation,
   getBlockedUserIds,
 } from "@/features/user/service/block";
 import { validateUserStatus } from "@/features/user/service/admin";
+import {
+  canSendPushForType,
+  isNotificationTypeEnabled,
+} from "@/features/notification/utils/policy";
+import { sendPushNotification } from "@/features/notification/service/sender";
+
+function normalizeNotificationText(text: string) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+async function notifyStreamerOnRecordingComment({
+  vodId,
+  recordingTitle,
+  ownerId,
+  commenterId,
+  commenterName,
+  commenterAvatar,
+  payload,
+}: {
+  vodId: number;
+  recordingTitle: string;
+  ownerId: number;
+  commenterId: number;
+  commenterName: string;
+  commenterAvatar: string | null;
+  payload: string;
+}) {
+  if (ownerId === commenterId) return;
+
+  try {
+    const prefs = await db.notificationPreferences.findUnique({
+      where: { userId: ownerId },
+    });
+
+    if (!isNotificationTypeEnabled(prefs, "STREAM")) return;
+
+    const title = "다시보기에 새 댓글이 달렸습니다";
+    const body = `${commenterName}님이 '${recordingTitle}' 다시보기에 댓글을 남겼습니다: ${normalizeNotificationText(
+      payload
+    )}`;
+    const link = `/streams/${vodId}/recording`;
+    const image = commenterAvatar ? `${commenterAvatar}/avatar` : undefined;
+
+    const notification = await db.notification.create({
+      data: {
+        userId: ownerId,
+        title,
+        body,
+        type: "STREAM",
+        link,
+        image,
+        isPushSent: false,
+      },
+    });
+
+    await supabase.channel(`user-${ownerId}-notifications`).send({
+      type: "broadcast",
+      event: "notification",
+      payload: {
+        id: notification.id,
+        userId: ownerId,
+        title: notification.title,
+        body: notification.body,
+        link: notification.link,
+        type: notification.type,
+        image: notification.image,
+        created_at: notification.created_at,
+      },
+    });
+
+    if (canSendPushForType(prefs, "STREAM")) {
+      const pushRes = await sendPushNotification({
+        targetUserId: ownerId,
+        title,
+        message: body,
+        url: link,
+        type: "STREAM",
+        image,
+        tag: `recording-comment-${vodId}`,
+        renotify: true,
+      });
+
+      if (pushRes.success && (pushRes.data?.sent ?? 0) > 0) {
+        await db.notification.update({
+          where: { id: notification.id },
+          data: { isPushSent: true, sentAt: new Date() },
+        });
+      }
+    }
+  } catch (error) {
+    console.warn("[RecordingComment] Notification failed:", error);
+  }
+}
 
 /**
  * 녹화본 댓글 목록 조회 로직
@@ -104,7 +199,12 @@ export const createRecordingComment = async (
   const vod = await db.vodAsset.findUnique({
     where: { id: vodId },
     select: {
-      broadcast: { select: { liveInput: { select: { userId: true } } } },
+      broadcast: {
+        select: {
+          title: true,
+          liveInput: { select: { userId: true } },
+        },
+      },
     },
   });
 
@@ -116,13 +216,30 @@ export const createRecordingComment = async (
     if (isBlocked) throw new Error("FORBIDDEN");
   }
 
-  await db.recordingComment.create({
+  const comment = await db.recordingComment.create({
     data: {
       payload,
       vodId,
       userId,
     },
+    select: {
+      id: true,
+      payload: true,
+      user: { select: { username: true, avatar: true } },
+    },
   });
+
+  if (vod?.broadcast.liveInput.userId) {
+    await notifyStreamerOnRecordingComment({
+      vodId,
+      recordingTitle: vod.broadcast.title,
+      ownerId: vod.broadcast.liveInput.userId,
+      commenterId: userId,
+      commenterName: comment.user.username,
+      commenterAvatar: comment.user.avatar,
+      payload: comment.payload,
+    });
+  }
 };
 
 /**

--- a/features/stream/utils/recordingListCache.ts
+++ b/features/stream/utils/recordingListCache.ts
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.18  임도헌   Created   녹화본 좋아요/댓글 변경 시 메인/채널 다시보기 목록 캐시 갱신 유틸 추가
+ * 2026.06.22  임도헌   Modified  녹화 삭제 후 메인/채널 다시보기 목록에서 항목을 즉시 제거하는 유틸 추가
  */
 
 import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query";
@@ -133,6 +134,50 @@ export function updateRecordingListCaches(
   queryClient.setQueriesData<RecordingInfiniteCache>(
     { predicate: (query) => isChannelRecordingsKey(query.queryKey) },
     (oldData) => patchRecordingListCache(oldData, vodId, patcher)
+  );
+}
+
+/**
+ * 다시보기 목록의 특정 녹화본 항목 제거
+ *
+ * @param oldData - 기존 infinite query 캐시
+ * @param vodId - 제거 대상 VOD ID
+ * @returns 제거된 infinite query 캐시
+ */
+function removeRecordingFromListCache(
+  oldData: RecordingInfiniteCache | undefined,
+  vodId: number
+) {
+  if (!oldData?.pages) return oldData;
+
+  return {
+    ...oldData,
+    pages: oldData.pages.map((page) => ({
+      ...page,
+      recordings: page.recordings.filter(
+        (recording) => recording.vodId !== vodId
+      ),
+    })),
+  };
+}
+
+/**
+ * 다시보기 메인/채널 목록 캐시에서 삭제된 녹화본을 즉시 제거
+ *
+ * @param queryClient - TanStack Query Client
+ * @param vodId - 제거 대상 VOD ID
+ */
+export function removeRecordingFromListCaches(
+  queryClient: QueryClient,
+  vodId: number
+) {
+  queryClient.setQueriesData<RecordingInfiniteCache>(
+    { queryKey: queryKeys.streams.recordingLists() },
+    (oldData) => removeRecordingFromListCache(oldData, vodId)
+  );
+  queryClient.setQueriesData<RecordingInfiniteCache>(
+    { predicate: (query) => isChannelRecordingsKey(query.queryKey) },
+    (oldData) => removeRecordingFromListCache(oldData, vodId)
   );
 }
 

--- a/features/user/components/follow/FollowListItem.tsx
+++ b/features/user/components/follow/FollowListItem.tsx
@@ -19,6 +19,7 @@
  * 2026.03.29  임도헌   Modified  행 레이아웃을 리스트 문법으로 되돌려 아바타/닉네임을 좌정렬하고 과한 보더를 제거
  * 2026.03.29  임도헌   Modified  팔로우 CTA를 outline 대신 채움형으로 조정해 모달 내 가시성 보강
  * 2026.04.26  임도헌   Modified  팔로우 목록 CTA와 맞팔로잉 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
+ * 2026.06.17  임도헌   Modified  row 팔로우 버튼도 pending 동안 선반영 상태로 표시
  */
 
 "use client";
@@ -57,6 +58,7 @@ export default function FollowListItem({
 }: FollowListItemProps) {
   const isMe = viewerId != null && user.id === viewerId;
   const following = !!user.isFollowedByViewer;
+  const displayFollowing = pending ? !following : following;
 
   const handleClick = async () => {
     if (!onToggle || pending) return;
@@ -80,17 +82,19 @@ export default function FollowListItem({
           type="button"
           onClick={handleClick}
           disabled={pending}
+          aria-busy={pending}
+          aria-pressed={displayFollowing}
           className={cn(
             "focus-ring-soft inline-flex h-8 min-w-[86px] items-center justify-center px-3 text-xs font-medium rounded-lg transition-colors border shrink-0",
-            "disabled:opacity-50 disabled:cursor-not-allowed",
-            following
+            "disabled:cursor-not-allowed",
+            displayFollowing
               ? "bg-surface text-muted border-border-subtle hover:bg-surface-dim hover:border-border dark:bg-surface-dim dark:text-primary dark:border-border dark:hover:bg-border/40" // Unfollow
               : buttonVariant === "primary"
                 ? "bg-brand text-white border-transparent hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark" // Primary Follow
                 : "bg-brand text-white border-transparent hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark"
           )}
         >
-          {pending ? "..." : following ? "팔로우 취소" : "팔로우"}
+          {displayFollowing ? "팔로우 취소" : "팔로우"}
         </button>
       ) : isMe ? (
         <span className="inline-flex h-8 min-w-[44px] items-center justify-center rounded-lg border border-border-subtle bg-surface-dim px-2.5 text-xs font-medium text-muted">

--- a/features/user/components/follow/FollowSection.tsx
+++ b/features/user/components/follow/FollowSection.tsx
@@ -24,6 +24,7 @@
  * 2026.04.06  임도헌   Modified  좁은 모바일 폭 헤더에서 compact 카운트/버튼이 한 줄에 더 안정적으로 머물도록 간격과 크기 재조정
  * 2026.04.10  임도헌   Modified  follow 타이포 정책에 맞춰 compact 카운트/CTA 크기와 weight를 400·500·700 기준으로 정리
  * 2026.04.26  임도헌   Modified  채널 팔로우 CTA의 다크모드 대비와 색조를 primary CTA 톤에 맞춰 보강
+ * 2026.06.17  임도헌   Modified  팔로우 버튼은 선반영 상태를 보여주고 외부 권한 콜백은 확정 상태만 전달
  */
 "use client";
 
@@ -101,6 +102,7 @@ export default function FollowSection({
   // 상태 관리, 쿼리 캐시 조작 및 모달 오픈 트리거를 통합 관리하는 컨트롤러 훅 호출
   const {
     isFollowing,
+    confirmedIsFollowing,
     followerCount,
     followingCount,
     isPending,
@@ -130,8 +132,8 @@ export default function FollowSection({
       didMount.current = true;
       return;
     }
-    onFollowingChange(isFollowing);
-  }, [isFollowing, onFollowingChange]);
+    onFollowingChange(confirmedIsFollowing);
+  }, [confirmedIsFollowing, onFollowingChange]);
 
   const sizes = useMemo(
     () =>
@@ -202,16 +204,10 @@ export default function FollowSection({
           title={isBlocked ? "차단 관계에서는 팔로우할 수 없습니다" : ""}
           aria-pressed={isFollowing}
           aria-busy={isPending}
-          aria-label={
-            isPending
-              ? "팔로우 처리 중"
-              : isFollowing
-                ? "팔로잉 취소"
-                : "팔로우"
-          }
+          aria-label={isFollowing ? "팔로잉 취소" : "팔로우"}
           className={[
             "inline-flex items-center justify-center rounded-lg border transition-colors whitespace-nowrap font-medium",
-            "disabled:opacity-60 disabled:cursor-not-allowed",
+            "disabled:cursor-not-allowed",
             size === "compact" ? "shadow-none" : "shadow-sm",
             sizes.btnCls,
             isFollowing ? "focus-ring-soft" : "focus-ring-strong",
@@ -220,7 +216,7 @@ export default function FollowSection({
               : "border-transparent bg-brand text-white hover:bg-brand-dark dark:bg-brand dark:text-white dark:hover:bg-brand-dark",
           ].join(" ")}
         >
-          {isPending ? "처리 중..." : isFollowing ? "팔로우 취소" : "팔로우"}
+          {isFollowing ? "팔로우 취소" : "팔로우"}
         </button>
       )}
 

--- a/features/user/components/profile/AvatarCropModal.tsx
+++ b/features/user/components/profile/AvatarCropModal.tsx
@@ -11,11 +11,15 @@
  * 2026.03.28  임도헌   Modified  모바일에서 모달이 우측으로 밀리지 않도록 중앙 정렬과 폭 계산을 flex 기반으로 재정리
  * 2026.04.08  임도헌   Modified  공용 bodyScrollLock과 ESC 닫기, 포커스 진입을 추가해 오버레이 동작 안정화
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.06.19  임도헌   Modified  X 닫기 버튼을 추가하고 푸터 취소 버튼을 제거해 크롭 적용 CTA 위계 정리
+ * 2026.06.19  임도헌   Modified  모바일 프로필 이미지 조정 UI를 공용 BottomSheet로 분기해 모달 문법 통일
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import NextImage from "next/image";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import BottomSheet from "@/components/global/BottomSheet";
 import Button from "@/components/ui/Button";
 import { lockBodyScroll, unlockBodyScroll } from "@/lib/bodyScrollLock";
 import {
@@ -23,6 +27,7 @@ import {
   type AvatarCropValues,
   getAvatarCropPreviewStyle,
 } from "@/features/user/utils/avatarCrop";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 interface AvatarCropModalProps {
   open: boolean;
@@ -45,6 +50,7 @@ export default function AvatarCropModal({
   onConfirm,
   loading = false,
 }: AvatarCropModalProps) {
+  const isMobile = useIsMobile();
   const [mounted, setMounted] = useState(false);
   const [imageSize, setImageSize] = useState({ width: 1, height: 1 });
   const [crop, setCrop] = useState<AvatarCropValues>(DEFAULT_CROP);
@@ -62,6 +68,7 @@ export default function AvatarCropModal({
 
   useEffect(() => {
     if (!open) return;
+    if (isMobile) return;
 
     lockBodyScroll();
     const timer = window.setTimeout(() => dialogRef.current?.focus(), 0);
@@ -79,7 +86,7 @@ export default function AvatarCropModal({
       window.removeEventListener("keydown", handleKeyDown);
       unlockBodyScroll();
     };
-  }, [loading, onClose, open]);
+  }, [isMobile, loading, onClose, open]);
 
   useEffect(() => {
     if (!open || !imageUrl) return;
@@ -107,6 +114,122 @@ export default function AvatarCropModal({
 
   if (!mounted || !open) return null;
 
+  const bodyContent = (
+    <>
+      <div className="mt-2 flex justify-center sm:mt-5">
+        <div
+          className="relative overflow-hidden rounded-full border-4 border-border-subtle bg-surface-dim"
+          style={{
+            width: AVATAR_CROP_VIEWPORT_SIZE,
+            height: AVATAR_CROP_VIEWPORT_SIZE,
+          }}
+        >
+          <NextImage
+            src={imageUrl}
+            alt="아바타 크롭 미리보기"
+            width={imageSize.width}
+            height={imageSize.height}
+            unoptimized
+            className="absolute left-1/2 top-1/2 max-w-none select-none pointer-events-none"
+            style={previewStyle}
+          />
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-4">
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-primary">
+            확대
+          </span>
+          <input
+            type="range"
+            min="1"
+            max="2.5"
+            step="0.01"
+            value={crop.zoom}
+            onChange={(e) =>
+              setCrop((prev) => ({
+                ...prev,
+                zoom: Number(e.target.value),
+              }))
+            }
+            className="w-full"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-primary">
+            좌우 위치
+          </span>
+          <input
+            type="range"
+            min="-100"
+            max="100"
+            step="1"
+            value={crop.offsetXPercent}
+            onChange={(e) =>
+              setCrop((prev) => ({
+                ...prev,
+                offsetXPercent: Number(e.target.value),
+              }))
+            }
+            className="w-full"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-primary">
+            상하 위치
+          </span>
+          <input
+            type="range"
+            min="-100"
+            max="100"
+            step="1"
+            value={crop.offsetYPercent}
+            onChange={(e) =>
+              setCrop((prev) => ({
+                ...prev,
+                offsetYPercent: Number(e.target.value),
+              }))
+            }
+            className="w-full"
+          />
+        </label>
+      </div>
+    </>
+  );
+
+  const footer = (
+    <div className="flex justify-end">
+      <Button
+        type="button"
+        text={loading ? "적용 중..." : "이대로 적용"}
+        disabled={loading}
+        className="w-full sm:w-auto sm:min-w-[132px]"
+        onClick={() => onConfirm(crop)}
+      />
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open={open}
+        title="프로필 이미지 조정"
+        description="확대와 위치를 조절한 뒤 정사각형 아바타로 저장합니다."
+        onClose={() => {
+          if (!loading) onClose();
+        }}
+        contentClassName="pt-4"
+        footer={footer}
+        panelClassName="max-h-[90dvh]"
+      >
+        {bodyContent}
+      </BottomSheet>
+    );
+  }
+
   return createPortal(
     <div className="fixed inset-0 z-[70] flex items-start justify-center overflow-y-auto p-4 pt-6 sm:items-center sm:p-6">
       <div
@@ -123,111 +246,29 @@ export default function AvatarCropModal({
         tabIndex={-1}
         className="relative w-full max-w-xl rounded-3xl border border-border-subtle bg-surface p-5 shadow-2xl outline-none sm:p-6"
       >
-        <div className="space-y-1">
-          <h2 className="text-lg font-bold text-primary">프로필 이미지 조정</h2>
-          <p className="text-sm text-muted">
-            확대와 위치를 조절한 뒤 정사각형 아바타로 저장합니다.
-          </p>
-        </div>
-
-        <div className="mt-5 flex justify-center">
-          <div
-            className="relative overflow-hidden rounded-full border-4 border-border-subtle bg-surface-dim"
-            style={{
-              width: AVATAR_CROP_VIEWPORT_SIZE,
-              height: AVATAR_CROP_VIEWPORT_SIZE,
-            }}
-          >
-            <NextImage
-              src={imageUrl}
-              alt="아바타 크롭 미리보기"
-              width={imageSize.width}
-              height={imageSize.height}
-              unoptimized
-              className="absolute left-1/2 top-1/2 max-w-none select-none pointer-events-none"
-              style={previewStyle}
-            />
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-bold text-primary">
+              프로필 이미지 조정
+            </h2>
+            <p className="text-sm text-muted">
+              확대와 위치를 조절한 뒤 정사각형 아바타로 저장합니다.
+            </p>
           </div>
-        </div>
-
-        <div className="mt-6 space-y-4">
-          <label className="block">
-            <span className="mb-1 block text-sm font-medium text-primary">
-              확대
-            </span>
-            <input
-              type="range"
-              min="1"
-              max="2.5"
-              step="0.01"
-              value={crop.zoom}
-              onChange={(e) =>
-                setCrop((prev) => ({
-                  ...prev,
-                  zoom: Number(e.target.value),
-                }))
-              }
-              className="w-full"
-            />
-          </label>
-
-          <label className="block">
-            <span className="mb-1 block text-sm font-medium text-primary">
-              좌우 위치
-            </span>
-            <input
-              type="range"
-              min="-100"
-              max="100"
-              step="1"
-              value={crop.offsetXPercent}
-              onChange={(e) =>
-                setCrop((prev) => ({
-                  ...prev,
-                  offsetXPercent: Number(e.target.value),
-                }))
-              }
-              className="w-full"
-            />
-          </label>
-
-          <label className="block">
-            <span className="mb-1 block text-sm font-medium text-primary">
-              상하 위치
-            </span>
-            <input
-              type="range"
-              min="-100"
-              max="100"
-              step="1"
-              value={crop.offsetYPercent}
-              onChange={(e) =>
-                setCrop((prev) => ({
-                  ...prev,
-                  offsetYPercent: Number(e.target.value),
-                }))
-              }
-              className="w-full"
-            />
-          </label>
-        </div>
-
-        <div className="mt-6 grid grid-cols-2 gap-3">
           <button
             type="button"
             onClick={onClose}
             disabled={loading}
-            className="btn-secondary-modal h-12 text-sm font-medium"
+            aria-label="프로필 이미지 조정 모달 닫기"
+            className="focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
           >
-            취소
+            <XMarkIcon className="size-6" />
           </button>
-          <Button
-            type="button"
-            text={loading ? "적용 중..." : "이대로 적용"}
-            disabled={loading}
-            onClick={() => onConfirm(crop)}
-          />
         </div>
+
+        {bodyContent}
+
+        <div className="mt-6">{footer}</div>
       </div>
     </div>,
     document.body

--- a/features/user/components/profile/BlockedUsersModal.tsx
+++ b/features/user/components/profile/BlockedUsersModal.tsx
@@ -15,15 +15,19 @@
  * 2026.04.22  임도헌   Modified  차단 해제 액션을 텍스트 링크 대신 명확한 보조 버튼으로 정리
  * 2026.04.26  임도헌   Modified  차단 관리 모달에 dialog 의미와 제목 연결, ESC 닫기 포커스 흐름을 보강
  * 2026.05.17  임도헌   Modified  차단 유저 아이템 타입을 user types 공용 타입으로 이동
+ * 2026.06.18  임도헌   Modified  모바일 차단 관리 흐름을 BottomSheet로 분리하고 닫기 버튼 크기 기준 통일
+ * 2026.06.19  임도헌   Modified  X 닫기로 모달 종료 동작을 통일하고 푸터 닫기 버튼 제거
  */
 
 import { useEffect, useRef, useState, useTransition } from "react";
 import { toggleBlockAction } from "@/features/user/actions/block";
 import UserAvatar from "@/components/global/UserAvatar";
+import BottomSheet from "@/components/global/BottomSheet";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import type { BlockedUserSummary } from "@/features/user/types";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 /**
  * 차단한 선원(유저) 관리 모달
@@ -46,6 +50,7 @@ export default function BlockedUsersModal({
   loading?: boolean;
   onUsersChange?: (users: BlockedUserSummary[]) => void;
 }) {
+  const isMobile = useIsMobile();
   const [users, setUsers] = useState(initialBlockedUsers);
   const [isPending, startTransition] = useTransition();
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -72,6 +77,11 @@ export default function BlockedUsersModal({
 
   if (!isOpen) return null;
 
+  const handleClose = () => {
+    if (isPending) return;
+    onClose();
+  };
+
   const handleUnblock = (targetId: number, username: string) => {
     startTransition(async () => {
       const res = await toggleBlockAction(targetId, "unblock");
@@ -85,6 +95,61 @@ export default function BlockedUsersModal({
       }
     });
   };
+
+  const bodyContent = (
+    <div className="space-y-4">
+      {loading ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="size-6 animate-spin rounded-full border-2 border-brand/25 border-t-brand dark:border-brand-light/25 dark:border-t-brand-light" />
+          <p className="mt-3 text-sm text-muted">
+            차단한 선원 목록을 불러오는 중...
+          </p>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="text-muted text-sm">차단한 선원이 없습니다.</p>
+        </div>
+      ) : (
+        users.map((u) => (
+          <div
+            key={u.blocked.id}
+            className="flex items-center justify-between p-2 rounded-xl hover:bg-surface-dim transition-colors"
+          >
+            <UserAvatar
+              username={u.blocked.username}
+              avatar={u.blocked.avatar}
+              size="sm"
+            />
+            <button
+              onClick={() => handleUnblock(u.blocked.id, u.blocked.username)}
+              disabled={isPending}
+              className={cn(
+                "focus-ring-soft inline-flex min-h-[36px] items-center justify-center rounded-full border px-3 text-xs font-medium transition-colors",
+                "border-border-subtle bg-surface text-brand hover:bg-surface-dim hover:text-brand-dark",
+                "dark:text-brand-light dark:hover:text-white disabled:opacity-50"
+              )}
+            >
+              차단 해제
+            </button>
+          </div>
+        ))
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open={isOpen}
+        title="차단한 선원 관리"
+        description="차단한 선원 목록을 확인하고 필요하면 차단을 해제합니다."
+        onClose={handleClose}
+        contentClassName="pt-4"
+      >
+        {bodyContent}
+      </BottomSheet>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
@@ -101,64 +166,20 @@ export default function BlockedUsersModal({
             차단한 선원 관리
           </h2>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             type="button"
             aria-label="차단한 선원 관리 모달 닫기"
+            disabled={isPending}
             className={cn(
               "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-colors",
-              "text-muted hover:bg-surface-dim hover:text-primary"
+              "text-muted hover:bg-surface-dim hover:text-primary disabled:opacity-50"
             )}
           >
             <XMarkIcon className="size-6 text-muted" />
           </button>
         </div>
         <div className="p-4 max-h-[60vh] overflow-y-auto space-y-4">
-          {loading ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <div className="size-6 animate-spin rounded-full border-2 border-brand/25 border-t-brand dark:border-brand-light/25 dark:border-t-brand-light" />
-              <p className="mt-3 text-sm text-muted">
-                차단한 선원 목록을 불러오는 중...
-              </p>
-            </div>
-          ) : users.length === 0 ? (
-            <div className="py-12 text-center">
-              <p className="text-muted text-sm">차단한 선원이 없습니다.</p>
-            </div>
-          ) : (
-            users.map((u) => (
-              <div
-                key={u.blocked.id}
-                className="flex items-center justify-between p-2 rounded-xl hover:bg-surface-dim transition-colors"
-              >
-                <UserAvatar
-                  username={u.blocked.username}
-                  avatar={u.blocked.avatar}
-                  size="sm"
-                />
-                <button
-                  onClick={() =>
-                    handleUnblock(u.blocked.id, u.blocked.username)
-                  }
-                  disabled={isPending}
-                  className={cn(
-                    "focus-ring-soft inline-flex min-h-[36px] items-center justify-center rounded-full border px-3 text-xs font-medium transition-colors",
-                    "border-border-subtle bg-surface text-brand hover:bg-surface-dim hover:text-brand-dark",
-                    "dark:text-brand-light dark:hover:text-white disabled:opacity-50"
-                  )}
-                >
-                  차단 해제
-                </button>
-              </div>
-            ))
-          )}
-        </div>
-        <div className="p-4 border-t border-border-subtle bg-surface flex justify-end">
-          <button
-            onClick={onClose}
-            className="btn-secondary-modal h-10 px-6 text-sm font-medium"
-          >
-            닫기
-          </button>
+          {bodyContent}
         </div>
       </div>
     </div>

--- a/features/user/components/profile/CreateReviewModal.tsx
+++ b/features/user/components/profile/CreateReviewModal.tsx
@@ -18,11 +18,13 @@
  * 2026.03.22  임도헌   Modified  최근 모달 톤 기준으로 외곽선과 헤더/푸터 보더 강도 정리
  * 2026.04.06  임도헌   Modified  모바일 키보드가 열려도 textarea와 하단 액션 버튼이 덜 가려지도록 시트형 배치 적용
  * 2026.04.26  임도헌   Modified  리뷰 작성 모달에 dialog 의미와 별점 radiogroup, 후기 입력 라벨을 추가해 접근성을 보강
+ * 2026.06.19  임도헌   Modified  X 닫기 버튼을 추가하고 푸터 취소 버튼을 제거해 후기 작성 CTA 위계 정리
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import UserAvatar from "@/components/global/UserAvatar";
 import { StarIcon } from "@heroicons/react/24/solid";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import { cn } from "@/lib/utils";
 
 interface CreateReviewModalProps {
@@ -124,10 +126,19 @@ export default function CreateReviewModal({
         )}
       >
         {/* 헤더 */}
-        <div className="px-6 py-4 border-b border-border-subtle bg-surface">
+        <div className="flex items-center justify-between gap-3 px-6 py-4 border-b border-border-subtle bg-surface">
           <h2 id="create-review-title" className="text-lg font-bold text-primary">
             거래 후기 작성
           </h2>
+          <button
+            type="button"
+            onClick={handleBackdrop}
+            disabled={isSubmitting}
+            aria-label="거래 후기 작성 모달 닫기"
+            className="focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
+          >
+            <XMarkIcon className="size-6" />
+          </button>
         </div>
 
         {/* 본문 */}
@@ -193,14 +204,7 @@ export default function CreateReviewModal({
         </div>
 
         {/* 하단 액션 */}
-        <div className="shrink-0 px-6 py-4 border-t border-border-subtle bg-surface flex justify-end gap-3">
-          <button
-            onClick={handleBackdrop}
-            disabled={isSubmitting}
-            className="btn-secondary-modal h-10 px-4 text-sm font-medium"
-          >
-            취소
-          </button>
+        <div className="shrink-0 px-6 py-4 border-t border-border-subtle bg-surface flex justify-end">
           <button
             onClick={handleSubmit}
             disabled={disabled}

--- a/features/user/components/profile/MyProfile.tsx
+++ b/features/user/components/profile/MyProfile.tsx
@@ -53,6 +53,7 @@
  * 2026.04.10  임도헌   Modified   profile 타이포 정책에 맞춰 주요 CTA/상태 카드/거래 카드 라벨을 400·500·700 체계로 정리
  * 2026.04.16  임도헌   Modified   profile Lighthouse 대응으로 하단 섹션 지연 로드 분리 및 진입 라벨/a11y 주석 정리
  * 2026.05.17  임도헌   Modified   차단 유저 목록 상태 타입을 BlockedUserSummary로 명시
+ * 2026.06.18  임도헌   Modified   정규화된 지역 표시 포맷을 사용해 중복 지역명 노출 방지
  */
 "use client";
 
@@ -65,6 +66,7 @@ import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import ProfileHeader from "@/features/user/components/profile/ProfileHeader";
 import { PushNotificationToggle } from "@/features/notification/components/PushNotificationToggle";
 import MyLocationButton from "@/features/user/components/profile/MyLocationButton";
+import { formatNormalizedRegion } from "@/features/map/utils/normalizeRegion";
 import {
   ArrowPathIcon,
   BellAlertIcon,
@@ -160,9 +162,7 @@ export default function MyProfile({
   const [blockedUsersLoading, setBlockedUsersLoading] = useState(false);
   const [pushStatus, setPushStatus] =
     useState<PushNotificationStatus>("disabled");
-  const fullLocation = [user.region1, user.region2, user.region3]
-    .filter(Boolean)
-    .join(" ");
+  const fullLocation = formatNormalizedRegion(user);
 
   // Zustand 모달 스토어 구독
   const modals = useModalStore((state) => state.modals);

--- a/features/user/components/profile/NeighborhoodSearchModal.tsx
+++ b/features/user/components/profile/NeighborhoodSearchModal.tsx
@@ -16,6 +16,7 @@
  * 2026.04.26  임도헌   Modified  데스크톱 동네 검색 모달의 dialog 의미와 검색 입력/닫기 버튼 라벨을 보강
  * 2026.04.26  임도헌   Modified  동네 검색 로딩/오류/빈 결과 문구를 사용자 행동 기준으로 정리
  * 2026.05.16  임도헌   Modified  카카오 주소 검색 응답 타입을 명시해 any 제거
+ * 2026.06.18  임도헌   Modified  도 단위 카카오 주소를 시/군 중심 지역 계층으로 정규화
  */
 
 import { useState } from "react";
@@ -29,6 +30,10 @@ import {
 import { toast } from "sonner";
 import useKakaoLoader from "@/features/map/hooks/useKakaoLoader";
 import type { LocationData } from "@/features/map/types";
+import {
+  formatNormalizedRegion,
+  normalizeKakaoRegion,
+} from "@/features/map/utils/normalizeRegion";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
 interface Props {
@@ -77,15 +82,21 @@ function normalizeResults(
     const r1 = addr.region_1depth_name;
     const r2 = addr.region_2depth_name;
     const r3 = addr.region_3depth_h_name || addr.region_3depth_name;
-    const fullName = [r1, r2, r3].filter(Boolean).join(" ");
-
-    if (!r1 || !r2 || !r3 || !fullName || uniqueRegions.has(fullName)) return;
-
-    uniqueRegions.set(fullName, {
-      address_name: fullName,
+    const region = normalizeKakaoRegion({
       region1: r1,
       region2: r2,
       region3: r3,
+    });
+    const fullName = formatNormalizedRegion(region);
+
+    if (!region.region1 || !region.region2 || !fullName) return;
+    if (uniqueRegions.has(fullName)) return;
+
+    uniqueRegions.set(fullName, {
+      address_name: fullName,
+      region1: region.region1,
+      region2: region.region2,
+      region3: region.region3,
       x: item.x,
       y: item.y,
     });

--- a/features/user/components/profile/PasswordChangeModal.tsx
+++ b/features/user/components/profile/PasswordChangeModal.tsx
@@ -28,6 +28,8 @@
  * 2026.04.07  임도헌   Modified  모바일에서는 BottomSheet를 사용해 비밀번호 변경 흐름을 하단 시트로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.06.01  임도헌   Modified  비밀번호 변경 모달 입력 높이를 모바일 작성형 폼 기준으로 정리
+ * 2026.06.19  임도헌   Modified  submit Button 패턴을 유지하면서 완료 버튼의 최소 너비와 높이 기준 보정
+ * 2026.06.19  임도헌   Modified  X 닫기와 중복되는 푸터 취소 버튼을 제거해 비밀번호 변경 CTA 위계 정리
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -238,23 +240,13 @@ export default function PasswordChangeModal({
   );
 
   const footer = (
-    <div className="flex gap-3 justify-end">
-      <button
-        type="button"
-        onClick={doClose}
+    <div className="flex justify-end">
+      <Button
+        text={submitting ? "변경 중..." : "변경 완료"}
         disabled={submitting}
-        className="btn-secondary-modal h-10 px-4 text-sm font-medium"
-      >
-        취소
-      </button>
-      <button
-        type="submit"
+        className="!h-10 w-full min-w-[112px] px-6 text-sm sm:w-auto"
         form={formId}
-        disabled={submitting}
-        className="btn-primary h-10 px-6 text-sm"
-      >
-        {submitting ? "변경 중..." : "변경 완료"}
-      </button>
+      />
     </div>
   );
 
@@ -316,19 +308,11 @@ export default function PasswordChangeModal({
         <div className="p-6 space-y-5">
           {formContent}
 
-          <div className="pt-2 flex gap-3 justify-end">
-            <button
-              type="button"
-              onClick={doClose}
-              disabled={submitting}
-              className="btn-secondary-modal h-10 px-4 text-sm font-medium"
-            >
-              취소
-            </button>
+          <div className="pt-2 flex justify-end">
             <Button
               text={submitting ? "변경 중..." : "변경 완료"}
               disabled={submitting}
-              className="w-auto px-6 h-10 text-sm"
+              className="!h-10 w-auto min-w-[112px] px-6 text-sm"
               form={formId}
             />
           </div>

--- a/features/user/components/profile/ProfileOptionMenu.tsx
+++ b/features/user/components/profile/ProfileOptionMenu.tsx
@@ -10,18 +10,26 @@
  * 2026.03.12  임도헌   Modified  타인 프로필 flat 헤더 톤에 맞춰 패널 보더를 subtle 기준으로 정리
  * 2026.03.18  임도헌   Modified  차단/해제 시 search까지 포함한 현재 프로필 경로를 정규화해 revalidate·복귀 문맥과 nested returnTo 예외를 함께 보강
  * 2026.04.03  임도헌   Modified  전역 유저 차단 확인 문구를 다른 도메인과 같은 정책 설명 톤으로 통일
+ * 2026.06.21  임도헌   Modified  프로필 옵션 메뉴를 아이콘+텍스트 및 모바일 BottomSheet 문법으로 정리
  */
 "use client";
 
 import { useState, useRef, useEffect, useTransition } from "react";
 import dynamic from "next/dynamic";
-import { EllipsisHorizontalIcon } from "@heroicons/react/24/outline";
+import {
+  EllipsisHorizontalIcon,
+  ExclamationTriangleIcon,
+  NoSymbolIcon,
+  UserMinusIcon,
+} from "@heroicons/react/24/outline";
+import BottomSheet from "@/components/global/BottomSheet";
 import ConfirmDialog from "@/components/global/ConfirmDialog";
 import { toggleBlockAction } from "@/features/user/actions/block";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { usePathname, useSearchParams } from "next/navigation";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 const ReportModal = dynamic(
   () => import("@/features/report/components/ReportModal"),
@@ -53,6 +61,7 @@ export default function ProfileOptionMenu({
 
   const menuRef = useRef<HTMLDivElement>(null);
   const [isPending, startTransition] = useTransition();
+  const isMobile = useIsMobile();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentSearch = searchParams?.toString();
@@ -62,6 +71,8 @@ export default function ProfileOptionMenu({
 
   // 외부 클릭 닫기
   useEffect(() => {
+    if (isMobile) return;
+
     const onClick = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setIsOpen(false);
@@ -69,7 +80,7 @@ export default function ProfileOptionMenu({
     };
     if (isOpen) document.addEventListener("mousedown", onClick);
     return () => document.removeEventListener("mousedown", onClick);
-  }, [isOpen]);
+  }, [isMobile, isOpen]);
 
   // 차단/해제 실행
   const handleToggleBlock = () => {
@@ -92,6 +103,13 @@ export default function ProfileOptionMenu({
     });
   };
 
+  const blockLabel = isBlocked ? "차단 해제하기" : "차단하기";
+  const BlockIcon = isBlocked ? NoSymbolIcon : UserMinusIcon;
+  const desktopActionClass =
+    "focus-ring-soft flex w-full items-center gap-2 px-4 py-3 text-left text-sm font-medium transition-colors";
+  const mobileActionClass =
+    "focus-ring-soft flex min-h-[52px] w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium transition-colors";
+
   return (
     <div className="relative" ref={menuRef}>
       <button
@@ -99,37 +117,91 @@ export default function ProfileOptionMenu({
         onClick={() => setIsOpen(!isOpen)}
         className="focus-ring-soft p-2 text-muted hover:text-primary rounded-full hover:bg-surface-dim transition-colors"
         aria-label="옵션 더보기"
+        aria-expanded={isOpen}
+        aria-haspopup={isMobile ? "dialog" : "menu"}
       >
         <EllipsisHorizontalIcon className="size-6" />
       </button>
 
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-border-subtle bg-surface shadow-xl z-50">
+      {!isMobile && isOpen && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-border-subtle bg-surface shadow-xl z-50"
+        >
           {/* 차단하기 / 해제하기 */}
           <button
-            onClick={() => setConfirmOpen(true)}
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setIsOpen(false);
+              setConfirmOpen(true);
+            }}
             className={cn(
-              "focus-ring-soft w-full text-left px-4 py-3 text-sm font-medium transition-colors",
+              desktopActionClass,
               isBlocked
                 ? "text-primary hover:bg-surface-dim"
                 : "text-danger hover:bg-danger/10 dark:hover:bg-danger/20"
             )}
           >
-            {isBlocked ? "차단 해제하기" : "차단하기"}
+            <BlockIcon className="size-4 shrink-0" />
+            {blockLabel}
           </button>
 
           {/*  신고 버튼 */}
           <button
+            type="button"
+            role="menuitem"
             onClick={() => {
               setIsOpen(false);
               setReportOpen(true);
             }}
-            className="focus-ring-soft w-full border-t border-border-subtle px-4 py-3 text-left text-sm font-medium text-primary transition-colors hover:bg-surface-dim"
+            className={cn(
+              desktopActionClass,
+              "border-t border-border-subtle text-primary hover:bg-surface-dim"
+            )}
           >
+            <ExclamationTriangleIcon className="size-4 shrink-0" />
             신고하기
           </button>
         </div>
       )}
+
+      <BottomSheet
+        open={isMobile && isOpen}
+        title="프로필 옵션"
+        description="유저 차단 또는 신고를 진행할 수 있습니다."
+        onClose={() => setIsOpen(false)}
+      >
+        <div className="space-y-2 pt-2">
+          <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              setConfirmOpen(true);
+            }}
+            className={cn(
+              mobileActionClass,
+              isBlocked
+                ? "text-primary hover:bg-surface-dim"
+                : "text-danger hover:bg-danger/10"
+            )}
+          >
+            <BlockIcon className="size-5 shrink-0" />
+            {blockLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              setReportOpen(true);
+            }}
+            className={cn(mobileActionClass, "text-primary hover:bg-surface-dim")}
+          >
+            <ExclamationTriangleIcon className="size-5 shrink-0" />
+            신고하기
+          </button>
+        </div>
+      </BottomSheet>
 
       {/* 차단 확인 Dialog */}
       <ConfirmDialog

--- a/features/user/components/profile/ProfileSettingMenu.tsx
+++ b/features/user/components/profile/ProfileSettingMenu.tsx
@@ -22,6 +22,7 @@
  * 2026.03.13  임도헌   Modified  프로필 수정 진입 시 현재 경로를 returnTo로 함께 전달해 복귀 맥락 유지
  * 2026.03.14  임도헌   Modified  회원 탈퇴를 드롭다운 밖 독립 위험 액션으로 분리해 설정 메뉴 혼재를 완화
  * 2026.03.18  임도헌   Modified  설정 메뉴 현재 경로도 내부 경로 기준으로 정규화해 nested returnTo 예외를 완화
+ * 2026.06.21  임도헌   Modified  설정 메뉴 항목을 아이콘+텍스트 문법으로 통일
  */
 "use client";
 
@@ -29,8 +30,14 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import {
+  CheckBadgeIcon,
   Cog6ToothIcon,
   ComputerDesktopIcon,
+  EnvelopeIcon,
+  ExclamationTriangleIcon,
+  KeyIcon,
+  PencilSquareIcon,
+  UserMinusIcon,
 } from "@heroicons/react/24/outline";
 import { sanitizeCallbackUrl } from "@/features/auth/utils/redirect";
 import { cn } from "@/lib/utils";
@@ -171,9 +178,10 @@ export default function ProfileSettingMenu({
             href={`/profile/edit?returnTo=${encodeURIComponent(returnTo)}`}
             role="menuitem"
             data-menuitem="true"
-            className="focus-ring-soft block px-4 py-3 text-sm text-primary hover:bg-surface-dim transition-colors"
+            className="focus-ring-soft flex items-center gap-2 px-4 py-3 text-sm text-primary hover:bg-surface-dim transition-colors"
             onClick={() => setOpen(false)}
           >
+            <PencilSquareIcon className="size-4 shrink-0" />
             프로필 수정
           </Link>
 
@@ -187,8 +195,9 @@ export default function ProfileSettingMenu({
               setOpen(false);
               openModal("password"); // Zustand 액션으로 교체
             }}
-            className="focus-ring-soft w-full text-left px-4 py-3 text-sm text-primary hover:bg-surface-dim transition-colors"
+            className="focus-ring-soft flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-primary hover:bg-surface-dim transition-colors"
           >
+            <KeyIcon className="size-4 shrink-0" />
             비밀번호 변경
           </button>
 
@@ -198,8 +207,9 @@ export default function ProfileSettingMenu({
           {emailVerified ? (
             <div
               role="menuitem"
-              className="px-4 py-3 text-xs text-muted bg-surface-dim/50 cursor-default"
+              className="flex items-center gap-2 px-4 py-3 text-xs text-muted bg-surface-dim/50 cursor-default"
             >
+              <CheckBadgeIcon className="size-4 shrink-0" />
               이메일 인증됨
             </div>
           ) : hasEmail ? (
@@ -210,8 +220,9 @@ export default function ProfileSettingMenu({
                 setOpen(false);
                 openModal("email"); // Zustand 액션으로 교체
               }}
-              className="w-full text-left px-4 py-3 text-sm text-primary hover:bg-surface-dim transition-colors"
+              className="focus-ring-soft flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-primary hover:bg-surface-dim transition-colors"
             >
+              <EnvelopeIcon className="size-4 shrink-0" />
               이메일 인증하기
             </button>
           ) : (
@@ -219,9 +230,10 @@ export default function ProfileSettingMenu({
               href={`/profile/edit?returnTo=${encodeURIComponent(returnTo)}`}
               role="menuitem"
               data-menuitem="true"
-              className="focus-ring-soft block px-4 py-3 text-sm text-danger hover:bg-danger/5 transition-colors"
+              className="focus-ring-soft flex items-center gap-2 px-4 py-3 text-sm text-danger hover:bg-danger/5 transition-colors"
               onClick={() => setOpen(false)}
             >
+              <ExclamationTriangleIcon className="size-4 shrink-0" />
               이메일 설정 필요
             </Link>
           )}
@@ -236,8 +248,9 @@ export default function ProfileSettingMenu({
               setOpen(false);
               openModal("block"); // Zustand 액션으로 교체
             }}
-            className="focus-ring-soft w-full text-left px-4 py-3 text-sm text-primary hover:bg-surface-dim transition-colors"
+            className="focus-ring-soft flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-primary hover:bg-surface-dim transition-colors"
           >
+            <UserMinusIcon className="size-4 shrink-0" />
             차단한 선원 관리
           </button>
 

--- a/features/user/components/profile/ReviewDetailModal.tsx
+++ b/features/user/components/profile/ReviewDetailModal.tsx
@@ -18,12 +18,17 @@
  * 2026.03.23  임도헌   Modified  데스크톱에서 텍스트형 모달이 세로로만 길어지지 않도록 폭을 한 단계 확장
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
  * 2026.04.26  임도헌   Modified  리뷰 상세 별점 aria-label을 sr-only 텍스트와 장식용 아이콘 구조로 정리
+ * 2026.06.18  임도헌   Modified  닫기 버튼을 공통 secondary modal 스타일로 통일
+ * 2026.06.19  임도헌   Modified  X 닫기 버튼을 추가하고 푸터 닫기 버튼을 제거해 신고/삭제 액션만 남김
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { StarIcon } from "@heroicons/react/24/solid";
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import {
+  ExclamationTriangleIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { cn } from "@/lib/utils";
 import type { ProfileReview } from "@/features/user/types";
 
@@ -88,6 +93,8 @@ export default function ReviewDetailModal({
 
   if (!isOpen) return null;
 
+  const hasFooterActions = Boolean(review && (!isOwnReview || onDelete));
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
@@ -119,23 +126,33 @@ export default function ReviewDetailModal({
             >
               {title}
             </h3>
-            {review && (
-              <div className="flex gap-0.5">
-                <span className="sr-only">별점 {review.rate}점</span>
-                {[1, 2, 3, 4, 5].map((star) => (
-                  <StarIcon
-                    key={star}
-                    aria-hidden="true"
-                    className={cn(
-                      "w-4 h-4",
-                      star <= review.rate
-                        ? "text-yellow-400"
-                        : "text-neutral-300 dark:text-neutral-700"
-                    )}
-                  />
-                ))}
-              </div>
-            )}
+            <div className="flex items-center gap-3">
+              {review && (
+                <div className="flex gap-0.5">
+                  <span className="sr-only">별점 {review.rate}점</span>
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <StarIcon
+                      key={star}
+                      aria-hidden="true"
+                      className={cn(
+                        "w-4 h-4",
+                        star <= review.rate
+                          ? "text-yellow-400"
+                          : "text-neutral-300 dark:text-neutral-700"
+                      )}
+                    />
+                  ))}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="리뷰 상세 모달 닫기"
+                className="focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary"
+              >
+                <XMarkIcon className="size-6" />
+              </button>
+            </div>
           </div>
         </div>
 
@@ -152,23 +169,22 @@ export default function ReviewDetailModal({
           )}
         </div>
 
-        {/* Footer */}
-        <div className="px-6 py-4 border-t border-border-subtle bg-surface flex justify-between gap-2">
-          {/* 신고 버튼 (좌측 배치) */}
-          <div className="flex items-center">
-            {review && !isOwnReview && (
-              <button
-                onClick={() => setReportOpen(true)}
-                className="focus-ring-soft rounded-md text-muted hover:text-danger text-sm flex items-center gap-1 transition-colors"
-              >
-                <ExclamationTriangleIcon className="size-4" />
-                <span className="text-xs">신고</span>
-              </button>
-            )}
-          </div>
+        {hasFooterActions && (
+          <div className="px-6 py-4 border-t border-border-subtle bg-surface flex justify-between gap-2">
+            {/* 신고 버튼 (좌측 배치) */}
+            <div className="flex items-center">
+              {review && !isOwnReview && (
+                <button
+                  onClick={() => setReportOpen(true)}
+                  className="focus-ring-soft rounded-md text-muted hover:text-danger text-sm flex items-center gap-1 transition-colors"
+                >
+                  <ExclamationTriangleIcon className="size-4" />
+                  <span className="text-xs">신고</span>
+                </button>
+              )}
+            </div>
 
-          <div className="flex gap-2">
-            {review && onDelete && (
+            {review && onDelete ? (
               <button
                 onClick={handleDelete}
                 disabled={isDeleting}
@@ -176,15 +192,11 @@ export default function ReviewDetailModal({
               >
                 {isDeleting ? "삭제 중..." : "삭제"}
               </button>
+            ) : (
+              <div />
             )}
-            <button
-              onClick={onClose}
-              className="focus-ring-soft px-4 py-2 text-sm font-medium text-primary bg-surface hover:bg-surface-dim border border-border-subtle rounded-xl transition-colors"
-            >
-              닫기
-            </button>
           </div>
-        </div>
+        )}
       </div>
       {/* 신고 모달 */}
       {review && (

--- a/features/user/components/profile/SelectUserModal.tsx
+++ b/features/user/components/profile/SelectUserModal.tsx
@@ -24,11 +24,14 @@
  * 2026.04.07  임도헌   Modified  모바일에서는 BottomSheet를 사용해 예약자 선택 흐름을 하단 시트로 정리
  * 2026.04.10  임도헌   Modified  profile 타이포 정책에 맞춰 예약자 선택 모달의 상태 라벨과 CTA weight를 500 기준으로 정리
  * 2026.04.10  임도헌   Modified  상위 클라이언트 경계 아래에서만 쓰도록 use client 중복 선언을 제거해 직렬화 경고를 완화
+ * 2026.06.18  임도헌   Modified  모달 보조/닫기 버튼 톤을 공통 secondary modal 스타일로 통일
+ * 2026.06.19  임도헌   Modified  데스크톱 X 닫기를 추가하고 푸터 닫기 버튼을 제거해 닫기 동작 통일
  */
 
 import { useCallback, useEffect, useState } from "react";
 import UserAvatar from "@/components/global/UserAvatar";
 import BottomSheet from "@/components/global/BottomSheet";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import { cn } from "@/lib/utils";
 import { getProductChatUsersAction } from "@/features/product/actions/chat";
 import { ChatUser } from "@/features/chat/types";
@@ -62,7 +65,7 @@ export default function SelectUserModal({
   const [isProcessingId, setIsProcessingId] = useState<number | null>(null); // 현재 처리 중인 유저 ID
   const [error, setError] = useState<string | null>(null);
   const quietButtonClass =
-    "inline-flex items-center justify-center rounded-xl border border-border bg-surface-dim px-4 text-sm font-medium text-primary transition-colors hover:bg-background";
+    "btn-secondary-modal inline-flex items-center justify-center text-sm font-medium";
 
   const loadChatUsers = useCallback(
     async (mounted?: { current: boolean }) => {
@@ -246,16 +249,6 @@ export default function SelectUserModal({
     </div>
   );
 
-  const footer = (
-    <button
-      type="button"
-      className={cn(quietButtonClass, "h-11 w-full sm:w-auto sm:min-w-[96px]")}
-      onClick={() => onOpenChange(false)}
-    >
-      닫기
-    </button>
-  );
-
   if (isMobile) {
     return (
       <BottomSheet
@@ -264,7 +257,6 @@ export default function SelectUserModal({
         description="이 제품으로 대화를 나눈 사용자 중 한 명을 예약자로 지정합니다."
         onClose={() => onOpenChange(false)}
         contentClassName="pt-4"
-        footer={footer}
       >
         {bodyContent}
       </BottomSheet>
@@ -294,26 +286,35 @@ export default function SelectUserModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="border-b border-border-subtle bg-surface px-5 py-4 sm:px-6">
-          <h2 id="select-user-title" className="text-lg font-bold text-primary">
-            예약자 선택
-          </h2>
-          <p
-            id="select-user-description"
-            className="mt-1 text-sm leading-5 text-muted"
+        <div className="flex items-start justify-between gap-3 border-b border-border-subtle bg-surface px-5 py-4 sm:px-6">
+          <div className="min-w-0">
+            <h2
+              id="select-user-title"
+              className="text-lg font-bold text-primary"
+            >
+              예약자 선택
+            </h2>
+            <p
+              id="select-user-description"
+              className="mt-1 text-sm leading-5 text-muted"
+            >
+              이 제품으로 대화를 나눈 사용자 중 한 명을 예약자로 지정합니다.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            disabled={isProcessingId !== null}
+            aria-label="예약자 선택 모달 닫기"
+            className="focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-muted transition-colors hover:bg-surface-dim hover:text-primary disabled:opacity-50"
           >
-            이 제품으로 대화를 나눈 사용자 중 한 명을 예약자로 지정합니다.
-          </p>
+            <XMarkIcon className="size-6" />
+          </button>
         </div>
 
         {/* Body (User List) */}
         <div className="flex min-h-0 flex-1 flex-col px-5 py-5 sm:px-6 sm:py-6">
           {bodyContent}
-        </div>
-
-        {/* Footer */}
-        <div className="flex justify-end border-t border-border-subtle bg-surface px-5 py-4 sm:px-6">
-          {footer}
         </div>
       </div>
     </div>

--- a/features/user/components/profile/UserProfile.tsx
+++ b/features/user/components/profile/UserProfile.tsx
@@ -50,6 +50,7 @@
  * 2026.04.26  임도헌   Modified   차단 해제 CTA의 다크모드 색조를 primary CTA 톤과 맞춰 정리
  * 2026.05.12  임도헌   Modified   타인 프로필 방송국 StreamCard에 연결 보드게임 메타 전달
  * 2026.05.16  임도헌   Modified   판매 탭 제품 scope 매핑을 명시해 any 캐스팅 제거
+ * 2026.06.21  임도헌   Modified   타인 프로필 판매 목록 뷰 토글 모바일 크기를 목록 공통 36px 기준으로 정렬
  */
 
 "use client";
@@ -399,7 +400,7 @@ export default function UserProfile({
                     onClick={() => setViewMode("list")}
                     aria-label="리스트 보기"
                     className={cn(
-                      "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+                      "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow] sm:min-h-[44px] sm:min-w-[44px]",
                       viewMode === "list"
                         ? "bg-background text-brand dark:text-brand-light shadow-sm ring-1 ring-border/70"
                         : "text-muted hover:bg-background/70 hover:text-primary"
@@ -411,11 +412,11 @@ export default function UserProfile({
                     onClick={() => setViewMode("grid")}
                     aria-label="그리드 보기"
                     className={cn(
-                      "focus-ring-soft inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow]",
+                      "focus-ring-soft inline-flex min-h-[36px] min-w-[36px] items-center justify-center rounded-lg transition-[background-color,color,border-color,box-shadow] sm:min-h-[44px] sm:min-w-[44px]",
                       viewMode === "grid"
                         ? "bg-background text-brand dark:text-brand-light shadow-sm ring-1 ring-border/70"
                         : "text-muted hover:bg-background/70 hover:text-primary"
-            )}
+                    )}
                   >
                     <Squares2X2Icon className="size-4" />
                   </button>

--- a/features/user/hooks/useFollowController.ts
+++ b/features/user/hooks/useFollowController.ts
@@ -23,6 +23,7 @@
  * 2026.03.31  임도헌   Modified  헤더 통계와 모달 페이징 제어 목적이 보이도록 설명 톤 통일
  * 2026.04.08  임도헌   Modified  프로필/채널 헤더 팔로우 성공 시 맥락형 토스트를 노출해 상태 전환 체감 보강
  * 2026.05.16  임도헌   Modified  팔로우 모달 캐시 조회 타입을 명시해 any 캐스팅 제거
+ * 2026.06.17  임도헌   Modified  팔로우 버튼/카운트 표시만 선반영하고 팔로워 전용 접근 상태는 서버 성공 후 동기화
  */
 "use client";
 
@@ -52,9 +53,10 @@ type ControllerParams = {
  * 팔로우 기능 통합 상태 관리 및 컨트롤러 훅
  *
  * [기능]
- * - 프로필 상단 팔로우 통계와 버튼 상태를 전역 캐시 기준으로 관리
+ * - 프로필 상단 팔로우 통계와 버튼 상태를 전역 캐시 기준으로 관리하되, 버튼/카운트 표시는 pending 동안 선반영
  * - 팔로워/팔로잉 모달은 열릴 때만 지연 로딩으로 조회
  * - 리스트 내부 토글도 같은 `useFollowToggle` 경로를 재사용해 상태를 맞춤
+ * - 팔로워 전용 방송 잠금처럼 팔로우 성공 여부에 따라 바뀌는 접근 상태는 서버 성공 후 캐시 동기화 결과만 외부로 전달
  *
  * @param {ControllerParams} params - 소유자 정보, 초기 카운트, 뷰어 정보 및 로그인 콜백
  */
@@ -81,6 +83,10 @@ export function useFollowController({
     },
     staleTime: Infinity, // Mutation 발생 시 덮어쓰기 전까지 유지
   });
+  const [optimisticOwnerState, setOptimisticOwnerState] = useState<{
+    isFollowing: boolean;
+    followerCount: number;
+  } | null>(null);
 
   // 모달 활성화 플래그
   // 열릴 때만 목록 쿼리를 켜서 초기 렌더링 비용을 줄임
@@ -102,6 +108,11 @@ export function useFollowController({
     enabled: followingOpen,
   });
 
+  const ownerPending = isPending(ownerId);
+  const displayIsFollowing =
+    optimisticOwnerState?.isFollowing ?? followStats.isFollowing;
+  const displayFollowerCount =
+    optimisticOwnerState?.followerCount ?? followStats.followerCount;
   const isPendingById = useCallback((id: number) => isPending(id), [isPending]);
 
   /**
@@ -111,10 +122,23 @@ export function useFollowController({
   const onToggleFollow = useCallback(async () => {
     if (!viewerId) return onRequireLogin?.();
     const wasFollowing = followStats.isFollowing;
+    const nextIsFollowing = !wasFollowing;
+    const nextFollowerCount = Math.max(
+      0,
+      followStats.followerCount + (wasFollowing ? -1 : 1)
+    );
+
+    setOptimisticOwnerState({
+      isFollowing: nextIsFollowing,
+      followerCount: nextFollowerCount,
+    });
+
     const res = await toggle(ownerId, wasFollowing, {
       viewerId,
       onRequireLogin,
     });
+
+    setOptimisticOwnerState(null);
 
     if (!wasFollowing && res?.success && res.isFollowing) {
       toast.success(`${ownerUsername}님을 팔로우했습니다.`);
@@ -123,6 +147,7 @@ export function useFollowController({
     viewerId,
     onRequireLogin,
     followStats.isFollowing,
+    followStats.followerCount,
     toggle,
     ownerId,
     ownerUsername,
@@ -161,10 +186,11 @@ export function useFollowController({
   );
 
   return {
-    isFollowing: followStats.isFollowing,
-    followerCount: followStats.followerCount,
+    isFollowing: displayIsFollowing,
+    confirmedIsFollowing: followStats.isFollowing,
+    followerCount: displayFollowerCount,
     followingCount: followStats.followingCount,
-    isPending: isPending(ownerId),
+    isPending: ownerPending,
     onToggleFollow,
     openFollowers: () => setFollowersOpen(true),
     openFollowing: () => setFollowingOpen(true),

--- a/features/user/hooks/useFollowToggle.ts
+++ b/features/user/hooks/useFollowToggle.ts
@@ -24,6 +24,7 @@
  * 2026.03.31  임도헌   Modified  훅 역할과 캐시 동기화 맥락이 보이도록 설명 톤 통일
  * 2026.05.08  임도헌   Modified  팔로우 액션 결과 타입 import 경로를 user types로 정리
  * 2026.05.16  임도헌   Modified  팔로우/스트림 캐시 갱신 타입을 명시해 any 캐스팅 제거
+ * 2026.06.17  임도헌   Modified  서버 성공 후 팔로워 전용 접근 상태를 동기화하는 책임을 주석에 명확히 반영
  */
 
 "use client";
@@ -49,12 +50,12 @@ type FollowToggleOptions = {
 };
 
 /**
- * 팔로우/언팔로우 토글 액션 및 낙관적 상태 갱신 훅
+ * 팔로우/언팔로우 토글 액션 및 서버 확정 후 캐시 동기화 훅
  *
  * [기능]
  * - `toggleFollowAction` 서버 액션을 호출해 팔로우 상태 변경을 처리
- * - 헤더 통계, 모달 row, 스트리밍 팔로잉 목록 캐시를 함께 동기화
- * - 낙관적 갱신과 서버 확정 상태를 같은 queryClient 기준으로 맞춤
+ * - 성공 응답 기준으로 헤더 통계, 모달 row, 스트리밍 팔로잉 목록 캐시를 함께 동기화
+ * - 버튼/카운트의 표시용 선반영은 `useFollowController`에서 처리하고, 팔로워 전용 접근 상태는 서버 확정 후에만 반영
  */
 export function useFollowToggle() {
   const queryClient = useQueryClient();

--- a/features/user/types.ts
+++ b/features/user/types.ts
@@ -17,6 +17,7 @@
  * 2026.05.08  임도헌   Modified  팔로우 액션 결과 타입을 user types로 이동
  * 2026.05.16  임도헌   Modified  팔로우 캐시 동기화용 페이지/통계 타입 추가
  * 2026.05.17  임도헌   Modified  차단 관리 모달용 차단 유저 요약 타입 추가
+ * 2026.06.18  임도헌   Modified  지역 정규화 정책에 맞춰 UserProfile 지역 필드 설명 최신화
  */
 
 import type { Role } from "@/generated/prisma/enums";
@@ -46,8 +47,8 @@ export interface UserProfile {
   created_at: Date;
   emailVerified: boolean;
   locationName?: string | null;
-  region1?: string | null; // 시/도
-  region2?: string | null; // 구/군
+  region1?: string | null; // 지역 필터 1차 단위(카카오 1depth 또는 도 단위의 시/군)
+  region2?: string | null; // 지역 필터 2차 단위(구/군, 없으면 region1)
   region3?: string | null; // 동/읍/면
   _count: {
     followers: number;

--- a/features/user/utils/region.test.ts
+++ b/features/user/utils/region.test.ts
@@ -1,3 +1,14 @@
+/**
+ * File Name : features/user/utils/region.test.ts
+ * Description : 사용자 지역 범위 필터 유틸 테스트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.04  임도헌   Created   지역 범위 비교/where 빌더 회귀 테스트 추가
+ * 2026.06.18  임도헌   Modified  도 단위 정규화 정책에 맞춰 테스트 지역명을 1차 지역 기준으로 정리
+ */
+
 import { describe, expect, test } from "vitest";
 
 import type { RegionRange } from "@/generated/prisma/client";
@@ -6,9 +17,9 @@ import { buildRegionWhere, isWithinRegionRange } from "./region";
 describe("region range utils", () => {
   const range = (value: RegionRange) => value;
 
-  test("구 단위 필터는 같은 구 이름이어도 시/도가 다르면 제외한다", () => {
+  test("구 단위 필터는 같은 구 이름이어도 1차 지역이 다르면 제외한다", () => {
     const user = {
-      region1: "울산광역시",
+      region1: "울산",
       region2: "동구",
       region3: "화정동",
       regionRange: range("GU"),
@@ -16,27 +27,27 @@ describe("region range utils", () => {
 
     expect(
       isWithinRegionRange(user, {
-        region1: "광주광역시",
+        region1: "광주",
         region2: "동구",
         region3: "충장동",
       })
     ).toBe(false);
     expect(
       isWithinRegionRange(user, {
-        region1: "울산광역시",
+        region1: "울산",
         region2: "동구",
         region3: "방어동",
       })
     ).toBe(true);
     expect(buildRegionWhere(user)).toEqual({
-      region1: "울산광역시",
+      region1: "울산",
       region2: "동구",
     });
   });
 
-  test("동 단위 필터도 시/도와 구를 함께 적용한다", () => {
+  test("동 단위 필터도 1차 지역과 구를 함께 적용한다", () => {
     const user = {
-      region1: "서울특별시",
+      region1: "서울",
       region2: "중구",
       region3: "신당동",
       regionRange: range("DONG"),
@@ -44,20 +55,20 @@ describe("region range utils", () => {
 
     expect(
       isWithinRegionRange(user, {
-        region1: "부산광역시",
+        region1: "부산",
         region2: "중구",
         region3: "신당동",
       })
     ).toBe(false);
     expect(
       isWithinRegionRange(user, {
-        region1: "서울특별시",
+        region1: "서울",
         region2: "다른구",
         region3: "신당동",
       })
     ).toBe(false);
     expect(buildRegionWhere(user)).toEqual({
-      region1: "서울특별시",
+      region1: "서울",
       region2: "중구",
       region3: "신당동",
     });

--- a/features/user/utils/region.ts
+++ b/features/user/utils/region.ts
@@ -8,7 +8,8 @@
  * 2026.02.20  임도헌   Created   지역 범위 비교 로직(isWithinRegionRange) 및 쿼리 빌더 분리
  * 2026.02.22  임도헌   Modified  위치 미설정 유저 방어(Fallback) 및 특수 행정구역 처리 일치화
  * 2026.05.16  임도헌   Modified  지역 where 조건 타입을 명시해 any 제거
- * 2026.06.04  임도헌   Modified  구/동 단위 필터에 시/도 조건을 함께 적용
+ * 2026.06.04  임도헌   Modified  구/동 단위 필터에 1차 지역 조건을 함께 적용
+ * 2026.06.18  임도헌   Modified  도 단위 시/군 정규화 정책에 맞춰 주석 용어를 1차 지역 기준으로 정리
  */
 
 import type { RegionRange } from "@/generated/prisma/client";
@@ -27,7 +28,7 @@ function matchesRegion1(
  *
  * - 위치 설정을 하지 않은 신규 유저는 전국(ALL) 매칭으로 처리하여 알림 누락을 방지
  * - 세종시 등 구(region2)가 없는 특수 행정구역의 경우, 'GU(보통)' 범위 선택 시
- *   시(region1) 전체가 아닌 동(region3) 단위로 좁혀서 비교
+ *   1차 지역(region1) 전체가 아닌 동(region3) 단위로 좁혀서 비교
  * - DB 쿼리 빌더(`buildRegionWhere`) 로직과 일치해야 함
  *
  * @param user - 유저 지역 정보 및 범위 설정
@@ -53,12 +54,12 @@ export function isWithinRegionRange(
     return true;
   }
 
-  // 구 존재 여부 파악 (세종시 등 판별)
+  // 구 존재 여부 파악 (세종시, 구가 없는 시/군 등 판별)
   const hasGu = !!user.region2 && user.region2 !== user.region1;
 
   switch (user.regionRange) {
     case "DONG":
-      // 1순위: 동(region3), 2순위: 구(region2). 같은 동/구 이름이 타 시도에 있어도 섞이지 않게 region1을 함께 비교.
+      // 1순위: 동(region3), 2순위: 구(region2). 같은 동/구 이름이 다른 1차 지역에 있어도 섞이지 않게 region1을 함께 비교.
       if (!matchesRegion1(user.region1, target.region1)) return false;
       if (user.region3) {
         if (hasGu && user.region2 !== target.region2) return false;
@@ -68,13 +69,13 @@ export function isWithinRegionRange(
 
     case "GU":
       if (hasGu) {
-        // 일반 도시: 같은 시/도 안의 '구' 단위 일치
+        // 일반 도시: 같은 1차 지역 안의 '구' 단위 일치
         return (
           matchesRegion1(user.region1, target.region1) &&
           user.region2 === target.region2
         );
       } else {
-        // 세종시 등 특수 행정구역: 쿼리 빌더와 동일하게 동->시 순으로 Fallback
+        // 구가 없는 지역: 쿼리 빌더와 동일하게 동->1차 지역 순으로 Fallback
         if (user.region3) {
           return (
             matchesRegion1(user.region1, target.region1) &&
@@ -101,7 +102,7 @@ export function isWithinRegionRange(
 /**
  * 유저의 설정 범위에 따른 Prisma Where 조건 생성
  * - 제품 목록, 게시글 목록 조회 시 사용
- * - 세종시 등 구(region2)가 없는 특수 행정구역 대응 강화
+ * - 세종시와 구가 없는 시/군처럼 region2가 region1과 같은 지역 대응 강화
  */
 export function buildRegionWhere(user: {
   region1?: string | null;
@@ -119,7 +120,7 @@ export function buildRegionWhere(user: {
 
   switch (user.regionRange) {
     case "DONG":
-      // 1순위: 동(region3), 없으면 구(region2). 시/도 조건을 함께 걸어 동명/구명 충돌을 방지.
+      // 1순위: 동(region3), 없으면 구(region2). 1차 지역 조건을 함께 걸어 동명/구명 충돌을 방지.
       if (user.region3) {
         condition = {
           region1: user.region1,
@@ -133,10 +134,10 @@ export function buildRegionWhere(user: {
 
     case "GU":
       if (hasGu) {
-        // 일반적인 도시: 같은 시/도 안의 '구' 단위 필터
+        // 일반적인 도시: 같은 1차 지역 안의 '구' 단위 필터
         condition = { region1: user.region1, region2: user.region2! };
       } else {
-        // 구가 없는 지역은 '시' 전체 대신 '동'으로 좁혀 보여줌(세종시)
+        // 구가 없는 지역은 1차 지역 전체 대신 동으로 좁혀 보여줌(세종시, 구가 없는 시/군)
         if (user.region3) {
           condition = { region1: user.region1, region3: user.region3 };
         } else {
@@ -146,7 +147,7 @@ export function buildRegionWhere(user: {
       break;
 
     case "CITY":
-      // 시/도 단위는 언제나 region1
+      // 시/군/특별시/광역시 단위는 region1 기준
       condition = { region1: user.region1 ?? undefined };
       break;
 

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -31,6 +31,7 @@
  * 2026.05.15  임도헌   Modified  유저 채널 다시보기 무한스크롤용 query key 추가
  * 2026.05.17  임도헌   Modified  query key 필터 객체 타입을 QueryKeyParams로 명시
  * 2026.06.07  임도헌   Modified  VOD 좋아요 상태 query key를 시청자별로 분리
+ * 2026.06.17  임도헌   Modified  상품/게시글 좋아요 상태 query key도 시청자별로 분리
  */
 
 import type { QueryKeyParams } from "@/lib/types";
@@ -52,8 +53,12 @@ export const queryKeys = {
       [...queryKeys.products.lists(), filters] as const,
     details: () => [...queryKeys.products.all, "detail"] as const,
     detail: (id: number) => [...queryKeys.products.details(), id] as const,
-    likeStatus: (productId: number) =>
-      [...queryKeys.products.detail(productId), "likeStatus"] as const,
+    likeStatus: (productId: number, viewerId?: number | null) =>
+      [
+        ...queryKeys.products.detail(productId),
+        "likeStatus",
+        viewerId ?? "guest",
+      ] as const,
     // 유저 프로필 탭의 판매/구매/찜 목록용
     userScope: (scope: string, userId: number) =>
       [...queryKeys.products.all, "userScope", scope, userId] as const,
@@ -71,8 +76,12 @@ export const queryKeys = {
       [...queryKeys.posts.all, "comments", postId] as const,
     stats: (postId: number) =>
       [...queryKeys.posts.detail(postId), "stats"] as const,
-    likeStatus: (postId: number) =>
-      [...queryKeys.posts.detail(postId), "likeStatus"] as const,
+    likeStatus: (postId: number, viewerId?: number | null) =>
+      [
+        ...queryKeys.posts.detail(postId),
+        "likeStatus",
+        viewerId ?? "guest",
+      ] as const,
   },
 
   // 3. 리뷰(Review) 도메인

--- a/prisma/migrations/20260618113023_add_post_feed_region/migration.sql
+++ b/prisma/migrations/20260618113023_add_post_feed_region/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "feedRegion1" TEXT,
+ADD COLUMN     "feedRegion2" TEXT,
+ADD COLUMN     "feedRegion3" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Post_feedRegion1_feedRegion2_idx" ON "Post"("feedRegion1", "feedRegion2");

--- a/prisma/migrations/20260618114500_backfill_post_feed_region/migration.sql
+++ b/prisma/migrations/20260618114500_backfill_post_feed_region/migration.sql
@@ -1,0 +1,11 @@
+-- Backfill existing posts so current local-feed behavior is preserved.
+-- The add-column migration may already be applied in some environments, so keep this idempotent.
+UPDATE "Post"
+SET
+  "feedRegion1" = COALESCE("feedRegion1", "region1"),
+  "feedRegion2" = COALESCE("feedRegion2", "region2"),
+  "feedRegion3" = COALESCE("feedRegion3", "region3")
+WHERE
+  "feedRegion1" IS NULL
+  OR "feedRegion2" IS NULL
+  OR "feedRegion3" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,7 +99,7 @@ enum Role {
 enum RegionRange {
   DONG // 좁게 (동/읍/면)
   GU // 보통 (구/군) - 기본값
-  CITY // 넓게 (시/도)
+  CITY // 넓게 (시/군/특별시/광역시)
   ALL // 전국
 }
 
@@ -126,8 +126,8 @@ model User {
   latitude     Float?
   longitude    Float?
   locationName String? // 예: "집 근처", "강남역" 등 유저가 지정한 별칭 또는 주소
-  region1      String? // 시/도 (예: 부산광역시)
-  region2      String? // 구/군 (예: 금정구) - *주 필터 기준*
+  region1      String? // 지역 필터 1차 단위(카카오 1depth 또는 도 단위의 시/군)
+  region2      String? // 지역 필터 2차 단위(구/군, 없으면 region1)
   region3      String? // 동/읍/면 (예: 부곡동)
   regionRange  RegionRange @default(GU) // 유저가 설정한 동네 보기 범위 (기본값: GU)
 
@@ -159,19 +159,19 @@ model User {
   followers Follow[] @relation("Followers") // 나를 팔로우하는 사람들
   following Follow[] @relation("Following") // 내가 팔로우하는 사람들
 
-  recording_likes          RecordingLike[] // 녹화본 좋아요
-  recording_comments       RecordingComment[] // 녹화본 댓글
-  live_inputs              LiveInput? // 스트리밍 송출 정보 (1인 1채널)
-  stream_chat_mutes        StreamChatMute[]   @relation("StreamMutedUser") // 방송 단위 채팅 금지 대상 이력
-  stream_chat_mute_actions StreamChatMute[]   @relation("StreamMuteActor") // 방송 채팅 금지 집행 이력
-  view_throttles           ViewThrottle[] // 조회수 어뷰징 방지 기록
-  blocked_users            Block[]            @relation("Blocker") // 내가 차단한 사람들
-  blocked_by               Block[]            @relation("Blocked") // 나를 차단한 사람들
-  reports                  Report[]           @relation("ReportReporter") // 제출한 신고 내역
-  reports_received         Report[]           @relation("ReportTargetUser") // 접수된 피신고 내역
-  admin_logs               AuditLog[]         @relation("AdminActions") // 내가 수행한 관리 활동 로그(관리자용)
-  keyword_alerts           KeywordAlert[]
-  reviewed_boardgame_locales BoardGameLocale[] @relation("BoardGameLocaleReviewer") // 보드게임 한국어 표시 정보 검수 이력
+  recording_likes            RecordingLike[] // 녹화본 좋아요
+  recording_comments         RecordingComment[] // 녹화본 댓글
+  live_inputs                LiveInput? // 스트리밍 송출 정보 (1인 1채널)
+  stream_chat_mutes          StreamChatMute[]   @relation("StreamMutedUser") // 방송 단위 채팅 금지 대상 이력
+  stream_chat_mute_actions   StreamChatMute[]   @relation("StreamMuteActor") // 방송 채팅 금지 집행 이력
+  view_throttles             ViewThrottle[] // 조회수 어뷰징 방지 기록
+  blocked_users              Block[]            @relation("Blocker") // 내가 차단한 사람들
+  blocked_by                 Block[]            @relation("Blocked") // 나를 차단한 사람들
+  reports                    Report[]           @relation("ReportReporter") // 제출한 신고 내역
+  reports_received           Report[]           @relation("ReportTargetUser") // 접수된 피신고 내역
+  admin_logs                 AuditLog[]         @relation("AdminActions") // 내가 수행한 관리 활동 로그(관리자용)
+  keyword_alerts             KeywordAlert[]
+  reviewed_boardgame_locales BoardGameLocale[]  @relation("BoardGameLocaleReviewer") // 보드게임 한국어 표시 정보 검수 이력
 
   @@index([username]) // 유저 검색 최적화
 }
@@ -305,7 +305,7 @@ model Product {
   has_manual   Boolean // 설명서 유무
   views        Int     @default(0) // 조회수
 
-  category    Category    @relation(fields: [categoryId], references: [id])
+  category    Category           @relation(fields: [categoryId], references: [id])
   categoryId  Int
   search_tags SearchTag[] // 검색용 태그
   board_games ProductBoardGame[] // 연결된 보드게임 기준 정보
@@ -314,8 +314,8 @@ model Product {
   latitude     Float? // 위도
   longitude    Float? // 경도
   locationName String? // 위치 명
-  region1      String? // 시/도
-  region2      String? // 구/군
+  region1      String? // 지역 필터 1차 단위(카카오 1depth 또는 도 단위의 시/군)
+  region2      String? // 지역 필터 2차 단위(구/군, 없으면 region1)
   region3      String? // 동/읍/면
 
   // 목록 정렬 인덱스: created_at -> refreshed_at (최신순 노출 기준 변경)
@@ -416,23 +416,28 @@ model Post {
   created_at  DateTime @default(now())
   updated_at  DateTime @updatedAt
 
-  // --- Location Info (모임 장소, 카페 위치 등) ---
+  // --- Location Info (사용자가 직접 선택한 게시글 관련 장소) ---
   latitude     Float? // 위도
   longitude    Float? // 경도
   locationName String? // 위치 명
-  region1      String? // 시/도
-  region2      String? // 구/군
+  region1      String? // 장소 지역 1차 단위(카카오 1depth 또는 도 단위의 시/군)
+  region2      String? // 장소 지역 2차 단위(구/군, 없으면 region1)
   region3      String? // 동/읍/면
+
+  // --- Feed Region Info (동네 피드 노출 기준 지역) ---
+  feedRegion1 String? // 피드 노출 지역 1차 단위
+  feedRegion2 String? // 피드 노출 지역 2차 단위
+  feedRegion3 String? // 피드 노출 지역 동/읍/면
 
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId Int
 
-  comments   Comment[] // 댓글
-  post_likes PostLike[] // 좋아요
-  images     PostImage[] // 첨부 이미지
-  video      PostVideo? // 첨부 동영상 (게시글당 최대 1개)
-  blocks     PostBlock[] // 본문/미디어 블록 (2차 확장용)
-  tags       PostTag[] // 태그
+  comments    Comment[] // 댓글
+  post_likes  PostLike[] // 좋아요
+  images      PostImage[] // 첨부 이미지
+  video       PostVideo? // 첨부 동영상 (게시글당 최대 1개)
+  blocks      PostBlock[] // 본문/미디어 블록 (2차 확장용)
+  tags        PostTag[] // 태그
   board_games PostBoardGame[] // 연결된 보드게임 기준 정보
 
   // [Optimization] 게시글 목록 조회
@@ -441,7 +446,8 @@ model Post {
   @@index([created_at]) // 전체 최신순
   @@index([title]) // 제목 검색
   @@index([latitude, longitude]) // "내 주변 게시글" 검색용
-  @@index([region1, region2]) // "우리 동네 이야기" 필터용
+  @@index([region1, region2]) // 명시 장소 기반 조회용
+  @@index([feedRegion1, feedRegion2]) // "우리 동네 이야기" 필터용
 }
 
 enum PostVideoStatus {
@@ -882,9 +888,9 @@ model Broadcast {
   streamCategoryId Int?
   tags             StreamTag[]     @relation("BroadcastTags")
 
-  chatRoom  StreamChatRoom? // 방송 채팅방
-  chatMutes StreamChatMute[] // 방송 단위 채팅 금지 목록
-  vodAssets VodAsset[] // 녹화본 (VOD)
+  chatRoom    StreamChatRoom? // 방송 채팅방
+  chatMutes   StreamChatMute[] // 방송 단위 채팅 금지 목록
+  vodAssets   VodAsset[] // 녹화본 (VOD)
   board_games StreamBoardGame[] // 연결된 보드게임 기준 정보
 
   // [Optimization] 방송 목록 조회 인덱스
@@ -922,7 +928,7 @@ enum BoardGameTaxonomyType {
 model BoardGame {
   id Int @id @default(autoincrement()) // BoardPort 내부 보드게임 ID
 
-  bggId       Int     @unique // BoardGameGeek thing ID
+  bggId       Int    @unique // BoardGameGeek thing ID
   primaryName String // BGG 원제
   bggUrl      String // BGG 원문 링크
 

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -20,13 +20,14 @@
  * 2026.05.26  임도헌   Modified  다시보기 목록/상세 E2E 검증용 ready VOD seed 추가
  * 2026.05.26  임도헌   Modified  상품 삭제/약속 수락/신고 처리 E2E 전용 seed 데이터 추가
  * 2026.05.26  임도헌   Modified  알림 설정 저장 E2E 반복 실행을 위해 seed 계정 preference 기본값 리셋
+ * 2026.06.22  임도헌   Modified  지역 노출 정책 변경에 맞춰 E2E 계정/콘텐츠 지역 seed 보정
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import bcrypt from "bcrypt";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient, Role } from "../generated/prisma/client";
+import { PrismaClient, RegionRange, Role } from "../generated/prisma/client";
 import {
   BoardGameLocaleSource,
   BoardGameLocaleStatus,
@@ -60,6 +61,15 @@ const E2E_USERS = {
     email: "e2e.admin@boardport.test",
     role: Role.ADMIN,
   },
+} as const;
+
+const E2E_LOCATION = {
+  locationName: "E2E 테스트 항구",
+  region1: "서울특별시",
+  region2: "마포구",
+  region3: "합정동",
+  latitude: 37.549,
+  longitude: 126.913,
 } as const;
 
 /**
@@ -133,7 +143,18 @@ async function createE2EUsers(db: PrismaClient) {
       const existing = await db.user.findUnique({
         where: { email: user.email },
       });
-      if (existing) return existing;
+      if (existing) {
+        return db.user.update({
+          where: { id: existing.id },
+          data: {
+            username: user.username,
+            role: user.role,
+            bannedAt: null,
+            regionRange: RegionRange.ALL,
+            ...E2E_LOCATION,
+          },
+        });
+      }
 
       return db.user.create({
         data: {
@@ -142,12 +163,8 @@ async function createE2EUsers(db: PrismaClient) {
           emailVerified: true,
           password,
           role: user.role,
-          locationName: "E2E 테스트 항구",
-          region1: "서울특별시",
-          region2: "마포구",
-          region3: "합정동",
-          latitude: 37.549,
-          longitude: 126.913,
+          regionRange: RegionRange.ALL,
+          ...E2E_LOCATION,
         },
       });
     })
@@ -240,18 +257,21 @@ async function createProduct(
   });
 
   if (existing) {
-    if (input.resetTradeState) {
-      await db.product.update({
-        where: { id: existing.id },
-        data: {
-          reservation_at: null,
-          reservation_userId: null,
-          purchased_at: null,
-          purchase_userId: null,
-          hidden_at: null,
-        },
-      });
-    }
+    await db.product.update({
+      where: { id: existing.id },
+      data: {
+        ...(input.resetTradeState
+          ? {
+              reservation_at: null,
+              reservation_userId: null,
+              purchased_at: null,
+              purchase_userId: null,
+            }
+          : {}),
+        hidden_at: null,
+        ...E2E_LOCATION,
+      },
+    });
 
     if (!input.imageUrl) return existing;
 
@@ -290,12 +310,7 @@ async function createProduct(
       condition: "GOOD",
       completeness: "COMPLETE",
       has_manual: true,
-      locationName: "E2E 테스트 항구",
-      region1: "서울특별시",
-      region2: "마포구",
-      region3: "합정동",
-      latitude: 37.549,
-      longitude: 126.913,
+      ...E2E_LOCATION,
       images: input.imageUrl
         ? {
             create: [
@@ -323,7 +338,15 @@ async function createPost(
   });
 
   if (existing) {
-    return existing;
+    return db.post.update({
+      where: { id: existing.id },
+      data: {
+        ...E2E_LOCATION,
+        feedRegion1: E2E_LOCATION.region1,
+        feedRegion2: E2E_LOCATION.region2,
+        feedRegion3: E2E_LOCATION.region3,
+      },
+    });
   }
 
   return db.post.create({
@@ -332,12 +355,10 @@ async function createPost(
       description: `${input.title} 본문입니다.`,
       category: "FREE",
       userId: input.authorId,
-      locationName: "E2E 테스트 항구",
-      region1: "서울특별시",
-      region2: "마포구",
-      region3: "합정동",
-      latitude: 37.549,
-      longitude: 126.913,
+      ...E2E_LOCATION,
+      feedRegion1: E2E_LOCATION.region1,
+      feedRegion2: E2E_LOCATION.region2,
+      feedRegion3: E2E_LOCATION.region3,
     },
   });
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -109,7 +109,7 @@ const config: Config = {
       },
       // [Rule 5.1] 간격(Spacing)에 대한 Semantic Token (선택 사항이나 권장)
       spacing: {
-        "page-x": "1.5rem", // px-6 (Page horizontal padding)
+        "page-x": "1rem", // px-4 (Page horizontal padding)
         "page-y": "2.5rem", // py-10 (Page vertical padding)
         "form-gap": "1.25rem", // gap-5 (Between form fields)
       },


### PR DESCRIPTION
## Summary

- 검색어, 분류, 상세 필터 조합이 화면 전환 후에도 자연스럽게 유지되도록 탐색 흐름을 정리했습니다.
- 상품과 게시글의 지역 기준을 정리해 동네 기반 노출 정책을 명확히 했습니다.
- 모바일 모달, BottomSheet, 닫기 버튼 사용 방식을 통일했습니다.
- 알림 본문 표시, 알림 설정 설명, 실제 알림 발송 범위를 정리했습니다.
- VOD 삭제 후 채널/목록에 삭제된 녹화본이 남지 않도록 캐시 정리를 보강했습니다.

## Background

릴리즈 전 데모 촬영 과정에서 기능 자체의 큰 결함보다는, 화면별 UX 기준과 데이터 정책이 조금씩 다르게 보이는 지점들이 발견되었습니다.

특히 검색/필터 조합, 지역 기반 노출, 모바일 모달 문법, 알림 표시 방식처럼 사용자가 여러 도메인을 오가며 사용할 때 일관성이 중요해지는 부분을 중심으로 정리했습니다.

## Changes

- 검색/필터
  - 검색어, 분류, 상세 필터 조합 유지 기준 정리
  - 상품/게시글 검색어 초기화 및 필터 해제 UX 보강
  - empty state 문구와 CTA를 현재 검색 조건에 맞게 조정

- 지역 정책
  - 상품 등록 시 노출 및 거래 기준 지역을 명확히 저장하도록 정리
  - 게시글의 관련 장소와 동네 피드 노출 기준 지역을 분리
  - Kakao 지역 데이터 정규화 유틸과 테스트 추가

- 모바일 UI/UX
  - 모달과 BottomSheet 사용 기준 정리
  - X 버튼과 취소 버튼이 중복되던 화면 정리
  - 채팅/프로필/신고/관리자 메뉴의 아이콘 및 버튼 표현 통일

- 알림
  - 모바일 알림 본문 더보기/접기 처리 보강
  - 알림 설정 설명을 실제 발송 범위에 맞게 정리
  - 약속 제안/수락/거절, 댓글, 다시보기 댓글 등 알림 발송 범위 보강
  - 링크가 필요 없는 시스템성 알림에서는 보기 버튼을 숨기도록 정리

- 스트리밍/VOD
  - VOD 삭제 후 채널/목록 캐시에 삭제된 녹화본이 남지 않도록 정리
  - 보드게임 도감 관련 방송 링크가 라이브/VOD 상태에 맞게 이동하도록 보강
  - 스트리밍 카드와 비공개 방송 모달 UI 정리

- 기타 UI 일관성
  - 좋아요/팔로우 optimistic UI 체감 개선
  - 예약 중/판매 완료 상태 배지 표현 통일
  - 리스트/그리드 토글 버튼 크기와 로딩 UI 정리
  - 라이트/다크 모드 버튼 색상과 위험 액션 색상 정리

## Verification

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`
- [x] `npx prisma validate`
- [x] `git diff --check`