### PR TITLE
🚑 Hotfix : 스트림 조회자 신뢰 경계 보강

### DIFF
--- a/app/(app)/(tabs)/streams/page.tsx
+++ b/app/(app)/(tabs)/streams/page.tsx
@@ -44,6 +44,7 @@
  * 2026.04.20  임도헌   Modified  sm 구간 데스크톱 헤더가 뒤 콘텐츠를 비치지 않도록 반투명 헤더/카테고리 레일 표면을 불투명 톤으로 정리
  * 2026.05.08  임도헌   Modified  스트림 조회 범위 타입을 StreamScope 공용 타입으로 교체
  * 2026.05.17  임도헌   Modified  prefetch 데이터 타입을 InfiniteData로 명시
+ * 2026.06.25  임도헌   Modified  서버 prefetch query key를 조회자/팔로잉 필터 스코프와 일치하도록 정리
 */
 import { Suspense } from "react";
 import { Metadata } from "next";
@@ -136,30 +137,39 @@ export default async function StreamsPage({ searchParams }: StreamsPageProps) {
     sort: recordingSort,
     scope: scope === "following" ? "following" : "",
   };
+  // 로그인 가드 이후에는 viewerId가 존재하지만, 클라이언트 훅의 query key 스코프와 맞추기 위해 guest fallback을 유지한다.
+  const liveListQueryKey = queryKeys.streams.list(scope, {
+    ...liveQueryParams,
+    viewerId: viewerId ?? "guest",
+  });
+  const recordingListQueryKey = queryKeys.streams.recordingList(
+    recordingSort,
+    {
+      ...recordingQueryParams,
+      followingOnly: scope === "following",
+      viewerId: viewerId ?? "guest",
+    }
+  );
 
   const queryClient = getQueryClient();
   const [, unreadCount] = await Promise.all([
     // 라이브/다시보기의 서로 다른 쿼리 키/fetcher에 맞춘 현재 모드 목록만 서버 선프리패치
     mode === "recordings"
       ? queryClient.prefetchInfiniteQuery({
-          queryKey: queryKeys.streams.recordingList(
-            recordingSort,
-            recordingQueryParams
-          ),
+          queryKey: recordingListQueryKey,
           queryFn: () =>
             getRecordingsListAction(
               recordingSort,
               scope === "following",
               null,
-              recordingQueryParams,
-              viewerId
+              recordingQueryParams
             ),
           initialPageParam: null as number | null,
         })
       : queryClient.prefetchInfiniteQuery({
-          queryKey: queryKeys.streams.list(scope, liveQueryParams),
+          queryKey: liveListQueryKey,
           queryFn: () =>
-            getStreamsListAction(scope, null, liveQueryParams, viewerId),
+            getStreamsListAction(scope, null, liveQueryParams),
           initialPageParam: null as number | null,
         }),
     getUnreadNotificationCount(),
@@ -167,11 +177,7 @@ export default async function StreamsPage({ searchParams }: StreamsPageProps) {
 
   const prefetchData = queryClient.getQueryData<
     InfiniteData<StreamsListPage | RecordingsPage>
-  >(
-    mode === "recordings"
-      ? queryKeys.streams.recordingList(recordingSort, recordingQueryParams)
-      : queryKeys.streams.list(scope, liveQueryParams)
-  );
+  >(mode === "recordings" ? recordingListQueryKey : liveListQueryKey);
   const firstPage = prefetchData?.pages[0];
   const isDataEmpty =
     mode === "recordings"
@@ -401,4 +407,3 @@ export default async function StreamsPage({ searchParams }: StreamsPageProps) {
     </div>
   );
 }
-

--- a/app/api/streams/recordings/route.test.ts
+++ b/app/api/streams/recordings/route.test.ts
@@ -1,0 +1,70 @@
+/**
+ * File Name : app/api/streams/recordings/route.test.ts
+ * Description : 다시보기 목록 API 권한 경계 회귀 테스트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.25  임도헌   Created   URL viewerId를 신뢰하지 않는 세션 기준 조회 테스트 추가
+ */
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getRecordingsList: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  default: mocks.getSession,
+}));
+
+vi.mock("@/features/stream/service/list", () => ({
+  getRecordingsList: mocks.getRecordingsList,
+}));
+
+describe("GET /api/streams/recordings", () => {
+  beforeEach(() => {
+    mocks.getSession.mockReset();
+    mocks.getRecordingsList.mockReset();
+  });
+
+  it("비로그인 요청의 viewerId query를 조회자 권한으로 사용하지 않는다", async () => {
+    const { GET } = await import("./route");
+    const request = new NextRequest(
+      "http://localhost/api/streams/recordings?followingOnly=true&viewerId=123"
+    );
+
+    mocks.getSession.mockResolvedValue(null);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      recordings: [],
+      nextCursor: null,
+    });
+    expect(mocks.getRecordingsList).not.toHaveBeenCalled();
+  });
+
+  it("세션이 있으면 query viewerId보다 세션 ID를 우선한다", async () => {
+    const { GET } = await import("./route");
+    const request = new NextRequest(
+      "http://localhost/api/streams/recordings?followingOnly=true&viewerId=123&cursor=50"
+    );
+
+    mocks.getSession.mockResolvedValue({ id: 7 });
+    mocks.getRecordingsList.mockResolvedValue([]);
+
+    await GET(request);
+
+    expect(mocks.getRecordingsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followingOnly: true,
+        viewerId: 7,
+        cursor: 50,
+      })
+    );
+  });
+});

--- a/app/api/streams/recordings/route.ts
+++ b/app/api/streams/recordings/route.ts
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 다시보기 목록 조회 API 분리
+ * 2026.06.25  임도헌   Modified  URL viewerId fallback 제거 및 세션 기준 조회자 권한 고정
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -52,8 +53,8 @@ export async function GET(request: NextRequest) {
   const sort: RecordingSort =
     searchParams.get("sort") === "popular" ? "popular" : "latest";
   const followingOnly = searchParams.get("followingOnly") === "true";
-  const viewerId =
-    session?.id ?? parseNullableNumberParam(searchParams.get("viewerId"));
+  // /api 경로는 middleware 인증 가드를 타지 않으므로 URL viewerId를 신뢰하지 않고 세션만 조회자 기준으로 사용한다.
+  const viewerId = session?.id ?? null;
 
   if (!viewerId) {
     return NextResponse.json({ recordings: [], nextCursor: null });

--- a/app/api/streams/route.test.ts
+++ b/app/api/streams/route.test.ts
@@ -1,0 +1,67 @@
+/**
+ * File Name : app/api/streams/route.test.ts
+ * Description : 라이브 방송 목록 API 권한 경계 회귀 테스트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.25  임도헌   Created   URL viewerId를 신뢰하지 않는 세션 기준 조회 테스트 추가
+ */
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getStreamsList: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  default: mocks.getSession,
+}));
+
+vi.mock("@/features/stream/service/list", () => ({
+  getStreamsList: mocks.getStreamsList,
+}));
+
+describe("GET /api/streams", () => {
+  beforeEach(() => {
+    mocks.getSession.mockReset();
+    mocks.getStreamsList.mockReset();
+  });
+
+  it("비로그인 요청의 viewerId query를 조회자 권한으로 사용하지 않는다", async () => {
+    const { GET } = await import("./route");
+    const request = new NextRequest(
+      "http://localhost/api/streams?scope=following&viewerId=123"
+    );
+
+    mocks.getSession.mockResolvedValue(null);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ streams: [], nextCursor: null });
+    expect(mocks.getStreamsList).not.toHaveBeenCalled();
+  });
+
+  it("세션이 있으면 query viewerId보다 세션 ID를 우선한다", async () => {
+    const { GET } = await import("./route");
+    const request = new NextRequest(
+      "http://localhost/api/streams?scope=following&viewerId=123&cursor=50"
+    );
+
+    mocks.getSession.mockResolvedValue({ id: 7 });
+    mocks.getStreamsList.mockResolvedValue([]);
+
+    await GET(request);
+
+    expect(mocks.getStreamsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "following",
+        viewerId: 7,
+        cursor: 50,
+      })
+    );
+  });
+});

--- a/app/api/streams/route.ts
+++ b/app/api/streams/route.ts
@@ -6,6 +6,7 @@
  * History
  * Date        Author   Status    Description
  * 2026.05.19  임도헌   Created   Client queryFn에서 조회용 Server Action을 직접 호출하지 않도록 라이브 방송 목록 조회 API 분리
+ * 2026.06.25  임도헌   Modified  URL viewerId fallback 제거 및 세션 기준 조회자 권한 고정
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -51,8 +52,8 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const scope: StreamScope =
     searchParams.get("scope") === "following" ? "following" : "all";
-  const viewerId =
-    session?.id ?? parseNullableNumberParam(searchParams.get("viewerId"));
+  // /api 경로는 middleware 인증 가드를 타지 않으므로 URL viewerId를 신뢰하지 않고 세션만 조회자 기준으로 사용한다.
+  const viewerId = session?.id ?? null;
 
   if (!viewerId) {
     return NextResponse.json({ streams: [], nextCursor: null });

--- a/app/api/webhooks/cloudflare/route.test.ts
+++ b/app/api/webhooks/cloudflare/route.test.ts
@@ -1,0 +1,117 @@
+/**
+ * File Name : app/api/webhooks/cloudflare/route.test.ts
+ * Description : Cloudflare Webhook Route 인증 경계 회귀 테스트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.25  임도헌   Created   production secret 누락 시 이벤트 처리 중단 테스트 추가
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  db: {
+    liveInput: {
+      findUnique: vi.fn(),
+    },
+    broadcast: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    vodAsset: {
+      upsert: vi.fn(),
+    },
+    postVideo: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  revalidateTag: vi.fn(),
+  sendLiveStatusFromServer: vi.fn(),
+  sendLiveStartNotifications: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  default: mocks.db,
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: mocks.revalidateTag,
+}));
+
+vi.mock("@/features/stream/service/realtime", () => ({
+  sendLiveStatusFromServer: mocks.sendLiveStatusFromServer,
+}));
+
+vi.mock("@/features/notification/service/live", () => ({
+  sendLiveStartNotifications: mocks.sendLiveStartNotifications,
+}));
+
+function liveConnectedRequest(headers?: HeadersInit) {
+  return new Request("http://localhost/api/webhooks/cloudflare", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({
+      type: "live_input.connected",
+      liveInput: "live-input-1",
+    }),
+  });
+}
+
+describe("POST /api/webhooks/cloudflare", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("production Stream webhook secret이 없으면 이벤트 처리를 시작하지 않는다", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CLOUDFLARE_STREAM_WEBHOOK_SECRET", "");
+    vi.stubEnv("CLOUDFLARE_WEBHOOK_SECRET", "destination-secret");
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      liveConnectedRequest({
+        "webhook-signature": "time=1,sig1=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "WEBHOOK_SECRET_NOT_CONFIGURED",
+    });
+    expect(mocks.db.liveInput.findUnique).not.toHaveBeenCalled();
+    expect(mocks.db.broadcast.update).not.toHaveBeenCalled();
+    expect(mocks.sendLiveStatusFromServer).not.toHaveBeenCalled();
+  });
+
+  it("production Destination webhook secret이 없으면 이벤트 처리를 시작하지 않는다", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CLOUDFLARE_STREAM_WEBHOOK_SECRET", "stream-secret");
+    vi.stubEnv("CLOUDFLARE_WEBHOOK_SECRET", "");
+
+    const { POST } = await import("./route");
+    const response = await POST(liveConnectedRequest());
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "WEBHOOK_SECRET_NOT_CONFIGURED",
+    });
+    expect(mocks.db.liveInput.findUnique).not.toHaveBeenCalled();
+    expect(mocks.db.broadcast.update).not.toHaveBeenCalled();
+    expect(mocks.sendLiveStatusFromServer).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/webhooks/cloudflare/route.ts
+++ b/app/api/webhooks/cloudflare/route.ts
@@ -21,6 +21,7 @@
  * 2026.04.05  임도헌   Modified  게시글 동영상 draftKey를 READY 웹훅에서 조기 해제하지 않고 실제 게시글 연결 시점까지 유지
  * 2026.05.12  임도헌   Modified  게시글 동영상 READY 선도착/Cloudflare error 웹훅 처리 보강
  * 2026.05.17  임도헌   Modified  Cloudflare Stream 웹훅 페이로드 타입 명시
+ * 2026.06.25  임도헌   Modified  production secret 누락 시 Stream/Destination 웹훅 fail-closed 처리
  */
 
 import "server-only";
@@ -32,6 +33,7 @@ import db from "@/lib/db";
 import { sendLiveStatusFromServer } from "@/features/stream/service/realtime";
 import { sendLiveStartNotifications } from "@/features/notification/service/live";
 import { Prisma } from "@/generated/prisma/client";
+import { isMissingRequiredCloudflareWebhookSecret } from "@/features/stream/utils/webhookAuth";
 import type {
   CloudflareStreamAssetPayload,
   CloudflareVideoListResponse,
@@ -813,8 +815,22 @@ export async function POST(req: Request) {
     const sigHeader = req.headers.get("webhook-signature");
     const isStreamWebhook = !!sigHeader;
 
+    // production에서는 secret 누락을 검증 생략으로 처리하지 않고 상태 변경 이벤트를 fail-closed 한다.
     if (isStreamWebhook) {
       // Stream Webhook → HMAC 서명 검증
+      if (
+        isMissingRequiredCloudflareWebhookSecret({
+          kind: "stream",
+          streamSecret: STREAM_SECRET,
+          destinationSecret: DEST_SECRET,
+        })
+      ) {
+        return NextResponse.json(
+          { ok: false, error: "WEBHOOK_SECRET_NOT_CONFIGURED" },
+          { status: 500 }
+        );
+      }
+
       if (STREAM_SECRET) {
         const ok = await verifyStreamSignatureWebCrypto(
           raw,
@@ -829,6 +845,19 @@ export async function POST(req: Request) {
       }
     } else {
       // Destination Webhook → 인증 헤더 확인 (옵션)
+      if (
+        isMissingRequiredCloudflareWebhookSecret({
+          kind: "destination",
+          streamSecret: STREAM_SECRET,
+          destinationSecret: DEST_SECRET,
+        })
+      ) {
+        return NextResponse.json(
+          { ok: false, error: "WEBHOOK_SECRET_NOT_CONFIGURED" },
+          { status: 500 }
+        );
+      }
+
       if (DEST_SECRET && !hasDestinationHeaderSecret(req, DEST_SECRET)) {
         return NextResponse.json(
           { ok: false, error: "UNAUTHORIZED" },
@@ -891,4 +920,3 @@ export async function POST(req: Request) {
     );
   }
 }
-

--- a/features/stream/actions/list.ts
+++ b/features/stream/actions/list.ts
@@ -21,6 +21,7 @@
  * 2026.05.08  임도헌   Modified  목록 응답 타입과 조회 범위 타입을 features/stream/types.ts로 이동
  * 2026.05.15  임도헌   Modified  유저 채널 다시보기 무한스크롤 액션 추가
  * 2026.05.18  임도헌   Modified  채널 다시보기 추가 페이지에서도 현재 사용자 좋아요 여부를 유지하도록 viewerId 전달
+ * 2026.06.25  임도헌   Modified  목록 액션의 조회자 권한 판단을 서버 세션 기준으로 고정
  */
 
 "use server";
@@ -90,17 +91,15 @@ function applyChannelVodAccess(
  * @param {StreamScope} scope - 조회 범위 ("all" | "following")
  * @param {number | null} cursor - 이전 페이지의 마지막 방송 ID
  * @param {Record<string, string>} searchParams - 카테고리 및 키워드 필터 조건
- * @param {number | null} viewerId - 조회자 ID (팔로잉 목록 확인용)
  * @returns {Promise<StreamsPage>} 평탄화된 방송 목록과 페이징 커서 반환
  */
 export async function getStreamsListAction(
   scope: StreamScope,
   cursor: number | null,
-  searchParams: Record<string, string>,
-  viewerId: number | null
+  searchParams: Record<string, string>
 ): Promise<StreamsPage> {
   const session = await getSession();
-  const userId = session?.id ?? viewerId;
+  const userId = session?.id ?? null;
 
   if (!userId) return { streams: [], nextCursor: null };
 
@@ -127,16 +126,16 @@ export async function getStreamsListAction(
  * - 정렬 기준(latest/popular)과 팔로잉 전용 필터를 service 계층에 위임
  * - 카테고리/키워드 검색 파라미터를 공백 정규화 후 전달
  * - 무한 스크롤용 recordings 배열과 다음 커서(nextCursor)를 반환
+ * - 조회자 권한 판단은 서버 세션만 신뢰
  */
 export async function getRecordingsListAction(
   sort: "latest" | "popular",
   followingOnly: boolean,
   cursor: number | null,
-  searchParams: Record<string, string>,
-  viewerId: number | null
+  searchParams: Record<string, string>
 ): Promise<RecordingsPage> {
   const session = await getSession();
-  const userId = session?.id ?? viewerId;
+  const userId = session?.id ?? null;
 
   if (!userId) return { recordings: [], nextCursor: null };
 

--- a/features/stream/hooks/useRecordingPagination.ts
+++ b/features/stream/hooks/useRecordingPagination.ts
@@ -10,6 +10,7 @@
  * 2026.03.31  임도헌   Modified  export 훅 역할과 반환값이 바로 보이도록 JSDoc 보강
  * 2026.04.02  임도헌   Modified  다시보기 페이징 훅 파라미터/반환 타입 설명 보강
  * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
+ * 2026.06.25  임도헌   Modified  viewerId URL 전달 제거 및 조회자/팔로잉 필터별 query key 스코프 분리
  */
 "use client";
 
@@ -42,9 +43,10 @@ function buildRecordingsApiUrl({
   sort,
   followingOnly,
   searchParams,
-  viewerId,
   cursor,
-}: UseRecordingPaginationParams & { cursor: number | null }): string {
+}: Omit<UseRecordingPaginationParams, "viewerId"> & {
+  cursor: number | null;
+}): string {
   const params = new URLSearchParams({ sort });
 
   if (followingOnly) {
@@ -53,10 +55,6 @@ function buildRecordingsApiUrl({
 
   if (cursor !== null) {
     params.set("cursor", String(cursor));
-  }
-
-  if (viewerId !== undefined && viewerId !== null) {
-    params.set("viewerId", String(viewerId));
   }
 
   const category = searchParams.category;
@@ -108,7 +106,11 @@ export function useRecordingPagination({
   viewerId,
 }: UseRecordingPaginationParams): UseRecordingPaginationResult {
   // 정렬/검색 조건이 바뀌면 목록 캐시도 별도 스코프로 분리
-  const queryKey = queryKeys.streams.recordingList(sort, searchParams);
+  const queryKey = queryKeys.streams.recordingList(sort, {
+    ...searchParams,
+    followingOnly,
+    viewerId: viewerId ?? "guest",
+  });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
@@ -120,7 +122,6 @@ export function useRecordingPagination({
             sort,
             followingOnly,
             searchParams,
-            viewerId,
             cursor: pageParam as number | null,
           })
         );

--- a/features/stream/hooks/useStreamPagination.ts
+++ b/features/stream/hooks/useStreamPagination.ts
@@ -13,6 +13,7 @@
  * 2026.04.17  임도헌   Modified  현재 훅이 담당하는 범위가 무한 스크롤 페이징 중심으로 읽히도록 설명을 최신화
  * 2026.05.08  임도헌   Modified  스트림 조회 범위 타입을 StreamScope 공용 타입으로 교체
  * 2026.05.19  임도헌   Modified  Client queryFn 초기 렌더의 조회용 Server Action 호출 오류를 피하도록 Route Handler fetch로 전환
+ * 2026.06.25  임도헌   Modified  viewerId URL 전달 제거 및 조회자별 query key 스코프 분리
  */
 
 "use client";
@@ -47,17 +48,14 @@ export interface UseStreamPaginationResult {
 function buildStreamsApiUrl({
   scope,
   searchParams,
-  viewerId,
   cursor,
-}: UseStreamPaginationParams & { cursor: number | null }): string {
+}: Omit<UseStreamPaginationParams, "viewerId"> & {
+  cursor: number | null;
+}): string {
   const params = new URLSearchParams({ scope });
 
   if (cursor !== null) {
     params.set("cursor", String(cursor));
-  }
-
-  if (viewerId !== undefined && viewerId !== null) {
-    params.set("viewerId", String(viewerId));
   }
 
   const category = searchParams.category;
@@ -107,7 +105,10 @@ export function useStreamPagination({
   searchParams,
   viewerId,
 }: UseStreamPaginationParams): UseStreamPaginationResult {
-  const queryKey = queryKeys.streams.list(scope, searchParams);
+  const queryKey = queryKeys.streams.list(scope, {
+    ...searchParams,
+    viewerId: viewerId ?? "guest",
+  });
 
   // TanStack Query를 활용한 무한 스크롤 쿼리 구성
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -119,7 +120,6 @@ export function useStreamPagination({
           buildStreamsApiUrl({
             scope,
             searchParams,
-            viewerId,
             cursor: pageParam as number | null,
           })
         );

--- a/features/stream/utils/webhookAuth.test.ts
+++ b/features/stream/utils/webhookAuth.test.ts
@@ -1,0 +1,55 @@
+/**
+ * File Name : features/stream/utils/webhookAuth.test.ts
+ * Description : Cloudflare Webhook 인증 정책 회귀 테스트
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.25  임도헌   Created   production secret 누락 fail-closed 정책 테스트 추가
+ */
+
+import { describe, expect, it } from "vitest";
+import { isMissingRequiredCloudflareWebhookSecret } from "./webhookAuth";
+
+describe("isMissingRequiredCloudflareWebhookSecret", () => {
+  it("production Stream webhook에서 HMAC secret이 없으면 누락으로 판단한다", () => {
+    expect(
+      isMissingRequiredCloudflareWebhookSecret({
+        kind: "stream",
+        streamSecret: "",
+        destinationSecret: "destination-secret",
+        nodeEnv: "production",
+      })
+    ).toBe(true);
+  });
+
+  it("production Destination webhook에서 destination secret이 없으면 누락으로 판단한다", () => {
+    expect(
+      isMissingRequiredCloudflareWebhookSecret({
+        kind: "destination",
+        streamSecret: "stream-secret",
+        destinationSecret: "",
+        nodeEnv: "production",
+      })
+    ).toBe(true);
+  });
+
+  it("secret이 설정되어 있거나 production이 아니면 누락으로 판단하지 않는다", () => {
+    expect(
+      isMissingRequiredCloudflareWebhookSecret({
+        kind: "stream",
+        streamSecret: "stream-secret",
+        destinationSecret: "",
+        nodeEnv: "production",
+      })
+    ).toBe(false);
+    expect(
+      isMissingRequiredCloudflareWebhookSecret({
+        kind: "destination",
+        streamSecret: "",
+        destinationSecret: "",
+        nodeEnv: "test",
+      })
+    ).toBe(false);
+  });
+});

--- a/features/stream/utils/webhookAuth.ts
+++ b/features/stream/utils/webhookAuth.ts
@@ -1,0 +1,36 @@
+/**
+ * File Name : features/stream/utils/webhookAuth.ts
+ * Description : Cloudflare Webhook 인증 정책 유틸
+ * Author : 임도헌
+ *
+ * History
+ * Date        Author   Status    Description
+ * 2026.06.25  임도헌   Created   웹훅 secret 누락 시 production fail-closed 정책 분리
+ */
+
+export type CloudflareWebhookKind = "stream" | "destination";
+
+/**
+ * 운영 환경에서는 실제 상태 변경 웹훅에 필요한 secret이 비어 있으면 요청을 거부한다.
+ *
+ * @param params.kind - Stream signature 웹훅인지 Destination header 웹훅인지
+ * @param params.streamSecret - Stream HMAC 검증용 secret
+ * @param params.destinationSecret - Destination header 검증용 secret
+ * @param params.nodeEnv - 현재 Node 환경
+ * @returns production에서 해당 웹훅 secret이 필수인데 누락되었는지 여부
+ */
+export function isMissingRequiredCloudflareWebhookSecret({
+  kind,
+  streamSecret,
+  destinationSecret,
+  nodeEnv = process.env.NODE_ENV,
+}: {
+  kind: CloudflareWebhookKind;
+  streamSecret: string;
+  destinationSecret: string;
+  nodeEnv?: string;
+}) {
+  if (nodeEnv !== "production") return false;
+
+  return kind === "stream" ? !streamSecret : !destinationSecret;
+}

--- a/features/user/hooks/useFollowToggle.ts
+++ b/features/user/hooks/useFollowToggle.ts
@@ -25,6 +25,7 @@
  * 2026.05.08  임도헌   Modified  팔로우 액션 결과 타입 import 경로를 user types로 정리
  * 2026.05.16  임도헌   Modified  팔로우/스트림 캐시 갱신 타입을 명시해 any 캐스팅 제거
  * 2026.06.17  임도헌   Modified  서버 성공 후 팔로워 전용 접근 상태를 동기화하는 책임을 주석에 명확히 반영
+ * 2026.06.25  임도헌   Modified  기본 팔로잉 스트림 seed key를 조회자별 캐시 스코프와 일치하도록 정리
  */
 
 "use client";
@@ -211,10 +212,18 @@ export function useFollowToggle() {
           );
         }
 
-        if (res.isFollowing && targetUserStreams.size > 0) {
+        if (
+          res.isFollowing &&
+          targetUserStreams.size > 0 &&
+          opts?.viewerId != null
+        ) {
+          // 기본 팔로잉 탭 seed도 실제 스트림 목록과 같은 조회자별 query key에만 기록한다.
           const defaultFollowingKey = queryKeys.streams.list(
             "following",
-            DEFAULT_STREAM_LIST_FILTERS
+            {
+              ...DEFAULT_STREAM_LIST_FILTERS,
+              viewerId: opts.viewerId,
+            }
           );
 
           queryClient.setQueryData<InfiniteData<StreamsPage>>(


### PR DESCRIPTION
🚑 Hotfix : 스트림 조회자 신뢰 경계 보강

## Summary

릴리즈 전 코드 감사에서 확인한 스트림/다시보기 목록 API의 조회자 신뢰 경계와 Cloudflare webhook secret 정책을 보강했습니다.

이번 PR은 `/api/*`가 middleware 인증 가드를 타지 않는 구조에서, 목록 API가 query `viewerId`를 조회자 정체성으로 fallback하던 문제를 서버 세션 기준으로 정리하고, 개인화 캐시 key와 production webhook fail-closed 정책까지 함께 닫는 hotfix입니다.

## Background

`/streams` 페이지는 로그인 보호 페이지지만, `/api/streams`와 `/api/streams/recordings` Route Handler는 middleware matcher에서 제외됩니다.

기존에는 세션이 없을 때 URL query의 `viewerId`를 fallback으로 사용해, 비로그인 직접 API 요청이 타인의 팔로잉/좋아요/잠금 상태 같은 개인화 조회 맥락을 흉내낼 수 있었습니다.

또한 Stream/VOD 목록 query key 일부에 조회자 ID와 팔로잉 필터가 빠져 있어 계정 전환, 팔로우 토글, guest/login 전환 시 개인화 캐시가 섞일 수 있었습니다.

Cloudflare webhook은 서명 검증 로직은 있었지만, production에서 secret이 비어 있으면 검증을 건너뛰고 상태 변경 처리로 진행될 수 있어 fail-open 가능성이 있었습니다.

## Changes

[🎥 Stream]

- 스트림/다시보기 목록 API의 `viewerId` query fallback을 제거했습니다.
- 목록 조회 권한 기준을 URL query가 아니라 서버 세션 ID로 고정했습니다.
- 비로그인 목록 API 직접 호출은 빈 목록으로 종료하도록 정리했습니다.
- Server Action 목록 조회도 서버 세션 기준으로 맞췄습니다.
- Stream/VOD 목록 query key에 `viewerId`, `followingOnly`를 반영했습니다.
- 팔로우 직후 기본 팔로잉 스트림 cache seed key를 조회자별 key와 일치시켰습니다.

[☁️ Webhook]

- Cloudflare Stream webhook secret 누락 시 production에서 fail-closed 처리했습니다.
- Cloudflare Destination webhook secret 누락 시 production에서 fail-closed 처리했습니다.
- secret 누락 정책을 `webhookAuth` 유틸로 분리했습니다.
- 핸드셰이크와 빈 body 요청은 상태 변경이 없으므로 기존 통과 정책을 유지했습니다.

[☔️ Test]

- 스트림/다시보기 목록 API의 `viewerId` spoof 방지 회귀 테스트를 추가했습니다.
- 세션이 있을 때 query `viewerId`보다 session ID가 우선되는지 검증했습니다.
- production webhook secret 누락 시 DB 갱신과 Realtime 송신이 시작되지 않는지 검증했습니다.
- webhook secret 정책 유틸 테스트를 추가했습니다.

## Notes

- 이번 수정은 PRIVATE/FOLLOWERS 재생 권한 우회 확정이 아니라, 목록 API에서 클라이언트 입력을 조회자 정체성으로 사용하던 개인화·권한 경계 오류를 닫는 작업입니다.
- `/streams`는 로그인 보호 페이지이므로, 비로그인 직접 목록 API 요청은 401 대신 빈 목록으로 안전하게 종료합니다.
- 배포 전 Production 환경에 `CLOUDFLARE_STREAM_WEBHOOK_SECRET`, `CLOUDFLARE_WEBHOOK_SECRET`이 설정되어 있는지 확인합니다.

## Verification
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run test` — 23 files / 107 tests
- [x] `npm run build`
- [x] `npm run test:e2e` — 7 passed / 19 skipped
- [x] `git diff --check`